### PR TITLE
Support qBittorrent v4.3.3

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,8 +20,8 @@ jobs:
     continue-on-error: true
     env:
       LATEST_PYTHON_VERSION: 3.9
-      LATEST_QBT_VERSION: 4.3.2
-      QBT_ALWAYS_TEST: 4.3.2, 4.3.1
+      LATEST_QBT_VERSION: 4.3.3
+      QBT_ALWAYS_TEST: 4.3.3, 4.3.2, 4.3.1
       SUBMIT_COVERAGE_VERSIONS: 2.7, 3.9
       COMPREHENSIVE_TESTS_BRANCH: comprehensive_tests
       PYTHON_QBITTORRENTAPI_HOST: localhost:8080
@@ -31,7 +31,7 @@ jobs:
       QBT_LEGACY_INSTALL: 4.2.5, 4.2.0
     strategy:
       matrix:
-        QBT_VER: [4.2.0, 4.2.5, 4.3.0.1, 4.3.1, 4.3.2]
+        QBT_VER: [4.2.0, 4.2.5, 4.3.0.1, 4.3.1, 4.3.2, 4.3.3]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev, pypy2, pypy3]
         # python-version: [3.9]
 
@@ -171,6 +171,7 @@ jobs:
       if: contains(env.LATEST_PYTHON_VERSION, matrix.python-version) && (env.LATEST_QBT_VERSION == matrix.QBT_VER)
       run: |
         pip -q install -U black
+        black --version
         black . --check
 
     - name: Test with pytest

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+Version 2021.1.16 (26 jan 2021)
+ - Support qBittorrent v4.3.3 and Web API v2.7 (...again)
+ - New torrents/renameFile and torrents/renameFolder endpoints
+ - Retrieve app api version when needed instead of caching
+ - Stop verifying and removing individual parameters when they aren't supported
+
 Version 2020.12.15 (27 dec 2020)
  - Support qBittorrent v4.3.2 and Web API v2.7
  - torrents/add supports adding torrents with tags via "tags" parameter

--- a/qbittorrentapi/app.py
+++ b/qbittorrentapi/app.py
@@ -3,10 +3,10 @@ from json import dumps
 
 from qbittorrentapi.decorators import Alias
 from qbittorrentapi.decorators import aliased
+from qbittorrentapi.decorators import endpoint_introduced
 from qbittorrentapi.decorators import login_required
 from qbittorrentapi.decorators import response_json
 from qbittorrentapi.decorators import response_text
-from qbittorrentapi.decorators import version_implemented
 from qbittorrentapi.definitions import APINames
 from qbittorrentapi.definitions import ClientCache
 from qbittorrentapi.definitions import Dictionary
@@ -117,7 +117,6 @@ class AppAPIMixIn(Request):
     def _app_web_api_version_from_version_checker(self):
         if self._cached_web_api_version:
             return self._cached_web_api_version
-        logger.debug("Retrieving API version for version_implemented verifier")
         self._cached_web_api_version = self.app_web_api_version()
         return self._cached_web_api_version
 
@@ -134,7 +133,7 @@ class AppAPIMixIn(Request):
             return self._MOCK_WEB_API_VERSION
         return self._get(_name=APINames.Application, _method="webapiVersion", **kwargs)
 
-    @version_implemented("2.3", "app/buildInfo")
+    @endpoint_introduced("2.3", "app/buildInfo")
     @response_json(BuildInfoDictionary)
     @Alias("app_buildInfo")
     @login_required

--- a/qbittorrentapi/app.py
+++ b/qbittorrentapi/app.py
@@ -113,13 +113,6 @@ class AppAPIMixIn(Request):
         """
         return self._get(_name=APINames.Application, _method="version", **kwargs)
 
-    @login_required
-    def _app_web_api_version_from_version_checker(self):
-        if self._cached_web_api_version:
-            return self._cached_web_api_version
-        self._cached_web_api_version = self.app_web_api_version()
-        return self._cached_web_api_version
-
     @Alias("app_webapiVersion")
     @response_text(str)
     @login_required

--- a/qbittorrentapi/decorators.py
+++ b/qbittorrentapi/decorators.py
@@ -172,7 +172,7 @@ def _version_too_old(client, version_to_compare):
     """
     Return True if provided API version is older than the connected API, False otherwise
     """
-    current_version = client._app_web_api_version_from_version_checker()
+    current_version = client.app_web_api_version()
     if _is_version_less_than(current_version, version_to_compare, lteq=False):
         return True
     return False
@@ -182,7 +182,7 @@ def _version_too_new(client, version_to_compare):
     """
     Return True if provided API version is newer or equal to the connected API, False otherwise
     """
-    current_version = client._app_web_api_version_from_version_checker()
+    current_version = client.app_web_api_version()
     if _is_version_less_than(version_to_compare, current_version, lteq=True):
         return True
     return False

--- a/qbittorrentapi/request.py
+++ b/qbittorrentapi/request.py
@@ -57,7 +57,6 @@ class Request(object):
         #   or a new login is required. All of these (except the SID cookie) should
         #   be reset in _initialize_connection().
         self._SID = None  # authorization cookie
-        self._cached_web_api_version = None
         self._application = None
         self._transfer = None
         self._torrents = None
@@ -227,9 +226,6 @@ class Request(object):
     ########################################
     def _initialize_context(self):
         """Reset context. This is necessary when the auth cookie needs to be replaced."""
-        # cache to avoid perf hit from version checking certain endpoints
-        self._cached_web_api_version = None
-
         # reset URL so the full URL is derived again (primarily allows for switching scheme for WebUI: HTTP <-> HTTPS)
         self._API_BASE_URL = None
 
@@ -527,7 +523,7 @@ class Request(object):
                     "Request body: %s%s"
                     % (
                         response.request.body[:body_len],
-                        "...<truncated>" if body_len >= 80 else "",
+                        "...<truncated>" if body_len >= 200 else "",
                     )
                 )
 

--- a/qbittorrentapi/rss.py
+++ b/qbittorrentapi/rss.py
@@ -2,9 +2,9 @@ from json import dumps
 
 from qbittorrentapi.decorators import Alias
 from qbittorrentapi.decorators import aliased
+from qbittorrentapi.decorators import endpoint_introduced
 from qbittorrentapi.decorators import login_required
 from qbittorrentapi.decorators import response_json
-from qbittorrentapi.decorators import version_implemented
 from qbittorrentapi.definitions import APINames
 from qbittorrentapi.definitions import ClientCache
 from qbittorrentapi.definitions import Dictionary
@@ -195,7 +195,7 @@ class RSSAPIMixIn(Request):
         params = {"withData": include_feed_data}
         return self._get(_name=APINames.RSS, _method="items", params=params, **kwargs)
 
-    @version_implemented("2.2", "rss/refreshItem")
+    @endpoint_introduced("2.2", "rss/refreshItem")
     @Alias("rss_refreshItem")
     @login_required
     def rss_refresh_item(self, item_path=None, **kwargs):
@@ -210,7 +210,7 @@ class RSSAPIMixIn(Request):
             data = {"itemPath": item_path}
             self._post(_name=APINames.RSS, _method="refreshItem", data=data, **kwargs)
 
-    @version_implemented("2.5.1", "rss/markAsRead")
+    @endpoint_introduced("2.5.1", "rss/markAsRead")
     @Alias("rss_markAsRead")
     @login_required
     def rss_mark_as_read(self, item_path=None, article_id=None, **kwargs):
@@ -276,7 +276,7 @@ class RSSAPIMixIn(Request):
         """
         return self._get(_name=APINames.RSS, _method="rules", **kwargs)
 
-    @version_implemented("2.5.1", "rss/matchingArticles")
+    @endpoint_introduced("2.5.1", "rss/matchingArticles")
     @Alias("rss_matchingArticles")
     @response_json(RSSitemsDictionary)
     @login_required

--- a/qbittorrentapi/rss.py
+++ b/qbittorrentapi/rss.py
@@ -206,7 +206,7 @@ class RSSAPIMixIn(Request):
         :return: None
         """
         # HACK: v4.1.7 and v4.1.8 both use api v2.2; however, refreshItem was introduced in v4.1.8
-        if self._is_version_less_than("v4.1.7", self.app_version(), False):
+        if self._is_version_less_than("v4.1.7", self.app.version, False):
             data = {"itemPath": item_path}
             self._post(_name=APINames.RSS, _method="refreshItem", data=data, **kwargs)
 

--- a/qbittorrentapi/search.py
+++ b/qbittorrentapi/search.py
@@ -1,8 +1,8 @@
 from qbittorrentapi.decorators import Alias
 from qbittorrentapi.decorators import aliased
+from qbittorrentapi.decorators import endpoint_introduced
 from qbittorrentapi.decorators import login_required
 from qbittorrentapi.decorators import response_json
-from qbittorrentapi.decorators import version_implemented
 from qbittorrentapi.decorators import version_removed
 from qbittorrentapi.definitions import APINames
 from qbittorrentapi.definitions import ClientCache
@@ -152,7 +152,7 @@ class SearchAPIMixIn(Request):
             self._search = Search(client=self)
         return self._search
 
-    @version_implemented("2.1.1", "search/start")
+    @endpoint_introduced("2.1.1", "search/start")
     @response_json(SearchJobDictionary)
     @login_required
     def search_start(self, pattern=None, plugins=None, category=None, **kwargs):
@@ -173,7 +173,7 @@ class SearchAPIMixIn(Request):
         }
         return self._post(_name=APINames.Search, _method="start", data=data, **kwargs)
 
-    @version_implemented("2.1.1", "search/stop")
+    @endpoint_introduced("2.1.1", "search/stop")
     @login_required
     def search_stop(self, search_id=None, **kwargs):
         """
@@ -187,7 +187,7 @@ class SearchAPIMixIn(Request):
         data = {"id": search_id}
         self._post(_name=APINames.Search, _method="stop", data=data, **kwargs)
 
-    @version_implemented("2.1.1", "search/status")
+    @endpoint_introduced("2.1.1", "search/status")
     @response_json(SearchStatusesList)
     @login_required
     def search_status(self, search_id=None, **kwargs):
@@ -205,7 +205,7 @@ class SearchAPIMixIn(Request):
             _name=APINames.Search, _method="status", params=params, **kwargs
         )
 
-    @version_implemented("2.1.1", "search/results")
+    @endpoint_introduced("2.1.1", "search/results")
     @response_json(SearchResultsDictionary)
     @login_required
     def search_results(self, search_id=None, limit=None, offset=None, **kwargs):
@@ -224,7 +224,7 @@ class SearchAPIMixIn(Request):
         data = {"id": search_id, "limit": limit, "offset": offset}
         return self._post(_name=APINames.Search, _method="results", data=data, **kwargs)
 
-    @version_implemented("2.1.1", "search/delete")
+    @endpoint_introduced("2.1.1", "search/delete")
     @login_required
     def search_delete(self, search_id=None, **kwargs):
         """
@@ -238,7 +238,7 @@ class SearchAPIMixIn(Request):
         data = {"id": search_id}
         self._post(_name=APINames.Search, _method="delete", data=data, **kwargs)
 
-    @version_implemented("2.1.1", "search/categories")
+    @endpoint_introduced("2.1.1", "search/categories")
     @version_removed("2.6", "search/categories")
     @response_json(SearchCategoriesList)
     @login_required
@@ -255,7 +255,7 @@ class SearchAPIMixIn(Request):
             _name=APINames.Search, _method="categories", data=data, **kwargs
         )
 
-    @version_implemented("2.1.1", "search/plugins")
+    @endpoint_introduced("2.1.1", "search/plugins")
     @response_json(SearchPluginsList)
     @login_required
     def search_plugins(self, **kwargs):
@@ -267,7 +267,7 @@ class SearchAPIMixIn(Request):
         """
         return self._get(_name=APINames.Search, _method="plugins", **kwargs)
 
-    @version_implemented("2.1.1", "search/installPlugin")
+    @endpoint_introduced("2.1.1", "search/installPlugin")
     @Alias("search_installPlugin")
     @login_required
     def search_install_plugin(self, sources=None, **kwargs):
@@ -280,7 +280,7 @@ class SearchAPIMixIn(Request):
         data = {"sources": self._list2string(sources, "|")}
         self._post(_name=APINames.Search, _method="installPlugin", data=data, **kwargs)
 
-    @version_implemented("2.1.1", "search/uninstallPlugin")
+    @endpoint_introduced("2.1.1", "search/uninstallPlugin")
     @Alias("search_uninstallPlugin")
     @login_required
     def search_uninstall_plugin(self, names=None, **kwargs):
@@ -295,7 +295,7 @@ class SearchAPIMixIn(Request):
             _name=APINames.Search, _method="uninstallPlugin", data=data, **kwargs
         )
 
-    @version_implemented("2.1.1", "search/enablePlugin")
+    @endpoint_introduced("2.1.1", "search/enablePlugin")
     @Alias("search_enablePlugin")
     @login_required
     def search_enable_plugin(self, plugins=None, enable=None, **kwargs):
@@ -309,7 +309,7 @@ class SearchAPIMixIn(Request):
         data = {"names": self._list2string(plugins, "|"), "enable": enable}
         self._post(_name=APINames.Search, _method="enablePlugin", data=data, **kwargs)
 
-    @version_implemented("2.1.1", "search/updatePlugin")
+    @endpoint_introduced("2.1.1", "search/updatePlugin")
     @Alias("search_updatePlugins")
     @login_required
     def search_update_plugins(self, **kwargs):

--- a/qbittorrentapi/torrents.py
+++ b/qbittorrentapi/torrents.py
@@ -20,10 +20,10 @@ from qbittorrentapi.definitions import ListEntry
 from qbittorrentapi.definitions import TorrentStates
 from qbittorrentapi.decorators import Alias
 from qbittorrentapi.decorators import aliased
+from qbittorrentapi.decorators import endpoint_introduced
 from qbittorrentapi.decorators import login_required
 from qbittorrentapi.decorators import response_json
 from qbittorrentapi.decorators import response_text
-from qbittorrentapi.decorators import version_implemented
 from qbittorrentapi.exceptions import TorrentFileError
 from qbittorrentapi.exceptions import TorrentFileNotFoundError
 from qbittorrentapi.exceptions import TorrentFilePermissionError
@@ -912,8 +912,6 @@ class TorrentsAPIMixIn(Request):
         return self._torrent_tags
 
     @response_text(str)
-    @version_implemented("2.6.2", "torrents/add", ("tags", "tags"))
-    @version_implemented("2.7", "torrents/add", ("content_layout", "contentLayout"))
     @login_required
     def torrents_add(
         self,
@@ -965,8 +963,8 @@ class TorrentsAPIMixIn(Request):
         :param use_auto_torrent_management: True or False to use automatic torrent management
         :param is_sequential_download: True or False for sequential download
         :param is_first_last_piece_priority: True or False for first and last piece download priority
-        :param tags: tag(s) to assign to torrent(s)
-        :param content_layout: Original, Subfolder, or NoSubfolder to control filesystem structure for content
+        :param tags: tag(s) to assign to torrent(s) (added in Web API v2.6.2)
+        :param content_layout: Original, Subfolder, or NoSubfolder to control filesystem structure for content (added in Web API v2.7)
         :return: "Ok." for success and "Fails." for failure
         """
 
@@ -1189,7 +1187,7 @@ class TorrentsAPIMixIn(Request):
         }
         self._post(_name=APINames.Torrents, _method="addTrackers", data=data, **kwargs)
 
-    @version_implemented("2.2.0", "torrents/editTracker")
+    @endpoint_introduced("2.2.0", "torrents/editTracker")
     @Alias("torrents_editTracker")
     @login_required
     def torrents_edit_tracker(
@@ -1214,7 +1212,7 @@ class TorrentsAPIMixIn(Request):
         }
         self._post(_name=APINames.Torrents, _method="editTracker", data=data, **kwargs)
 
-    @version_implemented("2.2.0", "torrents/removeTrackers")
+    @endpoint_introduced("2.2.0", "torrents/removeTrackers")
     @Alias("torrents_removeTrackers")
     @login_required
     def torrents_remove_trackers(self, torrent_hash=None, urls=None, **kwargs):
@@ -1274,7 +1272,7 @@ class TorrentsAPIMixIn(Request):
         data = {"hash": torrent_hash or kwargs.pop("hash"), "name": new_torrent_name}
         self._post(_name=APINames.Torrents, _method="rename", data=data, **kwargs)
 
-    @version_implemented("2.4.0", "torrents/renameFile")
+    @endpoint_introduced("2.4.0", "torrents/renameFile")
     @Alias("torrents_renameFile")
     @login_required
     def torrents_rename_file(
@@ -1303,7 +1301,6 @@ class TorrentsAPIMixIn(Request):
     # MULTIPLE TORRENT ENDPOINTS
     ##########################################################################
     @response_json(TorrentInfoList)
-    @version_implemented("2.0.1", "torrents/info", ("torrent_hashes", "hashes"))
     @login_required
     def torrents_info(
         self,
@@ -1396,7 +1393,7 @@ class TorrentsAPIMixIn(Request):
         }
         self._post(_name=APINames.Torrents, _method="recheck", data=data, **kwargs)
 
-    @version_implemented("2.0.2", "torrents/reannounce")
+    @endpoint_introduced("2.0.2", "torrents/reannounce")
     @login_required
     def torrents_reannounce(self, torrent_hashes=None, **kwargs):
         """
@@ -1510,7 +1507,7 @@ class TorrentsAPIMixIn(Request):
             _name=APINames.Torrents, _method="setDownloadLimit", data=data, **kwargs
         )
 
-    @version_implemented("2.0.1", "torrents/setShareLimits")
+    @endpoint_introduced("2.0.1", "torrents/setShareLimits")
     @Alias("torrents_setShareLimits")
     @login_required
     def torrents_set_share_limits(
@@ -1696,7 +1693,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     @Alias("torrents_addPeers")
-    @version_implemented("2.3.0", "torrents/addPeers")
+    @endpoint_introduced("2.3.0", "torrents/addPeers")
     @response_json(TorrentsAddPeersDictionary)
     @login_required
     def torrents_add_peers(self, peers=None, torrent_hashes=None, **kwargs):
@@ -1718,7 +1715,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     # TORRENT CATEGORIES ENDPOINTS
-    @version_implemented("2.1.1", "torrents/categories")
+    @endpoint_introduced("2.1.1", "torrents/categories")
     @response_json(TorrentCategoriesDictionary)
     @login_required
     def torrents_categories(self, **kwargs):
@@ -1731,7 +1728,6 @@ class TorrentsAPIMixIn(Request):
         return self._get(_name=APINames.Torrents, _method="categories", **kwargs)
 
     @Alias("torrents_createCategory")
-    @version_implemented("2.1.0", "torrents/createCategory", ("save_path", "savePath"))
     @login_required
     def torrents_create_category(self, name=None, save_path=None, **kwargs):
         """
@@ -1750,7 +1746,7 @@ class TorrentsAPIMixIn(Request):
             _name=APINames.Torrents, _method="createCategory", data=data, **kwargs
         )
 
-    @version_implemented("2.1.0", "torrents/editCategory")
+    @endpoint_introduced("2.1.0", "torrents/editCategory")
     @Alias("torrents_editCategory")
     @login_required
     def torrents_edit_category(self, name=None, save_path=None, **kwargs):
@@ -1783,7 +1779,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     # TORRENT TAGS ENDPOINTS
-    @version_implemented("2.3.0", "torrents/tags")
+    @endpoint_introduced("2.3.0", "torrents/tags")
     @response_json(TagList)
     @login_required
     def torrents_tags(self, **kwargs):
@@ -1795,7 +1791,7 @@ class TorrentsAPIMixIn(Request):
         return self._get(_name=APINames.Torrents, _method="tags", **kwargs)
 
     @Alias("torrents_addTags")
-    @version_implemented("2.3.0", "torrents/addTags")
+    @endpoint_introduced("2.3.0", "torrents/addTags")
     @login_required
     def torrents_add_tags(self, tags=None, torrent_hashes=None, **kwargs):
         """
@@ -1813,7 +1809,7 @@ class TorrentsAPIMixIn(Request):
         self._post(_name=APINames.Torrents, _method="addTags", data=data, **kwargs)
 
     @Alias("torrents_removeTags")
-    @version_implemented("2.3.0", "torrents/removeTags")
+    @endpoint_introduced("2.3.0", "torrents/removeTags")
     @login_required
     def torrents_remove_tags(self, tags=None, torrent_hashes=None, **kwargs):
         """
@@ -1830,7 +1826,7 @@ class TorrentsAPIMixIn(Request):
         self._post(_name=APINames.Torrents, _method="removeTags", data=data, **kwargs)
 
     @Alias("torrents_createTags")
-    @version_implemented("2.3.0", "torrents/createTags")
+    @endpoint_introduced("2.3.0", "torrents/createTags")
     @login_required
     def torrents_create_tags(self, tags=None, **kwargs):
         """
@@ -1843,7 +1839,7 @@ class TorrentsAPIMixIn(Request):
         self._post(_name=APINames.Torrents, _method="createTags", data=data, **kwargs)
 
     @Alias("torrents_deleteTags")
-    @version_implemented("2.3.0", "torrents/deleteTags")
+    @endpoint_introduced("2.3.0", "torrents/deleteTags")
     @login_required
     def torrents_delete_tags(self, tags=None, **kwargs):
         """

--- a/qbittorrentapi/transfer.py
+++ b/qbittorrentapi/transfer.py
@@ -3,7 +3,7 @@ from qbittorrentapi.decorators import aliased
 from qbittorrentapi.decorators import login_required
 from qbittorrentapi.decorators import response_json
 from qbittorrentapi.decorators import response_text
-from qbittorrentapi.decorators import version_implemented
+from qbittorrentapi.decorators import endpoint_introduced
 from qbittorrentapi.definitions import APINames
 from qbittorrentapi.definitions import ClientCache
 from qbittorrentapi.definitions import Dictionary
@@ -206,7 +206,7 @@ class TransferAPIMixIn(Request):
         )
 
     @Alias("transfer_banPeers")
-    @version_implemented("2.3", "transfer/banPeers")
+    @endpoint_introduced("2.3", "transfer/banPeers")
     @login_required
     def transfer_ban_peers(self, peers=None, **kwargs):
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="qbittorrent-api",
-    version="2020.12.15",
+    version="2021.1.16",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     install_requires=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ api_version_map = {
     "v4.3.0.1": "2.6",
     "v4.3.1": "2.6.1",
     "v4.3.2": "2.7",
+    "v4.3.3": "2.7",
 }
 
 _check_limit = 10
@@ -232,7 +233,7 @@ def api_version():
 
 def pytest_sessionfinish(session, exitstatus):
     try:
-        if "TRAVIS" not in environ:
+        if environ.get("CI") != "true":
             client = Client()
             # remove all torrents
             for torrent in client.torrents_info():

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -11,7 +11,7 @@ from qbittorrentapi.decorators import (
     response_json,
     response_text,
 )
-from qbittorrentapi.decorators import version_implemented, version_removed
+from qbittorrentapi.decorators import endpoint_introduced, version_removed
 from qbittorrentapi import APIError
 
 
@@ -103,38 +103,22 @@ def test_version_implemented():
         def _app_web_api_version_from_version_checker(self):
             return self.version
 
-        @version_implemented("1.1", "test1")
+        @endpoint_introduced("1.1", "test1")
         def endpoint_not_implemented(self):
             return
 
-        @version_implemented("0.9", "test2")
+        @endpoint_introduced("0.9", "test2")
         def endpoint_implemented(self):
             return
-
-        @version_implemented("1.1", "test3", ("var1", "var1"))
-        def endpoint_param_not_implemented(self, var1="zxcv"):
-            return var1
-
-        @version_implemented("0.9", "test3", ("var1", "var1"))
-        def endpoint_param_implemented(self, var1="zxcv"):
-            return var1
 
     with pytest.raises(NotImplementedError):
         FakeClient().endpoint_not_implemented()
 
     assert FakeClient().endpoint_implemented() is None
 
-    with pytest.raises(NotImplementedError):
-        FakeClient().endpoint_param_not_implemented(var1="asdf")
-
-    assert FakeClient().endpoint_param_not_implemented(var1=None) is None
-
     fake_client = FakeClient()
     fake_client._RAISE_UNIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS = False
-    assert fake_client.endpoint_param_not_implemented(var1="asdf") is None
     assert fake_client.endpoint_not_implemented() is None
-
-    assert FakeClient().endpoint_param_implemented(var1="asdf") == "asdf"
 
 
 def test_version_removed():

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -100,7 +100,7 @@ def test_version_implemented():
         _RAISE_UNIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS = True
         version = "1.0"
 
-        def _app_web_api_version_from_version_checker(self):
+        def app_web_api_version(self):
             return self.version
 
         @endpoint_introduced("1.1", "test1")
@@ -126,7 +126,7 @@ def test_version_removed():
         _RAISE_UNIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS = True
         version = "1.0"
 
-        def _app_web_api_version_from_version_checker(self):
+        def app_web_api_version(self):
             return self.version
 
         @version_removed("0.0.0", "test1")

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -25,9 +25,9 @@ from tests.test_torrents import (
 def test_info(orig_torrent):
     assert orig_torrent.info.hash == orig_torrent.hash
     # mimic <=v2.0.1 where torrents_info() doesn't support hash arg
-    orig_torrent._client._cached_web_api_version = "2"
+    orig_torrent._client._MOCK_WEB_API_VERSION = "2"
     assert orig_torrent.info.hash == orig_torrent.hash
-    orig_torrent._client._cached_web_api_version = None
+    orig_torrent._client._MOCK_WEB_API_VERSION = None
 
 
 def test_sync_local(orig_torrent):
@@ -325,13 +325,45 @@ def test_reannounce(client, api_version, orig_torrent):
 
 @pytest.mark.parametrize("client_func", ("rename_file", "renameFile"))
 @pytest.mark.parametrize("name", ("new_name", "new name"))
-def test_rename_file(api_version, orig_torrent, client_func, name):
+def test_rename_file(api_version, app_version, new_torrent, client_func, name):
     if is_version_less_than(api_version, "2.4.0", lteq=False):
         with pytest.raises(NotImplementedError):
-            getattr(orig_torrent, client_func)(file_id=0, new_file_name=name)
+            getattr(new_torrent, client_func)(file_id=0, new_file_name=name)
     else:
-        getattr(orig_torrent, client_func)(file_id=0, new_file_name=name)
-        check(lambda: orig_torrent.files[0].name, name)
+        getattr(new_torrent, client_func)(file_id=0, new_file_name=name)
+        check(lambda: new_torrent.files[0].name, name)
+
+    if is_version_less_than("4.3.3", app_version, lteq=True):
+        curr_name = new_torrent.files[0].name
+        getattr(new_torrent, client_func)(old_path=curr_name, new_path=name + "_new")
+        check(lambda: new_torrent.files[0].name, name + "_new")
+
+
+@pytest.mark.parametrize("client_func", ("rename_folder", "renameFolder"))
+@pytest.mark.parametrize("name", ("new_name", "new name"))
+def test_rename_folder(api_version, app_version, new_torrent, client_func, name):
+    if is_version_less_than(api_version, "2.7", lteq=False):
+        with pytest.raises(NotImplementedError):
+            getattr(new_torrent, client_func)(old_path="", new_path="")
+    # need to ensure we're at least on v4.3.3 to run test
+    if is_version_less_than("v4.3.2", app_version, lteq=False):
+        # move the file in to a new folder
+        orig_file_path = new_torrent.files[0].name
+        new_folder = "qwer"
+        new_torrent.rename_file(
+            old_path=orig_file_path,
+            new_path=new_folder + "/" + orig_file_path,
+        )
+        sleep(1)  # qBittorrent crashes if you make these calls too fast...
+        # test rename that new folder
+        getattr(new_torrent, client_func)(
+            old_path=new_folder,
+            new_path=name,
+        )
+        check(
+            lambda: new_torrent.files[0].name.replace("+", " "),
+            name + "/" + orig_file_path,
+        )
 
 
 @pytest.mark.parametrize("client_func", ("piece_states", "pieceStates"))

--- a/tests/test_zzz_last_tests.py
+++ b/tests/test_zzz_last_tests.py
@@ -6,7 +6,7 @@ from qbittorrentapi import APIConnectionError
 
 
 def test_shutdown(client):
-    if "TRAVIS" in environ:
+    if environ.get("CI") == "true":
         client.app.shutdown()
         with pytest.raises(APIConnectionError):
             for _ in range(100):


### PR DESCRIPTION
 - Stop removing parameters from API requests after those parameters are officially dropped. The Client supports sending arbitrary parameters in any request....and qBittorrent appears to ignore unneeded parameters anyway.
 - Add support for the reimplemented `renameFile` and new `renameFolder` endpoints. Backwards compatibility should be maintained for `renameFile`....but not thanks to the qBittorrent devs who threw compatibility out the door...
 - ~~TODO: add test coverage for `renameFolder`~~
 - ~~TODO: verify the Web API version that is actually released....currently expecting 2.7.1...could be 2.8.0...~~
sooo....the api version wasn't bumped....it was left at 2.7.....so, welcome to a bunch of hacks
 - deferred ~~TODO: potentially create new decorator for converting all `hash`/`hashes` arguments to `torrent_hash`/`torrent_hashes`~~