### PR TITLE
Fix support to add single torrent with bytes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+Version 2020.11.12 (16 nov 2020)
+ - Fix support for raw bytes for torrent_files in torrents_add() for Python 3. Fixes #34.
+
 Version 2020.10.11 (29 oct 2020)
  - Support qBittorrent v4.3.0.1 and Web API v2.6
  - Due to qBittorrent changes, /search/categories no longer returns anything and /rss/renameRule works again

--- a/qbittorrentapi/torrents.py
+++ b/qbittorrentapi/torrents.py
@@ -644,7 +644,9 @@ class TorrentsAPIMixIn(Request):
         prefix = 'torrent__'
         # if it's string-like and not a list|set|tuple, then make it a list
         # checking for 'read' attr since a single file handle is iterable but also needs to be in a list
-        if isinstance(user_files, six.string_types) or not isinstance(user_files, Iterable) or hasattr(user_files, 'read'):
+        is_string_like = isinstance(user_files, (six.string_types, six.binary_type))
+        is_file_like = hasattr(user_files, 'read')
+        if is_string_like or is_file_like or not isinstance(user_files, Iterable):
             user_files = [user_files]
 
         # up convert to a dictionary to add fabricated torrent names
@@ -654,7 +656,7 @@ class TorrentsAPIMixIn(Request):
         for name, torrent_file in norm_files.items():
             try:
                 fh = None
-                if isinstance(torrent_file, bytes):
+                if isinstance(torrent_file, six.binary_type):
                     # since strings are bytes on python 2, simple filepaths will end up here
                     # just check if it's a file first in that case...
                     # this does prevent providing more useful IO errors on python 2....but it's dead anyway...

--- a/qbittorrentapi/torrents.py
+++ b/qbittorrentapi/torrents.py
@@ -644,7 +644,7 @@ class TorrentsAPIMixIn(Request):
         prefix = 'torrent__'
         # if it's string-like and not a list|set|tuple, then make it a list
         # checking for 'read' attr since a single file handle is iterable but also needs to be in a list
-        is_string_like = isinstance(user_files, (six.string_types, six.binary_type))
+        is_string_like = isinstance(user_files, (bytes, six.text_type))
         is_file_like = hasattr(user_files, 'read')
         if is_string_like or is_file_like or not isinstance(user_files, Iterable):
             user_files = [user_files]
@@ -656,7 +656,7 @@ class TorrentsAPIMixIn(Request):
         for name, torrent_file in norm_files.items():
             try:
                 fh = None
-                if isinstance(torrent_file, six.binary_type):
+                if isinstance(torrent_file, bytes):
                     # since strings are bytes on python 2, simple filepaths will end up here
                     # just check if it's a file first in that case...
                     # this does prevent providing more useful IO errors on python 2....but it's dead anyway...

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='qbittorrent-api',
-    version='2020.10.11',
+    version='2020.11.12',
     packages=find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']),
     include_package_data=True,
     install_requires=['attrdict>=2.0.0',


### PR DESCRIPTION
Passing a single bytes object to `torrents_add()` for `torrent_files` did not work in Python 3 because the bytes object was mis-identified and converted to a giant dictionary.
These single instances are properly identified now and wrapped in a list like other single instance inputs.
Closes #34.