### PR TITLE
Include previous qBittorrent versions in CI testing

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,59 +1,164 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Tests
 
 on:
+  schedule:
+    # run every few days so caches aren't evicted
+    - cron: "0 0 1-30/3 * *"
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - comprehensive_tests
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:
   tests:
-    name: "Python ${{ matrix.python-version }}"
-    runs-on: ubuntu-latest
+    name: "Python ${{ matrix.python-version }} - v${{ matrix.QBT_VER }}"
+    runs-on: ubuntu-20.04  # TODO: update back to ubuntu-latest once 20.04 is the default
     continue-on-error: true
     env:
-      EXTRA_TESTS_VERSION: 3.9
-      SUBMIT_COVERAGE_VERSIONS: "2.7,3.9"
+      LATEST_PYTHON_VERSION: 3.9
+      LATEST_QBT_VERSION: 4.3.2
+      QBT_ALWAYS_TEST: 4.3.2, 4.3.1
+      SUBMIT_COVERAGE_VERSIONS: 2.7, 3.9
+      COMPREHENSIVE_TESTS_BRANCH: comprehensive_tests
       PYTHON_QBITTORRENTAPI_HOST: localhost:8080
       PYTHON_QBITTORRENTAPI_PASSWORD: adminadmin
       PYTHON_QBITTORRENTAPI_USERNAME: admin
-      QBT_VER: 4.3.2
+      LIBTOR_VER: 1.2.12
+      QBT_LEGACY_INSTALL: 4.2.5, 4.2.0
     strategy:
       matrix:
+        QBT_VER: [4.2.0, 4.2.5, 4.3.0.1, 4.3.1, 4.3.2]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev, pypy2, pypy3]
         # python-version: [3.9]
 
+    # TODO: each step currently has an over-complicated conditional to prevent always running all tests.
+    # TODO: this can be removed once the matrix supports conditions
+
     steps:
+    - name: Branch
+      run: echo Branch ${{ github.ref }} ${{ github.head_ref }}
+
     - name: Checkout Repo
+      if: (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
       uses: actions/checkout@v2
     
     - name: Set up Python ${{ matrix.python-version }}
+      if: (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install OS Dependencies
+      # dependencies to compile and run libtorrent and qBittorrent
+      if: (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
+      run: |
+        sudo apt update
+        sudo apt install build-essential cmake ninja-build pkg-config git zlib1g-dev libssl-dev libgeoip-dev \
+          automake libtool libboost-dev libboost-system-dev libboost-chrono-dev libboost-random-dev
+        sudo apt install --no-install-recommends qtbase5-dev qttools5-dev libqt5svg5-dev
+
+    - name: Cache libtorrent
+      # set up cache for libtorrent library
+      if: (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
+      id: cache-libtorrent
+      uses: actions/cache@v2
+      with:
+        path: ~/libtor_installs
+        key: ${{ runner.os }}-libtor-installs-3-${{ env.LIBTOR_VER }}
+
+    - name: Build libtorrent
+      # if cache missed, build libtorrent library.
+      # right now, all relevant qBittorrent versions can be compiled using libtorrent 1.2.12
+      if: |
+        (steps.cache-libtorrent.outputs.cache-hit != 'true')
+        && (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
+      run: |
+        set -x
+        BASE_DIR="$HOME/libtor_installs"
+        SRC_DIR="$BASE_DIR/src"
+        LIBTOR_DIR="$BASE_DIR/libtorrent_${{ env.LIBTOR_VER }}"
+        mkdir -p "$SRC_DIR" && mkdir -p "$LIBTOR_DIR"
+
+        cd "$SRC_DIR"
+        git clone https://github.com/arvidn/libtorrent.git --branch v${{ env.LIBTOR_VER }} --depth 1
+        cd libtorrent
+        cmake -B cmake-build-dir/Release -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$LIBTOR_DIR"
+        cmake --build cmake-build-dir/Release --parallel $(nproc) && cmake --install cmake-build-dir/Release
+
+    - name: Cache qBittorrent
+      # set up cache for qBittorrent binary
+      if: (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
+      id: cache-qbittorrent
+      uses: actions/cache@v2
+      with:
+        path: ~/qbt_installs
+        key: ${{ runner.os }}-qbt-installs-3-${{ matrix.QBT_VER }}
+
+    - name: Build qBittorrent (legacy)
+      # if cache missed, compile an older version of qBittorrent, i.e. < v4.2.5
+      if: |
+        (steps.cache-qbittorrent.outputs.cache-hit != 'true' && contains(env.QBT_LEGACY_INSTALL, matrix.QBT_VER))
+        && (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
+      run: |
+        set -x
+        QBT_BASE="$HOME/qbt_installs"
+        SRC_DIR="$QBT_BASE/src"
+        QBT_DIR="$QBT_BASE/qbt_${{ matrix.QBT_VER }}"
+        LIBTOR_DIR="$HOME/libtor_installs/libtorrent_${{ env.LIBTOR_VER }}"
+        mkdir -p "$SRC_DIR" && mkdir -p "$QBT_DIR"
+
+        cd "$SRC_DIR"
+        git clone https://github.com/qbittorrent/qBittorrent.git --branch release-${{ matrix.QBT_VER }} --depth 1
+        cd qBittorrent
+        export libtorrent_CFLAGS="$LIBTOR_DIR/include/" && export libtorrent_LIBS="$LIBTOR_DIR/lib/libtorrent-rasterbar.so"
+        ./configure CXXFLAGS="-std=c++17" CFLAGS="-I$LIBTOR_DIR/include/libtorrent" --disable-gui --prefix="$QBT_DIR"
+        make -j$(nproc) install
+
+    - name: Build qBittorrent
+      # if cache missed, compile qBittorrent binary
+      if: |
+        ((steps.cache-qbittorrent.outputs.cache-hit != 'true') && ! contains(env.QBT_LEGACY_INSTALL, matrix.QBT_VER))
+        && (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
+      run: |
+        set -x
+        QBT_BASE="$HOME/qbt_installs"
+        SRC_DIR="$QBT_BASE/src"
+        QBT_DIR="$QBT_BASE/qbt_${{ matrix.QBT_VER }}"
+        LIBTOR_DIR="$HOME/libtor_installs/libtorrent_${{ env.LIBTOR_VER }}"
+        mkdir -p "$SRC_DIR" && mkdir -p "$QBT_DIR"
+
+        cd "$SRC_DIR"
+        git clone https://github.com/qbittorrent/qBittorrent.git --branch release-${{ matrix.QBT_VER }} --depth 1
+        cd qBittorrent
+        cmake -G "Ninja" -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$LIBTOR_DIR" -DVERBOSE_CONFIGURE=ON \
+          -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE -DQBT_VER_STATUS= -DGUI=OFF -DCMAKE_INSTALL_PREFIX="$QBT_DIR"
+        cmake --build build --parallel $(nproc) && cmake --install build
+
     - name: Cache pip
+      # cache the pip cache
+      if: (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-pip-3-${{ hashFiles('requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+          ${{ runner.os }}-pip-3-
 
     - name: Install Python Dependencies
+      # install the python dependencies to test qbittorrent-api
+      if: (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
       run: |
         python -m pip install -U pip wheel setuptools
         pip install -U codecov coveralls pytest pytest-cov
         pip install .
     
     - name: Lint with flake8
-      if: "contains(env.EXTRA_TESTS_VERSION, matrix.python-version)"
+      # lint the python code
+      if: contains(env.LATEST_PYTHON_VERSION, matrix.python-version) && (env.LATEST_QBT_VERSION == matrix.QBT_VER)
       run: |
         pip -q install -U flake8
         # stop the build if there are Python syntax errors or undefined names
@@ -62,33 +167,36 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Black
-      if: "contains(env.EXTRA_TESTS_VERSION, matrix.python-version)"
+      # verify code format with Black
+      if: contains(env.LATEST_PYTHON_VERSION, matrix.python-version) && (env.LATEST_QBT_VERSION == matrix.QBT_VER)
       run: |
         pip -q install -U black
         black . --check
 
-    - name: Install qBittorrent
-      run: |
-        sudo add-apt-repository -y -u ppa:qbittorrent-team/qbittorrent-stable
-        sudo apt-get -y install qbittorrent-nox
-        qbittorrent-nox --daemon
-        mkdir -p $HOME/Downloads  # default download location for qbittorrent
-
     - name: Test with pytest
+      # finally....start qBittorrent and run tests via pytest
+      if: contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER)
       run: |
+        mkdir -p $HOME/Downloads  # default download location for qbittorrent
+        export LD_LIBRARY_PATH="$HOME/libtor_installs/libtorrent_${{ env.LIBTOR_VER }}/lib/:$LD_LIBRARY_PATH"
+        $HOME/qbt_installs/qbt_${{ matrix.QBT_VER }}/bin/qbittorrent-nox --daemon
         python -c "import sys; print(sys.version)"
-        qbittorrent-nox -v
+        $HOME/qbt_installs/qbt_${{ matrix.QBT_VER }}/bin/qbittorrent-nox -v
+        export QBT_VER=${{ matrix.QBT_VER }}  # tell pytest which qbittorrent is being tested
         pytest
 
     - name: Upload Coverage to Codecov
-      if: "contains(env.SUBMIT_COVERAGE_VERSIONS, matrix.python-version)"
+      # send coverage report from pytest to codecov
+      if: |
+        contains(env.SUBMIT_COVERAGE_VERSIONS, matrix.python-version)
+        && (contains(github.ref, env.COMPREHENSIVE_TESTS_BRANCH) || contains(env.QBT_ALWAYS_TEST, matrix.QBT_VER))
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true
 
     # just sticking to codecov for now
     #- name: Upload Coverage to Coveralls
-    #  if: "contains(env.SUBMIT_COVERAGE_VERSIONS, matrix.python-version)"
+    #  if: contains(env.SUBMIT_COVERAGE_VERSIONS, matrix.python-version)
     #  env:
     #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     #  run: coveralls

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import pytest
 
 from qbittorrentapi import NotFound404Error
@@ -172,14 +174,16 @@ def test_stop(client, api_version, client_func):
         job = get_func(client, client_func[1])(
             pattern="Ubuntu", plugins="enabled", category="all"
         )
+        sleep(1)
         get_func(client, client_func[0])(search_id=job.id)
         check(lambda: client.search.status(search_id=job["id"])[0]["status"], "Stopped")
 
         job = get_func(client, client_func[1])(
             pattern="Ubuntu", plugins="enabled", category="all"
         )
+        sleep(1)
         job.stop()
-        assert job.status()[0].status == "Stopped"
+        check(lambda: client.search.status(search_id=job["id"])[0]["status"], "Stopped")
 
 
 def test_delete(client, api_version):


### PR DESCRIPTION
Enhance CI testing to include more testing qBitorrent versions
 - This is mostly just restoring the testing that was supported on Travis.
 - By default, any PR for master will test all supported python versions and the last two qBittorrent versions.
 - Merge to the comprehensive_tests branch to run tests for all CI-supported qBittorrent versions.
 - libtorrent and qBittorrent are now compiled directly in the CI leveraging caching to prevent long test times.
 - Given only libtorrent 1.2.12 is currently being supported in CI, testing can only back to qBittorrent v4.2.0.
 - To go back earlier, support for libtorrent 1.1.x would need to be added.
 - Additionally, given libtorrent 2.x is already released, qBittorrent is likely to require it eventually.