### PR TITLE
Advertise Python 3.9 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 os: linux
-dist: focal
+dist: bionic
 addons:
   apt:
     packages:
-      - libboost-dev libboost-system-dev libboost-chrono-dev libboost-random-dev
-      # - libboost-system-dev qtbase5-dev libboost-system1.65.1
+      - libboost-system-dev qtbase5-dev
   coverity_scan:
     project:
       name: "rmartin16/qbittorrent-api"
@@ -22,12 +21,14 @@ python:
   - 3.8
   - 3.9
   - 3.10-dev
-  - pypy3
+  - python-nightly
+  - pypy3.6-7.3.1
 jobs:
   fast_finish: true
   allow_failures:
     - python: 3.10-dev
-    - python: pypy3
+    - python: python-nightly
+    - python: pypy3.6-7.3.1
   exclude:
     - if: branch != comprehensive_tests AND env(QBT_VER) != env(LATEST_QBT_VERSION)
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ dist: focal
 addons:
   apt:
     packages:
-      - libboost-system-dev qtbase5-dev libboost-system1.65.1
+      - libboost-dev libboost-system-dev libboost-chrono-dev libboost-random-dev
+      # - libboost-system-dev qtbase5-dev libboost-system1.65.1
   coverity_scan:
     project:
       name: "rmartin16/qbittorrent-api"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 os: linux
-dist: bionic
+dist: focal
 addons:
   apt:
     packages:
@@ -14,7 +14,7 @@ addons:
     branch_pattern: coverity_scan
 python:
   - 2.7
-  #- 3.4  # not supported on bionic
+  - 3.4
   - 3.5
   - 3.6
   - 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ python:
   - 3.8
   - 3.9
   - 3.10-dev
-  - python-nightly
+  - nightly
   - pypy3.6-7.3.1
 jobs:
   fast_finish: true
   allow_failures:
     - python: 3.10-dev
-    - python: python-nightly
+    - python: nightly
     - python: pypy3.6-7.3.1
   exclude:
     - if: branch != comprehensive_tests AND env(QBT_VER) != env(LATEST_QBT_VERSION)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: focal
 addons:
   apt:
     packages:
-      - libboost-system-dev qtbase5-dev
+      - libboost-system-dev qtbase5-dev libboost-system1.65.1
   coverity_scan:
     project:
       name: "rmartin16/qbittorrent-api"
@@ -14,7 +14,7 @@ addons:
     branch_pattern: coverity_scan
 python:
   - 2.7
-  - 3.4
+  # - 3.4 - not available on travis-ci
   - 3.5
   - 3.6
   - 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9-dev  # remove once 3.9 is supported on travis-ci
   - 3.9
   - 3.10-dev
   - nightly
@@ -26,6 +27,7 @@ python:
 jobs:
   fast_finish: true
   allow_failures:
+    - python: 3.9  # remove once 3.9 is supported on travis-ci
     - python: 3.10-dev
     - python: nightly
     - python: pypy3.6-7.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,12 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - 3.9-dev
+  - 3.9
   - 3.10-dev
   - pypy3
 jobs:
   fast_finish: true
   allow_failures:
-    - python: 3.9-dev
     - python: 3.10-dev
     - python: pypy3
   exclude:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+Version 2020.10.10
+ - Advertise support for Python 3.9
+
 Version 2020.9.9
  - Only request enum34 for Python 2
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,5 @@
-include AUTHORS.rst
 include CHANGELOG.txt
-include CONTRIBUTING.rst
 include LICENSE
-include README.rst
+include README.md
 
 global-exclude *.py[cod] __pycache__ *.so

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='qbittorrent-api',
-    version='2020.9.9',
+    version='2020.10.10',
     packages=find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']),
     include_package_data=True,
     install_requires=['attrdict>=2.0.0',
@@ -18,10 +18,11 @@ setup(
     description='Python client for qBittorrent v4.1+ Web API',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    keywords='qbittorrent api',
+    keywords='python qbittorrent api client torrent torrents',
     zip_safe=False,
     license='GPL-3',
-    classifiers=['Programming Language :: Python :: 3.8',
+    classifiers=['Programming Language :: Python :: 3.9',
+                 'Programming Language :: Python :: 3.8',
                  'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
travis-ci.com doesn't yet seem to support the released 3.9....however, tests are passing on 3.9-dev which is just the Release Candidate 2.
I'll update the .travis.yml again once 3.9 is formally supported on travis.