### PR TITLE
Web API v2.6.1 release

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Version 2020.11.13 (29 nov 2020)
+ - Bump for Web API v2.6.1 release
+ - Path of torrent content now available via content_path from torrents/info
+
 Version 2020.11.12 (16 nov 2020)
  - Fix support for raw bytes for torrent_files in torrents_add() for Python 3. Fixes #34.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ qBittorrent Web API Client
 
 Python client implementation for qBittorrent Web API. Supports qBittorrent v4.1.0+ (i.e. Web API v2.0+).
 
-Currently supports up to qBittorrent [v4.3.0.1](https://github.com/qbittorrent/qBittorrent/releases/tag/release-4.3.0.1) (Web API v2.6) released on October 22, 2020.
+Currently supports up to qBittorrent [v4.3.1](https://github.com/qbittorrent/qBittorrent/releases/tag/release-4.3.1) (Web API v2.6.1) released on November 25, 2020.
 
 [Find the full documentation for this client on RTD.](https://qbittorrent-api.readthedocs.io/)
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -21,7 +21,7 @@ Introduction
 
 Python client implementation for qBittorrent Web API.
 
-Currently supports up to qBittorrent `v4.3.0.1 <https://github.com/qbittorrent/qBittorrent/releases/tag/release-4.3.0.1>`_ (Web API v2.6.0) released on October 22, 2020.
+Currently supports up to qBittorrent `v4.3.1 <https://github.com/qbittorrent/qBittorrent/releases/tag/release-4.3.1>`_ (Web API v2.6.1) released on November 25, 2020.
 
 The full qBittorrent Web API documentation is available on their `wiki <https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='qbittorrent-api',
-    version='2020.11.12',
+    version='2020.11.13',
     packages=find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']),
     include_package_data=True,
     install_requires=['attrdict>=2.0.0',


### PR DESCRIPTION
Path of torrent content now available via content_path from torrents/info