### PR TITLE
Refactor request.py | Clean Up Docs | Vendor attrdict

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+# .coveragerc to control coverage.py
+[run]
+source = qbittorrentapi
+omit = qbittorrentapi/_attrdict.py
+branch = True
+
+[report]
+show_missing = True
+
+[html]
+skip_empty = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,20 @@ branch = True
 
 [report]
 show_missing = True
+skip_covered = True
+exclude_lines =
+    # search categories was deprecated
+    class SearchCategoriesList
+    def search_categories
+    # defaults to exclude
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
 
 [html]
 skip_empty = True

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -172,7 +172,7 @@ jobs:
       run: |
         pip -q install -U black
         black --version
-        black . --check
+        black . --check --diff --target-version py27
 
     - name: Test with pytest
       # finally....start qBittorrent and run tests via pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,8 +31,8 @@ jobs:
       QBT_LEGACY_INSTALL: 4.2.5, 4.2.0
     strategy:
       matrix:
-        QBT_VER: [4.2.0, 4.2.5, 4.3.0.1, 4.3.1, 4.3.2, 4.3.3]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev, pypy2, pypy3]
+        QBT_VER: [4.3.3, 4.3.2, 4.3.1, 4.3.0.1, 4.2.5, 4.2.0]
+        python-version: [3.9, 3.8, 3.7, 3.6, 3.5, 2.7, 3.10-dev, pypy2, pypy3]
         # python-version: [3.9]
 
     # TODO: each step currently has an over-complicated conditional to prevent always running all tests.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+Version 2021.2.17 (7 feb 2021)
+ - Generally refactor requests.py so it's better and easier to read
+ - Persist a Requests Session between API calls instead of always creating a new one...small perf benefit
+ - Move auth endpoints back to a dedicated module
+ - Since attrdict is apparently going to break in Python 3.10 and it is no longer maintained, i've vendored a modified version (fixes #45).
+ - Created handle_hashes decorator to hide the cruft of continuing to support hash and hashes arguments
+
 Version 2021.1.16 (26 jan 2021)
  - Support qBittorrent v4.3.3 and Web API v2.7 (...again)
  - New torrents/renameFile and torrents/renameFolder endpoints

--- a/docs/source/apidoc/app.rst
+++ b/docs/source/apidoc/app.rst
@@ -1,12 +1,23 @@
 Application
 ================================
 
-.. automodule:: qbittorrentapi
-
-.. autoclass:: AppAPIMixIn
-    :members:
-    :exclude-members: app
-
-.. autoclass:: Application
+.. autoclass:: qbittorrentapi.app.AppAPIMixIn
     :members:
     :undoc-members:
+    :exclude-members: app, application, app_webapiVersion, app_buildInfo, app_setPreferences, app_defaultSavePath
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.app.Application
+    :members:
+    :undoc-members:
+    :exclude-members: app, application, webapiVersion, buildInfo, setPreferences, defaultSavePath
+
+.. autoclass:: qbittorrentapi.app.ApplicationPreferencesDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.app.BuildInfoDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/apidoc/auth.rst
+++ b/docs/source/apidoc/auth.rst
@@ -1,7 +1,12 @@
 Authentication
 ================================
 
-.. automodule:: qbittorrentapi
+.. autoclass:: qbittorrentapi.auth.AuthAPIMixIn
+    :members:
+    :undoc-members:
+    :exclude-members: auth, authorization
+    :show-inheritance:
 
-.. autoclass:: Request
-    :members: auth_log_in, auth_log_out
+.. autoclass:: qbittorrentapi.auth.Authorization
+    :members:
+    :undoc-members:

--- a/docs/source/apidoc/client.rst
+++ b/docs/source/apidoc/client.rst
@@ -1,7 +1,7 @@
 Client
 ================================
 
-.. automodule:: qbittorrentapi
-
-.. autoclass:: Client
+.. autoclass:: qbittorrentapi.client.Client
     :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/apidoc/definitions.rst
+++ b/docs/source/apidoc/definitions.rst
@@ -1,0 +1,8 @@
+Definitions
+================================
+
+.. automodule:: qbittorrentapi.definitions
+    :members:
+    :exclude-members: TorrentStates, ClientCache
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/apidoc/log.rst
+++ b/docs/source/apidoc/log.rst
@@ -1,12 +1,32 @@
 Log
 ================================
 
-.. automodule:: qbittorrentapi
-
-.. autoclass:: LogAPIMixIn
-    :members:
-    :exclude-members: log
-
-.. autoclass:: Log
+.. autoclass:: qbittorrentapi.log.LogAPIMixIn
     :members:
     :undoc-members:
+    :exclude-members: log
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.log.Log
+    :members:
+    :undoc-members:
+
+.. autoclass:: qbittorrentapi.log.LogPeersList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.log.LogPeer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.log.LogMainList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.log.LogEntry
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/apidoc/rss.rst
+++ b/docs/source/apidoc/rss.rst
@@ -1,12 +1,23 @@
 RSS
 ================================
 
-.. automodule:: qbittorrentapi
-
-.. autoclass:: RSSAPIMixIn
-    :members:
-    :exclude-members: rss
-
-.. autoclass:: RSS
+.. autoclass:: qbittorrentapi.rss.RSSAPIMixIn
     :members:
     :undoc-members:
+    :exclude-members: rss, rss_addFolder, rss_addFeed, rss_removeItem, rss_moveItem, rss_refreshItem, rss_markAsRead, rss_setRule, rss_renameRule, rss_removeRule, rss_matchingArticles
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.rss.RSS
+    :members:
+    :undoc-members:
+    :exclude-members: rss, addFolder, addFeed, removeItem, moveItem, refreshItem, markAsRead, setRule, renameRule, removeRule, matchingArticles
+
+.. autoclass:: qbittorrentapi.rss.RSSitemsDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.rss.RSSRulesDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/apidoc/search.rst
+++ b/docs/source/apidoc/search.rst
@@ -1,12 +1,53 @@
 Search
 ================================
 
-.. automodule:: qbittorrentapi
-
-.. autoclass:: SearchAPIMixIn
-    :members:
-    :exclude-members: search
-
-.. autoclass:: Search
+.. autoclass:: qbittorrentapi.search.SearchAPIMixIn
     :members:
     :undoc-members:
+    :exclude-members: search, search_installPlugin, search_uninstallPlugin, search_enablePlugin, search_updatePlugins
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.search.Search
+    :members:
+    :undoc-members:
+    :exclude-members: installPlugin, uninstallPlugin, enablePlugin, updatePlugins
+
+.. autoclass:: qbittorrentapi.search.SearchJobDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.search.SearchResultsDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.search.SearchStatusesList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.search.SearchStatus
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.search.SearchCategoriesList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.search.SearchCategory
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.search.SearchPluginsList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.search.SearchPlugin
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/apidoc/sync.rst
+++ b/docs/source/apidoc/sync.rst
@@ -1,12 +1,22 @@
 Sync
 ================================
 
-.. automodule:: qbittorrentapi
-
-.. autoclass:: SyncAPIMixIn
-    :members:
-    :exclude-members: sync
-
-.. autoclass:: Sync
+.. autoclass:: qbittorrentapi.sync.SyncAPIMixIn
     :members:
     :undoc-members:
+    :exclude-members: sync, sync_torrentPeers
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.sync.Sync
+    :members:
+    :undoc-members:
+
+.. autoclass:: qbittorrentapi.sync.SyncMainDataDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.sync.SyncTorrentPeersDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/apidoc/torrent_states.rst
+++ b/docs/source/apidoc/torrent_states.rst
@@ -1,8 +1,7 @@
 Torrent States
 ================================
 
-.. automodule:: qbittorrentapi
-
-.. autoclass:: TorrentStates
+.. autoclass:: qbittorrentapi.definitions.TorrentStates
     :members:
     :undoc-members:
+    :show-inheritance:

--- a/docs/source/apidoc/torrents.rst
+++ b/docs/source/apidoc/torrents.rst
@@ -1,15 +1,106 @@
 Torrents
 ================================
 
-.. automodule:: qbittorrentapi
-
-.. autoclass:: TorrentsAPIMixIn
-    :members:
-    :exclude-members: torrents, torrent_categories, torrent_tags
-.. autoclass:: Torrents
+.. autoclass:: qbittorrentapi.torrents.TorrentsAPIMixIn
     :members:
     :undoc-members:
+    :exclude-members: torrents, torrent_categories, torrent_tags, torrents_pieceStates, torrents_pieceHashes, torrents_addTrackers, torrents_editTracker, torrents_removeTrackers, torrents_filePrio, torrents_renameFile, torrents_renameFolder, torrents_increasePrio, torrents_decreasePrio, torrents_topPrio, torrents_bottomPrio, torrents_downloadLimit, torrents_setDownloadLimit, torrents_setShareLimits, torrents_uploadLimit, torrents_setUploadLimit, torrents_setLocation, torrents_setCategory, torrents_setAutoManagement, torrents_toggleSequentialDownload, torrents_toggleFirstLastPiecePrio, torrents_setForceStart, torrents_setSuperSeeding, torrents_addPeers, torrents_createCategory, torrents_editCategory, torrents_removeCategories, torrents_addTags, torrents_removeTags, torrents_createTags, torrents_deleteTags
+    :show-inheritance:
 
-.. autoclass:: TorrentDictionary
+.. autoclass:: qbittorrentapi.torrents.Torrents
     :members:
     :undoc-members:
+    :exclude-members: pieceStates, pieceHashes, addTrackers, editTracker, removeTrackers, filePrio, renameFile, renameFolder, increasePrio, decreasePrio, topPrio, bottomPrio, downloadLimit, setDownloadLimit, setShareLimits, uploadLimit, setUploadLimit, setLocation, setCategory, setAutoManagement, toggleSequentialDownload, toggleFirstLastPiecePrio, setForceStart, setSuperSeeding, addPeers, createCategory, editCategory, removeCategories, addTags, removeTags, createTags, deleteTags
+
+.. autoclass:: qbittorrentapi.torrents.TorrentDictionary
+    :members:
+    :undoc-members:
+    :exclude-members: pieceStates, pieceHashes, addTrackers, editTracker, removeTrackers, filePrio, renameFile, renameFolder, increasePrio, decreasePrio, topPrio, bottomPrio, downloadLimit, setDownloadLimit, setShareLimits, uploadLimit, setUploadLimit, setLocation, setCategory, setAutoManagement, toggleSequentialDownload, toggleFirstLastPiecePrio, setForceStart, setSuperSeeding, addPeers, createCategory, editCategory, removeCategories, addTags, removeTags, createTags, deleteTags, filePriority
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentCategories
+    :members:
+    :undoc-members:
+    :exclude-members: removeCategories, editCategory, createCategory
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentTags
+    :members:
+    :undoc-members:
+    :exclude-members: addTags, removeTags, createTags, deleteTags
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentPropertiesDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentLimitsDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentCategoriesDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentsAddPeersDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentFilesList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentFile
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.WebSeedsList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.WebSeed
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TrackersList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.Tracker
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentInfoList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentPieceInfoList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TorrentPieceData
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.TagList
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.torrents.Tag
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/apidoc/transfer.rst
+++ b/docs/source/apidoc/transfer.rst
@@ -1,12 +1,18 @@
 Transfer
 ================================
 
-.. automodule:: qbittorrentapi
-
-.. autoclass:: TransferAPIMixIn
-    :members:
-    :exclude-members: transfer
-
-.. autoclass:: Transfer
+.. autoclass:: qbittorrentapi.transfer.TransferAPIMixIn
     :members:
     :undoc-members:
+    :exclude-members: transfer, transfer_speedLimitsMode, transfer_toggleSpeedLimitsMode, transfer_downloadLimit, transfer_uploadLimit, transfer_setDownloadLimit, transfer_setUploadLimit, transfer_banPeers
+    :show-inheritance:
+
+.. autoclass:: qbittorrentapi.transfer.Transfer
+    :members:
+    :undoc-members:
+    :exclude-members: toggleSpeedLimitsMode, setDownloadLimit, setUploadLimit, banPeers, speedLimitsMode, downloadLimit, uploadLimit
+
+.. autoclass:: qbittorrentapi.transfer.TransferInfoDictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/behavior&configuration.rst
+++ b/docs/source/behavior&configuration.rst
@@ -13,6 +13,14 @@ Host, Username and Password
 * These can be provided when instantiating Client or calling ``qbt_client.auth_log_in(username='...', password='...')``.
 * Alternatively, set environment variables ``PYTHON_QBITTORRENTAPI_HOST``, ``PYTHON_QBITTORRENTAPI_USERNAME`` and ``PYTHON_QBITTORRENTAPI_PASSWORD``.
 
+Custom HTTP Headers
+***************************
+* To send a custom HTTP header in all requests made from an instantiated client, declare them during instantiation.
+    * ``qbt_client = Client(..., EXTRA_HEADERS={'X-My-Fav-Header': 'header value')``
+* Alternatively, you can send custom headers in individual requests.
+    * ``qbt_client.torrents.add(..., headers={'X-My-Fav-Header': 'header value')``
+    * These headers will be merged with other headers otherwise configured to be sent.
+
 Unimplemented API Endpoints
 ***************************
 * Since the qBittorrent Web API has evolved over time, some endpoints may not be available from the qBittorrent host.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,13 +17,14 @@ sys.path.insert(0, os.path.abspath("../.."))
 
 
 # -- Project information -----------------------------------------------------
+from datetime import datetime
 
 project = "qbittorrent-api"
-copyright = "2020, Russell Martin"
+copyright = "%s, Russell Martin" % datetime.today().year
 author = "Russell Martin"
 
 # The full version, including alpha/beta/rc tags
-release = "2020.6.4"
+release = ""
 
 
 # -- General configuration ---------------------------------------------------
@@ -32,7 +33,12 @@ pygments_style = "sphinx"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.todo", "sphinx.ext.githubpages", "sphinx.ext.autodoc"]
+extensions = [
+    "sphinx.ext.todo",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+]
 
 source_suffix = ".rst"
 
@@ -49,17 +55,10 @@ exclude_patterns = []
 
 
 # -- Options for HTML output -------------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-# html_theme = 'alabaster'
-html_theme = "guzzle_sphinx_theme"
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+## html_static_path = ["_static"]
 
 
 import sphinx_glpi_theme
@@ -73,3 +72,8 @@ html_theme_path = sphinx_glpi_theme.get_html_themes_path()
 # autoapi_dirs = ['../../qbittorrentapi']
 # autoapi_options = ['show-inheritance-diagram']
 # autoapi_ignore = ['*decorators*', '*exceptions*']
+
+# Add mappings
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,10 +4,8 @@ norecursedirs=dist build .tox scripts
 addopts =
   --doctest-modules
   --cov=qbittorrentapi
-  --cov-report=term-missing:skip-covered
   --cov-report=xml
   --cov-report=html
-  --cov-branch
   --no-cov-on-fail
   -r a
   -v

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 testpaths = tests
 norecursedirs=dist build .tox scripts
+filterwarnings = ignore::urllib3.exceptions.InsecureRequestWarning
 addopts =
   --doctest-modules
   --cov=qbittorrentapi

--- a/qbittorrentapi/__init__.py
+++ b/qbittorrentapi/__init__.py
@@ -2,9 +2,10 @@ from qbittorrentapi.client import Client
 from qbittorrentapi.definitions import *
 from qbittorrentapi.exceptions import *
 
-from qbittorrentapi.request import *
 from qbittorrentapi.app import *
+from qbittorrentapi.auth import *
 from qbittorrentapi.log import *
+from qbittorrentapi.request import *
 from qbittorrentapi.rss import *
 from qbittorrentapi.search import *
 from qbittorrentapi.sync import *

--- a/qbittorrentapi/_attrdict.py
+++ b/qbittorrentapi/_attrdict.py
@@ -1,0 +1,537 @@
+# Copyright (c) 2013 Brendan Curran-Johnson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+Functions and Classes from attrdict.
+
+*rmartin Feb 2021
+AttrDict finally broke with Python 3.10 since abstract base classes can no
+longer be imported from collections but should use collections.abc instead.
+Since AttrDict is abandoned, I've consolidated the code here for future use.
+AttrMap and AttrDefault are left for posterity but commented out.
+"""
+
+from abc import ABCMeta
+from abc import abstractmethod
+from re import match as re_match
+
+try:  # python 3
+    from collections.abc import Mapping
+    from collections.abc import MutableMapping
+    from collections.abc import Sequence
+except ImportError:  # python 2
+    from collections import Mapping
+    from collections import MutableMapping
+    from collections import Sequence
+
+from six import add_metaclass as six_add_metaclass
+from six import string_types as six_string_types
+from six import binary_type as six_binary_type
+from six import u as six_u
+
+
+def merge(left, right):
+    """
+    Merge two mappings objects together, combining overlapping Mappings,
+    and favoring right-values
+
+    left: The left Mapping object.
+    right: The right (favored) Mapping object.
+
+    NOTE: This is not commutative (merge(a,b) != merge(b,a)).
+    """
+    merged = {}
+
+    left_keys = frozenset(left)
+    right_keys = frozenset(right)
+
+    # Items only in the left Mapping
+    for key in left_keys - right_keys:
+        merged[key] = left[key]
+
+    # Items only in the right Mapping
+    for key in right_keys - left_keys:
+        merged[key] = right[key]
+
+    # in both
+    for key in left_keys & right_keys:
+        left_value = left[key]
+        right_value = right[key]
+
+        if isinstance(left_value, Mapping) and isinstance(
+            right_value, Mapping
+        ):  # recursive merge
+            merged[key] = merge(left_value, right_value)
+        else:  # overwrite with right value
+            merged[key] = right_value
+
+    return merged
+
+
+@six_add_metaclass(ABCMeta)
+class Attr(Mapping):
+    """
+    A mixin class for a mapping that allows for attribute-style access
+    of values.
+
+    A key may be used as an attribute if:
+     * It is a string
+     * It matches /^[A-Za-z][A-Za-z0-9_]*$/ (i.e., a public attribute)
+     * The key doesn't overlap with any class attributes (for Attr,
+        those would be 'get', 'items', 'keys', 'values', 'mro', and
+        'register').
+
+    If a values which is accessed as an attribute is a Sequence-type
+    (and is not a string/bytes), it will be converted to a
+    _sequence_type with any mappings within it converted to Attrs.
+
+    NOTE: This means that if _sequence_type is not None, then a
+        sequence accessed as an attribute will be a different object
+        than if accessed as an attribute than if it is accessed as an
+        item.
+    """
+
+    @abstractmethod
+    def _configuration(self):
+        """
+        All required state for building a new instance with the same
+        settings as the current object.
+        """
+
+    @classmethod
+    def _constructor(cls, mapping, configuration):
+        """
+        A standardized constructor used internally by Attr.
+
+        mapping: A mapping of key-value pairs. It is HIGHLY recommended
+            that you use this as the internal key-value pair mapping, as
+            that will allow nested assignment (e.g., attr.foo.bar = baz)
+        configuration: The return value of Attr._configuration
+        """
+        raise NotImplementedError("You need to implement this")
+
+    def __call__(self, key):
+        """
+        Dynamically access a key-value pair.
+
+        key: A key associated with a value in the mapping.
+
+        This differs from __getitem__, because it returns a new instance
+        of an Attr (if the value is a Mapping object).
+        """
+        if key not in self:
+            raise AttributeError(
+                "'{cls} instance has no attribute '{name}'".format(
+                    cls=self.__class__.__name__, name=key
+                )
+            )
+
+        return self._build(self[key])
+
+    def __getattr__(self, key):
+        """
+        Access an item as an attribute.
+        """
+        if key not in self or not self._valid_name(key):
+            raise AttributeError(
+                "'{cls}' instance has no attribute '{name}'".format(
+                    cls=self.__class__.__name__, name=key
+                )
+            )
+
+        return self._build(self[key])
+
+    def __add__(self, other):
+        """
+        Add a mapping to this Attr, creating a new, merged Attr.
+
+        other: A mapping.
+
+        NOTE: Addition is not commutative. a + b != b + a.
+        """
+        if not isinstance(other, Mapping):
+            return NotImplemented
+
+        return self._constructor(merge(self, other), self._configuration())
+
+    def __radd__(self, other):
+        """
+        Add this Attr to a mapping, creating a new, merged Attr.
+
+        other: A mapping.
+
+        NOTE: Addition is not commutative. a + b != b + a.
+        """
+        if not isinstance(other, Mapping):
+            return NotImplemented
+
+        return self._constructor(merge(other, self), self._configuration())
+
+    def _build(self, obj):
+        """
+        Conditionally convert an object to allow for recursive mapping
+        access.
+
+        obj: An object that was a key-value pair in the mapping. If obj
+            is a mapping, self._constructor(obj, self._configuration())
+            will be called. If obj is a non-string/bytes sequence, and
+            self._sequence_type is not None, the obj will be converted
+            to type _sequence_type and build will be called on its
+            elements.
+        """
+        if isinstance(obj, Mapping):
+            obj = self._constructor(obj, self._configuration())
+        elif isinstance(obj, Sequence) and not isinstance(
+            obj, (six_string_types, six_binary_type)
+        ):
+            sequence_type = getattr(self, "_sequence_type", None)
+
+            if sequence_type:
+                obj = sequence_type(self._build(element) for element in obj)
+
+        return obj
+
+    @classmethod
+    def _valid_name(cls, key):
+        """
+        Check whether a key is a valid attribute name.
+
+        A key may be used as an attribute if:
+         * It is a string
+         * It matches /^[A-Za-z][A-Za-z0-9_]*$/ (i.e., a public attribute)
+         * The key doesn't overlap with any class attributes (for Attr,
+            those would be 'get', 'items', 'keys', 'values', 'mro', and
+            'register').
+        """
+        return (
+            isinstance(key, six_string_types)
+            and re_match("^[A-Za-z][A-Za-z0-9_]*$", key)
+            and not hasattr(cls, key)
+        )
+
+
+@six_add_metaclass(ABCMeta)
+class MutableAttr(Attr, MutableMapping):
+    """
+    A mixin class for a mapping that allows for attribute-style access
+    of values.
+    """
+
+    def _setattr(self, key, value):
+        """
+        Add an attribute to the object, without attempting to add it as
+        a key to the mapping.
+        """
+        super(MutableAttr, self).__setattr__(key, value)
+
+    def __setattr__(self, key, value):
+        """
+        Add an attribute.
+
+        key: The name of the attribute
+        value: The attributes contents
+        """
+        if self._valid_name(key):
+            self[key] = value
+        elif getattr(self, "_allow_invalid_attributes", True):
+            super(MutableAttr, self).__setattr__(key, value)
+        else:
+            raise TypeError(
+                "'{cls}' does not allow attribute creation.".format(
+                    cls=self.__class__.__name__
+                )
+            )
+
+    def _delattr(self, key):
+        """
+        Delete an attribute from the object, without attempting to
+        remove it from the mapping.
+        """
+        super(MutableAttr, self).__delattr__(key)
+
+    def __delattr__(self, key, force=False):
+        """
+        Delete an attribute.
+
+        key: The name of the attribute
+        """
+        if self._valid_name(key):
+            del self[key]
+        elif getattr(self, "_allow_invalid_attributes", True):
+            super(MutableAttr, self).__delattr__(key)
+        else:
+            raise TypeError(
+                "'{cls}' does not allow attribute deletion.".format(
+                    cls=self.__class__.__name__
+                )
+            )
+
+
+class AttrDict(dict, MutableAttr):
+    """
+    A dict that implements MutableAttr.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+
+        self._setattr("_sequence_type", tuple)
+        self._setattr("_allow_invalid_attributes", False)
+
+    def _configuration(self):
+        """
+        The configuration for an attrmap instance.
+        """
+        return self._sequence_type
+
+    def __getstate__(self):
+        """
+        Serialize the object.
+        """
+        return (self.copy(), self._sequence_type, self._allow_invalid_attributes)
+
+    def __setstate__(self, state):
+        """
+        Deserialize the object.
+        """
+        mapping, sequence_type, allow_invalid_attributes = state
+        self.update(mapping)
+        self._setattr("_sequence_type", sequence_type)
+        self._setattr("_allow_invalid_attributes", allow_invalid_attributes)
+
+    def __repr__(self):
+        return six_u("AttrDict({contents})").format(
+            contents=super(AttrDict, self).__repr__()
+        )
+
+    @classmethod
+    def _constructor(cls, mapping, configuration):
+        """
+        A standardized constructor.
+        """
+        attr = cls(mapping)
+        attr._setattr("_sequence_type", configuration)
+
+        return attr
+
+
+# class AttrMap(MutableAttr):
+#     """
+#     An implementation of MutableAttr.
+#     """
+#     def __init__(self, items=None, sequence_type=tuple):
+#         if items is None:
+#             items = {}
+#         elif not isinstance(items, Mapping):
+#             items = dict(items)
+#
+#         self._setattr('_sequence_type', sequence_type)
+#         self._setattr('_mapping', items)
+#         self._setattr('_allow_invalid_attributes', False)
+#
+#     def _configuration(self):
+#         """
+#         The configuration for an attrmap instance.
+#         """
+#         return self._sequence_type
+#
+#     def __getitem__(self, key):
+#         """
+#         Access a value associated with a key.
+#         """
+#         return self._mapping[key]
+#
+#     def __setitem__(self, key, value):
+#         """
+#         Add a key-value pair to the instance.
+#         """
+#         self._mapping[key] = value
+#
+#     def __delitem__(self, key):
+#         """
+#         Delete a key-value pair
+#         """
+#         del self._mapping[key]
+#
+#     def __len__(self):
+#         """
+#         Check the length of the mapping.
+#         """
+#         return len(self._mapping)
+#
+#     def __iter__(self):
+#         """
+#         Iterated through the keys.
+#         """
+#         return iter(self._mapping)
+#
+#     def __repr__(self):
+#         """
+#         Return a string representation of the object.
+#         """
+#         # sequence type seems like more trouble than it is worth.
+#         # If people want full serialization, they can pickle, and in
+#         # 99% of cases, sequence_type won't change anyway
+#         return six_u("AttrMap({mapping})").format(mapping=repr(self._mapping))
+#
+#     def __getstate__(self):
+#         """
+#         Serialize the object.
+#         """
+#         return (
+#             self._mapping,
+#             self._sequence_type,
+#             self._allow_invalid_attributes
+#         )
+#
+#     def __setstate__(self, state):
+#         """
+#         Deserialize the object.
+#         """
+#         mapping, sequence_type, allow_invalid_attributes = state
+#         self._setattr('_mapping', mapping)
+#         self._setattr('_sequence_type', sequence_type)
+#         self._setattr('_allow_invalid_attributes', allow_invalid_attributes)
+#
+#     @classmethod
+#     def _constructor(cls, mapping, configuration):
+#         """
+#         A standardized constructor.
+#         """
+#         return cls(mapping, sequence_type=configuration)
+
+
+# class AttrDefault(MutableAttr):
+#     """
+#     An implementation of MutableAttr with defaultdict support
+#     """
+#     def __init__(self, default_factory=None, items=None, sequence_type=tuple,
+#                  pass_key=False):
+#         if items is None:
+#             items = {}
+#         elif not isinstance(items, Mapping):
+#             items = dict(items)
+#
+#         self._setattr('_default_factory', default_factory)
+#         self._setattr('_mapping', items)
+#         self._setattr('_sequence_type', sequence_type)
+#         self._setattr('_pass_key', pass_key)
+#         self._setattr('_allow_invalid_attributes', False)
+#
+#     def _configuration(self):
+#         """
+#         The configuration for a AttrDefault instance
+#         """
+#         return self._sequence_type, self._default_factory, self._pass_key
+#
+#     def __getitem__(self, key):
+#         """
+#         Access a value associated with a key.
+#
+#         Note: values returned will not be wrapped, even if recursive
+#         is True.
+#         """
+#         if key in self._mapping:
+#             return self._mapping[key]
+#         elif self._default_factory is not None:
+#             return self.__missing__(key)
+#
+#         raise KeyError(key)
+#
+#     def __setitem__(self, key, value):
+#         """
+#         Add a key-value pair to the instance.
+#         """
+#         self._mapping[key] = value
+#
+#     def __delitem__(self, key):
+#         """
+#         Delete a key-value pair
+#         """
+#         del self._mapping[key]
+#
+#     def __len__(self):
+#         """
+#         Check the length of the mapping.
+#         """
+#         return len(self._mapping)
+#
+#     def __iter__(self):
+#         """
+#         Iterated through the keys.
+#         """
+#         return iter(self._mapping)
+#
+#     def __missing__(self, key):
+#         """
+#         Add a missing element.
+#         """
+#         if self._pass_key:
+#             self[key] = value = self._default_factory(key)
+#         else:
+#             self[key] = value = self._default_factory()
+#
+#         return value
+#
+#     def __repr__(self):
+#         """
+#         Return a string representation of the object.
+#         """
+#         return six_u(
+#             "AttrDefault({default_factory}, {pass_key}, {mapping})"
+#         ).format(
+#             default_factory=repr(self._default_factory),
+#             pass_key=repr(self._pass_key),
+#             mapping=repr(self._mapping),
+#         )
+#
+#     def __getstate__(self):
+#         """
+#         Serialize the object.
+#         """
+#         return (
+#             self._default_factory,
+#             self._mapping,
+#             self._sequence_type,
+#             self._pass_key,
+#             self._allow_invalid_attributes,
+#         )
+#
+#     def __setstate__(self, state):
+#         """
+#         Deserialize the object.
+#         """
+#         (default_factory, mapping, sequence_type, pass_key,
+#          allow_invalid_attributes) = state
+#
+#         self._setattr('_default_factory', default_factory)
+#         self._setattr('_mapping', mapping)
+#         self._setattr('_sequence_type', sequence_type)
+#         self._setattr('_pass_key', pass_key)
+#         self._setattr('_allow_invalid_attributes', allow_invalid_attributes)
+#
+#     @classmethod
+#     def _constructor(cls, mapping, configuration):
+#         """
+#         A standardized constructor.
+#         """
+#         sequence_type, default_factory, pass_key = configuration
+#         return cls(default_factory, mapping, sequence_type=sequence_type,
+#                    pass_key=pass_key)

--- a/qbittorrentapi/app.py
+++ b/qbittorrentapi/app.py
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 class ApplicationPreferencesDictionary(Dictionary):
-    pass
+    """Response for :meth:`~AppAPIMixIn.app_preferences`"""
 
 
 class BuildInfoDictionary(Dictionary):
-    pass
+    """Response for :meth:`~AppAPIMixIn.app_build_info`"""
 
 
 @aliased
@@ -49,37 +49,45 @@ class Application(ClientCache):
 
     @property
     def version(self):
+        """Implements :meth:`~AppAPIMixIn.app_version`"""
         return self._client.app_version()
 
     @property
     def web_api_version(self):
+        """Implements :meth:`~AppAPIMixIn.app_web_api_version`"""
         return self._client.app_web_api_version()
 
     webapiVersion = web_api_version
 
     @property
     def build_info(self):
+        """Implements :meth:`~AppAPIMixIn.app_build_info`"""
         return self._client.app_build_info()
 
     buildInfo = build_info
 
     def shutdown(self):
+        """Implements :meth:`~AppAPIMixIn.app_shutdown`"""
         return self._client.app_shutdown()
 
     @property
     def preferences(self):
+        """Implements :meth:`~AppAPIMixIn.app_preferences` and :meth:`~AppAPIMixIn.app_set_preferences`"""
         return self._client.app_preferences()
 
     @preferences.setter
     def preferences(self, v):
+        """Implements :meth:`~AppAPIMixIn.app_set_preferences`"""
         self.set_preferences(prefs=v)
 
     @Alias("setPreferences")
     def set_preferences(self, prefs=None, **kwargs):
+        """Implements :meth:`~AppAPIMixIn.app_set_preferences`"""
         return self._client.app_set_preferences(prefs=prefs, **kwargs)
 
     @property
     def default_save_path(self, **kwargs):
+        """Implements :meth:`~AppAPIMixIn.app_default_save_path`"""
         return self._client.app_default_save_path(**kwargs)
 
     defaultSavePath = default_save_path
@@ -87,7 +95,15 @@ class Application(ClientCache):
 
 @aliased
 class AppAPIMixIn(Request):
-    """Implementation of all Application API methods"""
+    """
+    Implementation of all Application API methods
+
+    :Usage:
+        >>> from qbittorrentapi import Client
+        >>> client = Client(host='localhost:8080', username='admin', password='adminadmin')
+        >>> client.app_version()
+        >>> client.app_preferences()
+    """
 
     @property
     def app(self):
@@ -134,14 +150,15 @@ class AppAPIMixIn(Request):
         """
         Retrieve build info. (alias: app_buildInfo)
 
-        :return: Dictionary of build info. Each piece of info is an attribute.
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-build-info
+        :return: :class:`BuildInfoDictionary` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-build-info
         """
         return self._get(_name=APINames.Application, _method="buildInfo", **kwargs)
 
     @login_required
     def app_shutdown(self, **kwargs):
-        """Shutdown qBittorrent."""
+        """
+        Shutdown qBittorrent.
+        """
         self._post(_name=APINames.Application, _method="shutdown", **kwargs)
 
     @response_json(ApplicationPreferencesDictionary)
@@ -150,8 +167,7 @@ class AppAPIMixIn(Request):
         """
         Retrieve qBittorrent application preferences.
 
-        :return: Dictionary of preferences. Each preference is an attribute.
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-application-preferences
+        :return: :class:`ApplicationPreferencesDictionary` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-application-preferences
         """
         return self._get(_name=APINames.Application, _method="preferences", **kwargs)
 

--- a/qbittorrentapi/app.py
+++ b/qbittorrentapi/app.py
@@ -1,4 +1,4 @@
-import logging
+from logging import getLogger
 from json import dumps
 
 from qbittorrentapi.decorators import Alias
@@ -12,7 +12,7 @@ from qbittorrentapi.definitions import ClientCache
 from qbittorrentapi.definitions import Dictionary
 from qbittorrentapi.request import Request
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class ApplicationPreferencesDictionary(Dictionary):

--- a/qbittorrentapi/auth.py
+++ b/qbittorrentapi/auth.py
@@ -1,0 +1,123 @@
+import logging
+
+from qbittorrentapi.decorators import login_required
+from qbittorrentapi.definitions import APINames
+from qbittorrentapi.definitions import ClientCache
+from qbittorrentapi.exceptions import LoginFailed
+from qbittorrentapi.request import Request
+
+logger = logging.getLogger(__name__)
+
+
+class Authorization(ClientCache):
+    """
+    Allows interaction with the "Authorization" API endpoints.
+
+    :Usage:
+        >>> from qbittorrentapi import Client
+        >>> client = Client(host='localhost:8080', username='admin', password='adminadmin')
+        >>> client.auth.is_logged_in
+        >>> client.auth.log_in(username='admin', password='adminadmin')
+        >>> client.auth.log_out()
+    """
+
+    @property
+    def is_logged_in(self):
+        """Implements :meth:`~AuthAPIMixIn.is_logged_in`"""
+        return self._client.is_logged_in
+
+    def log_in(self, username=None, password=None):
+        """Implements :meth:`~AuthAPIMixIn.auth_log_in`"""
+        return self._client.auth_log_in(username=username, password=password)
+
+    def log_out(self):
+        """Implements :meth:`~AuthAPIMixIn.auth_log_out`"""
+        return self._client.auth_log_out()
+
+
+class AuthAPIMixIn(Request):
+    """
+    Implementation of all Authorization API methods.
+
+    :Usage:
+        >>> from qbittorrentapi import Client
+        >>> client = Client(host='localhost:8080', username='admin', password='adminadmin')
+        >>> client.auth_is_logged_in()
+        >>> client.auth_log_in(username='admin', password='adminadmin')
+        >>> client.auth_log_out()
+    """
+
+    @property
+    def auth(self):
+        """
+        Allows for transparent interaction with Authorization endpoints.
+
+        :return: Auth object
+        """
+        if self._authorization is None:
+            self._authorization = Authorization(client=self)
+        return self._authorization
+
+    authorization = auth
+
+    @property
+    def is_logged_in(self):
+        """
+        Returns True/False for whether a log-in attempt was ever successfully completed.
+
+        It isn't possible to know if qBittorrent will accept whatever SID is locally
+        cached...however, any request that is rejected because of the SID will be automatically
+        retried after a new SID is requested.
+
+        :returns: True/False for whether a log-in attempt was previously completed
+        """
+        return bool(self._SID)
+
+    def auth_log_in(self, username=None, password=None):
+        """
+        Log in to qBittorrent host.
+
+        :raises LoginFailed: if credentials failed to log in
+        :raises Forbidden403Error: if user user is banned...or not logged in
+
+        :param username: user name for qBittorrent client
+        :param password: password for qBittorrent client
+        :return: None
+        """
+        if username:
+            self.username = username or ""
+            self._password = password or ""
+
+        self._initialize_context()
+        self._post(
+            _name=APINames.Authorization,
+            _method="login",
+            data={"username": self.username, "password": self._password},
+        )
+
+        if not self.is_logged_in:
+            logger.debug('Login failed for user "%s"' % self.username)
+            raise self._suppress_context(
+                LoginFailed('Login authorization failed for user "%s"' % self.username)
+            )
+        else:
+            logger.debug('Login successful for user "%s"' % self.username)
+            logger.debug("SID: %s" % self._SID)
+
+    @property
+    def _SID(self):
+        """
+        Authorization cookie from qBittorrent.
+
+        :return: SID auth cookie from qBittorrent or None if one isn't already acquired
+        """
+        if self._requests_session:
+            return self._requests_session.cookies.get("SID", None)
+        return None
+
+    @login_required
+    def auth_log_out(self, **kwargs):
+        """
+        End session with qBittorrent.
+        """
+        self._get(_name=APINames.Authorization, _method="logout", **kwargs)

--- a/qbittorrentapi/auth.py
+++ b/qbittorrentapi/auth.py
@@ -73,7 +73,7 @@ class AuthAPIMixIn(Request):
         """
         return bool(self._SID)
 
-    def auth_log_in(self, username=None, password=None):
+    def auth_log_in(self, username=None, password=None, **kwargs):
         """
         Log in to qBittorrent host.
 
@@ -93,6 +93,7 @@ class AuthAPIMixIn(Request):
             _name=APINames.Authorization,
             _method="login",
             data={"username": self.username, "password": self._password},
+            **kwargs
         )
 
         if not self.is_logged_in:

--- a/qbittorrentapi/auth.py
+++ b/qbittorrentapi/auth.py
@@ -1,4 +1,4 @@
-import logging
+from logging import getLogger
 
 from qbittorrentapi.decorators import login_required
 from qbittorrentapi.definitions import APINames
@@ -6,7 +6,7 @@ from qbittorrentapi.definitions import ClientCache
 from qbittorrentapi.exceptions import LoginFailed
 from qbittorrentapi.request import Request
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class Authorization(ClientCache):

--- a/qbittorrentapi/client.py
+++ b/qbittorrentapi/client.py
@@ -1,4 +1,5 @@
 from qbittorrentapi.app import AppAPIMixIn
+from qbittorrentapi.auth import AuthAPIMixIn
 from qbittorrentapi.log import LogAPIMixIn
 from qbittorrentapi.sync import SyncAPIMixIn
 from qbittorrentapi.transfer import TransferAPIMixIn
@@ -43,6 +44,7 @@ from qbittorrentapi.search import SearchAPIMixIn
 
 class Client(
     AppAPIMixIn,
+    AuthAPIMixIn,
     LogAPIMixIn,
     SyncAPIMixIn,
     TransferAPIMixIn,
@@ -55,8 +57,13 @@ class Client(
     Initialize API for qBittorrent client.
 
     Host must be specified. Username and password can be specified at login.
-    A call to auth_log_in is not explicitly required if username and password are
-    provided during Client construction.
+    A call to :meth:`~qbittorrentapi.auth.AuthAPIMixIn.auth_log_in` is not explicitly
+    required if username and password are provided during Client construction.
+
+    :Usage:
+        >>> from qbittorrentapi import Client
+        >>> client = Client(host='localhost:8080', username='admin', password='adminadmin')
+        >>> torrents = client.torrents_info()
 
     :param host: hostname for qBittorrent Web API (e.g. [http[s]://]localhost[:8080])
     :param port: port number for qBittorrent Web API (note: only used if host does not contain a port)

--- a/qbittorrentapi/decorators.py
+++ b/qbittorrentapi/decorators.py
@@ -1,4 +1,4 @@
-import logging
+from logging import getLogger
 from functools import wraps
 from json import loads
 from pkg_resources import parse_version
@@ -6,7 +6,7 @@ from pkg_resources import parse_version
 from qbittorrentapi.exceptions import APIError
 from qbittorrentapi.exceptions import HTTP403Error
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def _is_version_less_than(ver1, ver2, lteq=True):

--- a/qbittorrentapi/definitions.py
+++ b/qbittorrentapi/definitions.py
@@ -10,7 +10,7 @@ from attrdict import AttrDict
 
 class APINames(Enum):
     """
-    API names for API endpoints
+    API namespaces for API endpoints
 
     e.g 'torrents' in http://localhost:8080/api/v2/torrents/addTrackers
     """

--- a/qbittorrentapi/definitions.py
+++ b/qbittorrentapi/definitions.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from UserList import UserList
 
-from attrdict import AttrDict
+from qbittorrentapi._attrdict import AttrDict
 
 
 class APINames(Enum):

--- a/qbittorrentapi/log.py
+++ b/qbittorrentapi/log.py
@@ -7,6 +7,8 @@ from qbittorrentapi.request import Request
 
 
 class LogPeersList(List):
+    """Response for :meth:`~LogAPIMixIn.log_peers`"""
+
     def __init__(self, list_entries=None, client=None):
         super(LogPeersList, self).__init__(
             list_entries, entry_class=LogPeer, client=client
@@ -14,10 +16,12 @@ class LogPeersList(List):
 
 
 class LogPeer(ListEntry):
-    pass
+    """Item in :class:`LogPeersList`"""
 
 
 class LogMainList(List):
+    """Response to :meth:`~LogAPIMixIn.log_main`"""
+
     def __init__(self, list_entries=None, client=None):
         super(LogMainList, self).__init__(
             list_entries, entry_class=LogEntry, client=client
@@ -25,7 +29,7 @@ class LogMainList(List):
 
 
 class LogEntry(ListEntry):
-    pass
+    """Item in :class:`LogMainList`"""
 
 
 class Log(ClientCache):
@@ -49,6 +53,7 @@ class Log(ClientCache):
         self.main = Log._Main(client=client)
 
     def peers(self, last_known_id=None, **kwargs):
+        """Implements :meth:`~LogAPIMixIn.log_peers`"""
         return self._client.log_peers(last_known_id=last_known_id, **kwargs)
 
     class _Main(ClientCache):
@@ -110,7 +115,15 @@ class Log(ClientCache):
 
 
 class LogAPIMixIn(Request):
-    """Implementation of all Log API methods."""
+    """
+    Implementation of all Log API methods.
+
+    :Usage:
+        >>> from qbittorrentapi import Client
+        >>> client = Client(host='localhost:8080', username='admin', password='adminadmin')
+        >>> client.log_main(info=False)
+        >>> client.log_peers()
+    """
 
     @property
     def log(self):
@@ -143,7 +156,7 @@ class LogAPIMixIn(Request):
         :param warning: False to exclude 'warning' entries
         :param critical: False to exclude 'critical' entries
         :param last_known_id: only entries with an ID greater than this value will be returned
-        :return: List of log entries.
+        :return: :class:`LogMainList`
         """
         parameters = {
             "normal": normal,
@@ -163,7 +176,7 @@ class LogAPIMixIn(Request):
         Retrieve qBittorrent peer log.
 
         :param last_known_id: only entries with an ID greater than this value will be returned
-        :return: list of log entries in a List
+        :return: :class:`LogPeersList`
         """
         parameters = {"last_known_id": last_known_id}
         return self._get(

--- a/qbittorrentapi/request.py
+++ b/qbittorrentapi/request.py
@@ -1,21 +1,26 @@
+from logging import getLogger
+from logging import NullHandler
 from os import environ
-import logging
 from pkg_resources import parse_version
 from time import sleep
-from urllib3 import disable_warnings
-from urllib3.exceptions import InsecureRequestWarning
-from urllib3.util.retry import Retry
 
 try:  # python 3
     from collections.abc import Iterable
-    from urllib.parse import urlparse, urljoin
+    from urllib.parse import urljoin
+    from urllib.parse import urlparse
 except ImportError:  # python 2
     from collections import Iterable
-    from urlparse import urlparse, urljoin
+    from urlparse import urljoin
+    from urlparse import urlparse
 
-import requests
+from requests import exceptions as requests_exceptions
+from requests import head as requests_head
+from requests import Session
 from requests.adapters import HTTPAdapter
-import six
+from six import string_types as six_string_types
+from urllib3 import disable_warnings
+from urllib3.exceptions import InsecureRequestWarning
+from urllib3.util.retry import Retry
 
 from qbittorrentapi.definitions import APINames
 from qbittorrentapi.exceptions import APIConnectionError
@@ -30,7 +35,8 @@ from qbittorrentapi.exceptions import Conflict409Error
 from qbittorrentapi.exceptions import UnsupportedMediaType415Error
 from qbittorrentapi.exceptions import InternalServerError500Error
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
+getLogger("qbittorrentapi").addHandler(NullHandler())
 
 
 class HelpersMixIn(object):
@@ -47,7 +53,7 @@ class HelpersMixIn(object):
         :param delimiter: delimiter for concatenation
         :return: if input is a list, concatenated string...else whatever the input was
         """
-        if not isinstance(input_list, six.string_types) and isinstance(
+        if not isinstance(input_list, six_string_types) and isinstance(
             input_list, Iterable
         ):
             return delimiter.join(map(str, input_list))
@@ -97,15 +103,32 @@ class Request(HelpersMixIn):
         self.username = username or ""
         self._password = password or ""
 
+        self._initialize_context()
+        self._initialize_lesser(**kwargs)
+
+        # turn off console-printed warnings about SSL certificate issues.
+        # these errors are only shown once the user has explicitly allowed
+        # untrusted certs via VERIFY_WEBUI_CERTIFICATE...so printing them
+        # in a console isn't particularly useful.
+        if not self._VERIFY_WEBUI_CERTIFICATE:
+            disable_warnings(InsecureRequestWarning)
+
+    def _initialize_context(self):
+        """
+        Initialize and/or reset communications context with qBittorrent.
+        This is necessary on startup or when the auth cookie needs to be replaced...perhaps
+        because it expired, qBittorrent was restarted, significant settings changes, etc.
+        """
         # base path for all API endpoints
         self._API_BASE_PATH = "api/v2"
 
-        # state, context, and caching variables
-        #   These variables are deleted if the connection to qBittorrent
-        #   is reset or a new login is required.
-        #   All of these should be reset in _initialize_connection().
-        self._requests_session = None
+        # reset URL so the full URL is derived again (primarily allows for switching scheme for WebUI: HTTP <-> HTTPS)
         self._API_BASE_URL = None
+
+        # reset Requests session so it is rebuilt with new auth cookie and all
+        self._requests_session = None
+
+        # reinitialize interaction layers
         self._application = None
         self._authorization = None
         self._transfer = None
@@ -117,31 +140,34 @@ class Request(HelpersMixIn):
         self._rss = None
         self._search = None
 
-        self._initialize_lesser(kwargs)
-
-        if not self._VERIFY_WEBUI_CERTIFICATE:
-            disable_warnings(InsecureRequestWarning)
-
-    def _initialize_lesser(self, kwargs):
+    def _initialize_lesser(
+        self,
+        EXTRA_HEADERS=None,
+        VERIFY_WEBUI_CERTIFICATE=True,
+        RAISE_UNIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS=False,
+        RAISE_NOTIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS=False,
+        VERBOSE_RESPONSE_LOGGING=False,
+        PRINT_STACK_FOR_EACH_REQUEST=False,
+        SIMPLE_RESPONSES=False,
+        DISABLE_LOGGING_DEBUG_OUTPUT=False,
+        MOCK_WEB_API_VERSION=None,
+    ):
         """Initialize lessor used configuration"""
 
-        # Configuration variables
-        self._VERIFY_WEBUI_CERTIFICATE = kwargs.pop("VERIFY_WEBUI_CERTIFICATE", True)
-        self._RAISE_UNIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS = kwargs.pop(
-            "RAISE_UNIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS",
-            kwargs.pop(
-                "RAISE_NOTIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS", False
-            ),
+        # Configuration parameters
+        self._EXTRA_HEADERS = EXTRA_HEADERS if isinstance(EXTRA_HEADERS, dict) else {}
+        self._VERIFY_WEBUI_CERTIFICATE = bool(VERIFY_WEBUI_CERTIFICATE)
+        self._VERBOSE_RESPONSE_LOGGING = bool(VERBOSE_RESPONSE_LOGGING)
+        self._PRINT_STACK_FOR_EACH_REQUEST = bool(PRINT_STACK_FOR_EACH_REQUEST)
+        self._SIMPLE_RESPONSES = bool(SIMPLE_RESPONSES)
+        self._RAISE_UNIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS = bool(
+            RAISE_UNIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS
+            or RAISE_NOTIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS
         )
-        self._VERBOSE_RESPONSE_LOGGING = kwargs.pop("VERBOSE_RESPONSE_LOGGING", False)
-        self._PRINT_STACK_FOR_EACH_REQUEST = kwargs.pop(
-            "PRINT_STACK_FOR_EACH_REQUEST", False
-        )
-        self._SIMPLE_RESPONSES = kwargs.pop("SIMPLE_RESPONSES", False)
-        if kwargs.pop("DISABLE_LOGGING_DEBUG_OUTPUT", False):
-            logging.getLogger("qbittorrentapi").setLevel(logging.INFO)
-            logging.getLogger("requests").setLevel(logging.INFO)
-            logging.getLogger("urllib3").setLevel(logging.INFO)
+        if bool(DISABLE_LOGGING_DEBUG_OUTPUT):
+            for logger_ in ("qbittorrentapi", "requests", "urllib3"):
+                if getLogger(logger_).level < 20:
+                    getLogger(logger_).setLevel("INFO")
 
         # Environment variables have lowest priority
         if self.host == "" and environ.get("PYTHON_QBITTORRENTAPI_HOST") is not None:
@@ -173,91 +199,73 @@ class Request(HelpersMixIn):
             self._VERIFY_WEBUI_CERTIFICATE = False
 
         # Mocking variables until better unit testing exists
-        self._MOCK_WEB_API_VERSION = kwargs.pop("MOCK_WEB_API_VERSION", None)
-        # turn off console-printed warnings about SSL certificate issues (e.g. untrusted since it is self-signed)
-
-    def _initialize_context(self):
-        """
-        Reset communications context with qBittorrent.
-        This is necessary when the auth cookie needs to be replaced...perhaps because
-        it expired, qBittorrent was restarted, significant settings changes, etc.
-        """
-        # reset URL so the full URL is derived again (primarily allows for switching scheme for WebUI: HTTP <-> HTTPS)
-        self._API_BASE_URL = None
-
-        # reset Requests session so it is rebuilt with new auth cookie and all
-        self._requests_session = None
-
-        # reinitialize interaction layers
-        self._application = None
-        self._authorization = None
-        self._transfer = None
-        self._torrents = None
-        self._torrent_categories = None
-        self._torrent_tags = None
-        self._log = None
-        self._sync = None
-        self._rss = None
-        self._search = None
+        self._MOCK_WEB_API_VERSION = MOCK_WEB_API_VERSION
 
     def _get(self, _name=APINames.EMPTY, _method="", **kwargs):
-        return self._request_wrapper(
+        return self._request_manager(
             http_method="get", api_namespace=_name, api_method=_method, **kwargs
         )
 
     def _post(self, _name=APINames.EMPTY, _method="", **kwargs):
-        return self._request_wrapper(
+        return self._request_manager(
             http_method="post", api_namespace=_name, api_method=_method, **kwargs
         )
 
-    def _request_wrapper(self, _retries=2, _retry_backoff_factor=0.3, **kwargs):
+    def _request_manager(self, _retries=2, _retry_backoff_factor=0.3, **kwargs):
         """
-        Wrapper to manage requests retries.
+        Wrapper to manage request retries and severe exceptions.
 
         This should retry at least twice to account for the Web API switching from HTTP to HTTPS.
         During the second attempt, the URL is rebuilt using HTTP or HTTPS as appropriate.
         """
+
+        def build_error_msg(exc):
+            """Create error message for exception to be raised to user."""
+            error_prologue = "Failed to connect to qBittorrent. "
+            error_messages = {
+                requests_exceptions.SSLError: "This is likely due to using an untrusted certificate "
+                "(likely self-signed) for HTTPS qBittorrent WebUI. To suppress this error (and skip "
+                "certificate verification consequently exposing the HTTPS connection to man-in-the-middle "
+                "attacks), set VERIFY_WEBUI_CERTIFICATE=False when instantiating Client or set "
+                "environment variable PYTHON_QBITTORRENTAPI_DO_NOT_VERIFY_WEBUI_CERTIFICATE "
+                "to a non-null value. SSL Error: %s" % repr(exc),
+                requests_exceptions.HTTPError: "Invalid HTTP Response: %s" % repr(exc),
+                requests_exceptions.TooManyRedirects: "Too many redirects: %s"
+                % repr(exc),
+                requests_exceptions.ConnectionError: "Connection Error: %s" % repr(exc),
+                requests_exceptions.Timeout: "Timeout Error: %s" % repr(exc),
+                requests_exceptions.RequestException: "Requests Error: %s" % repr(exc),
+            }
+            err_msg = error_messages.get(type(exc), "Unknown Error: %s" % repr(exc))
+            err_msg = error_prologue + err_msg
+            logger.debug(err_msg)
+            return err_msg
+
+        def retry_backoff(retry_count):
+            """Back off on attempting each subsequent request retry."""
+            if retry_count > 0:
+                # The first retry is always immediate. if the backoff factor is 0.3,
+                # then will sleep for 0s then .3s, then .6s, etc. between retries.
+                backoff_time = _retry_backoff_factor * (2 ** ((retry_count + 1) - 1))
+                sleep(backoff_time if backoff_time <= 10 else 10)
+            logger.debug("Retry attempt %d" % (retry_count + 1))
+
         max_retries = _retries if _retries > 1 else 2
         for retry in range(0, (max_retries + 1)):
             try:
                 return self._request(**kwargs)
             except HTTPError as e:
-                # retry the request for HTTP 500 statuses, raise immediately for everything else (e.g. 4XX statuses)
+                # retry the request for HTTP 500 statuses;
+                # raise immediately for other HTTP errors (e.g. 4XX statuses)
                 if not isinstance(e, HTTP5XXError) or retry >= max_retries:
                     raise
             except Exception as e:
                 if retry >= max_retries:
-                    error_prologue = "Failed to connect to qBittorrent. "
-                    error_messages = {
-                        requests.exceptions.SSLError: "This is likely due to using an untrusted certificate "
-                        "(likely self-signed) for HTTPS qBittorrent WebUI. To suppress this error (and skip "
-                        "certificate verification consequently exposing the HTTPS connection to man-in-the-middle "
-                        "attacks), set VERIFY_WEBUI_CERTIFICATE=False when instantiating Client or set "
-                        "environment variable PYTHON_QBITTORRENTAPI_DO_NOT_VERIFY_WEBUI_CERTIFICATE "
-                        "to a non-null value. SSL Error: %s" % repr(e),
-                        requests.exceptions.HTTPError: "Invalid HTTP Response: %s"
-                        % repr(e),
-                        requests.exceptions.TooManyRedirects: "Too many redirects: %s"
-                        % repr(e),
-                        requests.exceptions.ConnectionError: "Connection Error: %s"
-                        % repr(e),
-                        requests.exceptions.Timeout: "Timeout Error: %s" % repr(e),
-                        requests.exceptions.RequestException: "Requests Error: %s"
-                        % repr(e),
-                    }
-                    error_message = error_prologue + error_messages.get(
-                        type(e), "Unknown Error: %s" % repr(e)
-                    )
-                    logger.debug(error_message)
+                    error_message = build_error_msg(exc=e)
                     response = getattr(e, "response", None)
                     raise APIConnectionError(error_message, response=response)
 
-            # back off on attempting each subsequent retry. first retry is always immediate.
-            # if the backoff factor is 0.1, then sleep() will sleep for [0.0s, 0.2s, 0.4s, 0.8s, ...] between retries.
-            if retry > 0:
-                backoff_time = _retry_backoff_factor * (2 ** ((retry + 1) - 1))
-                sleep(backoff_time if backoff_time < 30 else 30)
-            logger.debug("Retry attempt %d" % (retry + 1))
+            retry_backoff(retry_count=retry)
             self._initialize_context()
 
     def _request(self, http_method, api_namespace, api_method, **kwargs):
@@ -272,7 +280,7 @@ class Request(HelpersMixIn):
         """
         url = self._build_url(api_namespace=api_namespace, api_method=api_method)
         kwargs = self._trim_known_kwargs(kwargs=kwargs)
-        params = self._normalize_requests_params(http_method=http_method, kwargs=kwargs)
+        params = self._normalize_requests_params(http_method=http_method, **kwargs)
 
         response = self._session.request(method=http_method, url=url, **params)
 
@@ -320,56 +328,68 @@ class Request(HelpersMixIn):
     def _build_base_url(base_url=None, host="", port=None):
         """
         Determine the Base URL for the Web API endpoints.
-        If the user doesn't provide a scheme for the URL, it will try HTTP first and fall back to
-        HTTPS if that doesn't work. While this is probably backwards, qBittorrent or an intervening
-        proxy can simply redirect to HTTPS and that'll be respected.
-        Additionally, if users want to augment the path to the API endpoints, any path provided here
-        will be preserved in the returned Base URL and prefixed to all subsequent API calls.
+
+        A URL is only actually built here if it's the first time here or
+        the context was re-initialized. Otherwise, the most recently
+        built URL is used.
+
+        If the user doesn't provide a scheme for the URL, it will try HTTP
+        first and fall back to HTTPS if that doesn't work. While this is
+        probably backwards, qBittorrent or an intervening proxy can simply
+        redirect to HTTPS and that'll be respected.
+
+        Additionally, if users want to augment the path to the API endpoints,
+        any path provided here will be preserved in the returned Base URL
+        and prefixed to all subsequent API calls.
 
         :param base_url: if the URL was already built, this is the base URL
         :param host: user provided hostname for WebUI
         :return: base URL for Web API endpoint
         """
-        # build full URL if the base URL isn't currently known.
-        # it will not be known when it's the first time we're here...or if the context was re-initialized.
-        if base_url is None:
-            # urlparse requires some sort of schema for parsing to work at all
-            if not host.lower().startswith(("http:", "https:", "//")):
-                host = "//" + host
-            base_url = urlparse(url=host)
-            logger.debug("Parsed user URL: %s" % repr(base_url))
-            # default to HTTP if user didn't specify
-            base_url = (
-                base_url._replace(scheme="http") if not base_url.scheme else base_url
+        if base_url is not None:
+            return base_url
+
+        # urlparse requires some sort of schema for parsing to work at all
+        if not host.lower().startswith(("http:", "https:", "//")):
+            host = "//" + host
+        base_url = urlparse(url=host)
+        logger.debug("Parsed user URL: %s" % repr(base_url))
+        # default to HTTP if user didn't specify
+        user_scheme = base_url.scheme
+        base_url = base_url._replace(scheme="http") if not user_scheme else base_url
+        alt_scheme = "https" if base_url.scheme == "http" else "http"
+        # add port number if host doesn't contain one
+        if port is not None and not isinstance(base_url.port, int):
+            base_url = base_url._replace(netloc="%s:%s" % (base_url.netloc, port))
+
+        # detect whether Web API is configured for HTTP or HTTPS
+        logger.debug("Detecting scheme for URL...")
+        try:
+            # skip verification here...if there's a problem, we'll catch it during the actual API call
+            r = requests_head(base_url.geturl(), allow_redirects=True, verify=False)
+            # if WebUI eventually supports sending a redirect from HTTP to HTTPS then
+            # Requests will automatically provide a URL using HTTPS.
+            # For instance, the URL returned below will use the HTTPS scheme.
+            #  >>> requests.head('http://grc.com', allow_redirects=True).url
+            scheme = urlparse(r.url).scheme
+        except requests_exceptions.RequestException:
+            # assume alternative scheme will work...we'll fail later if neither are working
+            scheme = alt_scheme
+
+        # use detected scheme
+        logger.debug("Using %s scheme" % scheme.upper())
+        base_url = base_url._replace(scheme=scheme)
+        if user_scheme and user_scheme != scheme:
+            logger.warning(
+                "Using '%s' instead of requested '%s' to communicate with qBittorrent"
+                % (scheme, user_scheme)
             )
-            alt_scheme = "https" if base_url.scheme == "http" else "http"
-            # add port number if host doesn't contain one
-            if port is not None and not isinstance(base_url.port, int):
-                base_url = base_url._replace(netloc="%s:%s" % (base_url.netloc, port))
 
-            # detect whether Web API is configured for HTTP or HTTPS
-            logger.debug("Detecting scheme for URL...")
-            try:
-                # skip verification here...if there's a problem, we'll catch it during the actual API call
-                r = requests.head(base_url.geturl(), allow_redirects=True, verify=False)
-                # if WebUI eventually supports sending a redirect from HTTP to HTTPS then
-                # Requests will automatically provide a URL using HTTPS.
-                # For instance, the URL returned below will use the HTTPS scheme.
-                #  >>> requests.head('http://grc.com', allow_redirects=True).url
-                scheme = urlparse(r.url).scheme
-            except requests.exceptions.RequestException:
-                # assume alternative scheme will work...we'll fail later if neither are working
-                scheme = alt_scheme
-
-            # use detected scheme
-            logger.debug("Using %s scheme" % scheme.upper())
-            base_url = base_url._replace(scheme=scheme)
-
-            # ensure URL always ends with a forward-slash
-            base_url = base_url.geturl()
-            if not base_url.endswith("/"):
-                base_url = base_url + "/"
-            logger.debug("Base URL: %s" % base_url)
+        # ensure URL always ends with a forward-slash
+        base_url = base_url.geturl()
+        if not base_url.endswith("/"):
+            base_url = base_url + "/"
+        logger.debug("Base URL: %s" % base_url)
 
         return base_url
 
@@ -387,12 +407,14 @@ class Request(HelpersMixIn):
         """
 
         def sanitize(piece):
-            """Ensure each piece of api path is a string without slashes"""
+            """Ensure each piece of api path is a string without leading or trailing slashes"""
             return str(piece or "").strip("/")
 
         if isinstance(api_namespace, APINames):
             api_namespace = api_namespace.value
         api_path = "/".join(map(sanitize, (api_base_path, api_namespace, api_method)))
+        # since base_url is guaranteed to end in a slash and api_path will never
+        # start with a slash, this join only ever append to the path in base_url
         url = urljoin(base_url, api_path)
         return url
 
@@ -403,51 +425,79 @@ class Request(HelpersMixIn):
 
         :return: Requests Session object
         """
-        if not self._requests_session:
-            self._requests_session = requests.Session()
+        if self._requests_session:
+            return self._requests_session
 
-            # default headers to prevent qBittorrent throwing any alarms
-            self._requests_session.headers.update({"Referer": self._API_BASE_URL})
-            self._requests_session.headers.update({"Origin": self._API_BASE_URL})
+        self._requests_session = Session()
 
-            # enable/disable TLS verification for all requests
-            self._requests_session.verify = self._VERIFY_WEBUI_CERTIFICATE
+        # default headers to prevent qBittorrent throwing any alarms
+        self._requests_session.headers.update(
+            {"Referer": self._API_BASE_URL, "Origin": self._API_BASE_URL}
+        )
 
-            # enable retries in Requests if HTTP call fails
-            retries = 2
-            backoff_factor = 0.1
-            retry = Retry(
-                total=retries,
-                read=retries,
-                connect=retries,
-                backoff_factor=backoff_factor,
-                status_forcelist=(500, 502, 504),
-                raise_on_status=False,
-            )
-            adapter = HTTPAdapter(max_retries=retry)
-            self._requests_session.mount("http://", adapter)
-            self._requests_session.mount("https://", adapter)
+        # add any user-defined headers to be sent in all requests
+        self._requests_session.headers.update(self._EXTRA_HEADERS)
+
+        # enable/disable TLS verification for all requests
+        self._requests_session.verify = self._VERIFY_WEBUI_CERTIFICATE
+
+        # enable retries in Requests if HTTP call fails.
+        # this is sorta doubling up on retries since request_manager() will
+        # attempt retries as well. however, these retries will not delay.
+        # so, if the problem is just a network blip then Requests will
+        # automatically retry (with zero delay) and probably fix the issue
+        # without coming all the way back to requests_wrapper. if this retries
+        # is increased much above 1, and backoff_factor is non-zero, this
+        # will start adding noticeable delays in these retry attempts...which
+        # would then compound with similar delay logic in request_manager.
+        # at any rate, the retries count in request_manager should always be
+        # at least 2 to accommodate significant settings changes in qBittorrent
+        # such as enabling HTTPs in Web UI settings.
+        retries = 1
+        retry = Retry(
+            total=retries,
+            read=retries,
+            connect=retries,
+            status_forcelist={500, 502, 504},
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self._requests_session.mount("http://", adapter)
+        self._requests_session.mount("https://", adapter)
 
         return self._requests_session
 
     @staticmethod
-    def _normalize_requests_params(http_method, kwargs):
+    def _normalize_requests_params(
+        http_method,
+        headers=None,
+        data=None,
+        params=None,
+        files=None,
+        requests_params=None,
+        **kwargs
+    ):
         """
         Extract several keyword arguments to send in the request.
 
+        :param headers: additional headers to send with the request
+        :param data: key/value pairs to send as body
+        :param params: key/value pairs to send as query parameters
+        :param files: key/value pairs to include as multipart POST requests
+        :param requests_params: keyword arguments for call to Requests
         :return: dictionary of parameters for Requests call
         """
         # these are completely user defined and intended to allow users
         # of this client to control the behavior of Requests
-        requests_params = kwargs.pop("requests_params", {})
+        requests_params = requests_params or {}
 
         # these are expected to be populated by this client as necessary for qBittorrent
-        data = kwargs.pop("data", {})
-        params = kwargs.pop("params", {})
-        files = kwargs.pop("files", {})
+        data = data or {}
+        params = params or {}
+        files = files or {}
 
         # these are user-defined headers to include with the request
-        headers = kwargs.pop("headers", {})
+        headers = headers or {}
         # send Content-Length as 0 for empty POSTs...Requests will not send Content-Length
         # if data is empty but qBittorrent may complain otherwise
         if http_method == "post" and not any(filter(None, data.values())):
@@ -538,6 +588,7 @@ class Request(HelpersMixIn):
                 max_text_length_to_log = 10000
 
             resp_logger("Request URL: (%s) %s" % (http_method.upper(), response.url))
+            resp_logger("Request Headers: %s" % response.request.headers)
             if (
                 str(response.request.body) not in ("None", "")
                 and "auth/login" not in url

--- a/qbittorrentapi/request.py
+++ b/qbittorrentapi/request.py
@@ -545,7 +545,7 @@ class Request(HelpersMixIn):
             # API method doesn't exist or more likely, torrent not found
             # APIErrorType::NotFound
             error_message = response.text
-            if error_message == "":
+            if error_message in ("", "Not Found"):
                 error_torrent_hash = ""
                 if params["data"]:
                     error_torrent_hash = params["data"].get("hash", error_torrent_hash)

--- a/qbittorrentapi/rss.py
+++ b/qbittorrentapi/rss.py
@@ -12,11 +12,11 @@ from qbittorrentapi.request import Request
 
 
 class RSSitemsDictionary(Dictionary):
-    pass
+    """Response for :meth:`~RSSAPIMixIn.rss_items`"""
 
 
 class RSSRulesDictionary(Dictionary):
-    pass
+    """Response for :meth:`~RSSAPIMixIn.rss_rules`"""
 
 
 @aliased
@@ -34,8 +34,8 @@ class RSS(ClientCache):
         >>> client.rss.addFeed(url='...', item_path="TPB\\Top100")
         >>> client.rss.remove_item(item_path="TPB") # deletes TPB and Top100
         >>> client.rss.set_rule(rule_name="...", rule_def={...})
-        >>> client.rss.items.with_data
-        >>> client.rss.items.without_data
+        >>> items = client.rss.items.with_data
+        >>> items = client.rss.items.without_data
     """
 
     def __init__(self, client):
@@ -44,54 +44,65 @@ class RSS(ClientCache):
 
     @Alias("addFolder")
     def add_folder(self, folder_path=None, **kwargs):
+        """Implements :meth:`~RSSAPIMixIn.rss_add_folder`"""
         return self._client.rss_add_folder(folder_path=folder_path, **kwargs)
 
     @Alias("addFeed")
     def add_feed(self, url=None, item_path=None, **kwargs):
+        """Implements :meth:`~RSSAPIMixIn.rss_add_feed`"""
         return self._client.rss_add_feed(url=url, item_path=item_path, **kwargs)
 
     @Alias("removeItem")
     def remove_item(self, item_path=None, **kwargs):
+        """Implements :meth:`~RSSAPIMixIn.rss_remove_item`"""
         return self._client.rss_remove_item(item_path=item_path, **kwargs)
 
     @Alias("moveItem")
     def move_item(self, orig_item_path=None, new_item_path=None, **kwargs):
+        """Implements :meth:`~RSSAPIMixIn.rss_move_item`"""
         return self._client.rss_move_item(
             orig_item_path=orig_item_path, new_item_path=new_item_path, **kwargs
         )
 
     @Alias("refreshItem")
     def refresh_item(self, item_path=None):
+        """Implements :meth:`~RSSAPIMixIn.rss_refresh_item`"""
         return self._client.rss_refresh_item(item_path=item_path)
 
     @Alias("markAsRead")
     def mark_as_read(self, item_path=None, article_id=None, **kwargs):
+        """Implements :meth:`~RSSAPIMixIn.rss_mark_as_read`"""
         return self._client.rss_mark_as_read(
             item_path=item_path, article_id=article_id, **kwargs
         )
 
     @Alias("setRule")
     def set_rule(self, rule_name=None, rule_def=None, **kwargs):
+        """Implements :meth:`~RSSAPIMixIn.rss_set_rule`"""
         return self._client.rss_set_rule(
             rule_name=rule_name, rule_def=rule_def, **kwargs
         )
 
     @Alias("renameRule")
     def rename_rule(self, orig_rule_name=None, new_rule_name=None, **kwargs):
+        """Implements :meth:`~RSSAPIMixIn.rss_rename_rule`"""
         return self._client.rss_rename_rule(
             orig_rule_name=orig_rule_name, new_rule_name=new_rule_name, **kwargs
         )
 
     @Alias("removeRule")
     def remove_rule(self, rule_name=None, **kwargs):
+        """Implements :meth:`~RSSAPIMixIn.rss_remove_rule`"""
         return self._client.rss_remove_rule(rule_name=rule_name, **kwargs)
 
     @property
     def rules(self):
+        """Implements :meth:`~RSSAPIMixIn.rss_rules`"""
         return self._client.rss_rules()
 
     @Alias("matchingArticles")
     def matching_articles(self, rule_name=None, **kwargs):
+        """Implements :meth:`~RSSAPIMixIn.rss_matching_articles`"""
         return self._client.rss_matching_articles(rule_name=rule_name, **kwargs)
 
     class _Items(ClientCache):
@@ -109,7 +120,15 @@ class RSS(ClientCache):
 
 @aliased
 class RSSAPIMixIn(Request):
-    """Implementation of all RSS API methods."""
+    """
+    Implementation of all RSS API methods.
+
+    :Usage:
+        >>> from qbittorrentapi import Client
+        >>> client = Client(host='localhost:8080', username='admin', password='adminadmin')
+        >>> rss_rules = client.rss_rules()
+        >>> client.rss_set_rule(rule_name="...", rule_def={...})
+    """
 
     @property
     def rss(self):
@@ -190,7 +209,7 @@ class RSSAPIMixIn(Request):
         Retrieve RSS items and optionally feed data.
 
         :param include_feed_data: True or false to include feed data
-        :return: dictionary of RSS items
+        :return: :class:`RSSitemsDictionary`
         """
         params = {"withData": include_feed_data}
         return self._get(_name=APINames.RSS, _method="items", params=params, **kwargs)
@@ -233,8 +252,7 @@ class RSSAPIMixIn(Request):
         Create a new RSS auto-downloading rule. (alias: rss_setRule)
 
         :param rule_name: name for new rule
-        :param rule_def: dictionary with rule fields
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-auto-downloading-rule
+        :param rule_def: dictionary with rule fields - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-auto-downloading-rule
         :return: None
         """
         data = {"ruleName": rule_name, "ruleDef": dumps(rule_def)}
@@ -272,7 +290,7 @@ class RSSAPIMixIn(Request):
         """
         Retrieve RSS auto-download rule definitions.
 
-        :return: None
+        :return: :class:`RSSRulesDictionary`
         """
         return self._get(_name=APINames.RSS, _method="rules", **kwargs)
 
@@ -285,7 +303,7 @@ class RSSAPIMixIn(Request):
         Fetch all articles matching a rule. (alias: rss_matchingArticles)
 
         :param rule_name: Name of rule to return matching articles
-        :return: RSSitemsDictionary of articles
+        :return: :class:`RSSitemsDictionary`
         """
         data = {"ruleName": rule_name}
         return self._post(

--- a/qbittorrentapi/search.py
+++ b/qbittorrentapi/search.py
@@ -13,30 +13,38 @@ from qbittorrentapi.request import Request
 
 
 class SearchJobDictionary(Dictionary):
+    """Response for :meth:`~SearchAPIMixIn.search_start`"""
+
     def __init__(self, data, client):
         self._search_job_id = data.get("id", None)
         super(SearchJobDictionary, self).__init__(data=data, client=client)
 
     def stop(self, **kwargs):
-        return self._client.search.stop(search_id=self._search_job_id, **kwargs)
+        """Implements :meth:`~SearchAPIMixIn.search_stop`"""
+        return self._client.search_stop(search_id=self._search_job_id, **kwargs)
 
     def status(self, **kwargs):
-        return self._client.search.status(search_id=self._search_job_id, **kwargs)
+        """Implements :meth:`~SearchAPIMixIn.search_status`"""
+        return self._client.search_status(search_id=self._search_job_id, **kwargs)
 
     def results(self, limit=None, offset=None, **kwargs):
-        return self._client.search.results(
+        """Implements :meth:`~SearchAPIMixIn.search_results`"""
+        return self._client.search_results(
             limit=limit, offset=offset, search_id=self._search_job_id, **kwargs
         )
 
     def delete(self, **kwargs):
-        return self._client.search.delete(search_id=self._search_job_id, **kwargs)
+        """Implements :meth:`~SearchAPIMixIn.search_delete`"""
+        return self._client.search_delete(search_id=self._search_job_id, **kwargs)
 
 
 class SearchResultsDictionary(Dictionary):
-    pass
+    """Response for :meth:`~SearchAPIMixIn.search_results`"""
 
 
 class SearchStatusesList(List):
+    """Response for :meth:`~SearchAPIMixIn.search_status`"""
+
     def __init__(self, list_entries=None, client=None):
         super(SearchStatusesList, self).__init__(
             list_entries, entry_class=SearchStatus, client=client
@@ -44,10 +52,12 @@ class SearchStatusesList(List):
 
 
 class SearchStatus(ListEntry):
-    pass
+    """Item in :class:`SearchStatusesList`"""
 
 
 class SearchCategoriesList(List):
+    """Response for :meth:`~SearchAPIMixIn.search_categories`"""
+
     def __init__(self, list_entries=None, client=None):
         super(SearchCategoriesList, self).__init__(
             list_entries, entry_class=SearchCategory, client=client
@@ -55,10 +65,12 @@ class SearchCategoriesList(List):
 
 
 class SearchCategory(ListEntry):
-    pass
+    """Item in :class:`SearchCategoriesList`"""
 
 
 class SearchPluginsList(List):
+    """Response for :meth:`~SearchAPIMixIn.search_plugins`"""
+
     def __init__(self, list_entries=None, client=None):
         super(SearchPluginsList, self).__init__(
             list_entries, entry_class=SearchPlugin, client=client
@@ -66,7 +78,7 @@ class SearchPluginsList(List):
 
 
 class SearchPlugin(ListEntry):
-    pass
+    """Item in :class:`SearchPluginsList`"""
 
 
 @aliased
@@ -92,53 +104,75 @@ class Search(ClientCache):
     """
 
     def start(self, pattern=None, plugins=None, category=None, **kwargs):
+        """Implements :meth:`~SearchAPIMixIn.search_start`"""
         return self._client.search_start(
             pattern=pattern, plugins=plugins, category=category, **kwargs
         )
 
     def stop(self, search_id=None, **kwargs):
+        """Implements :meth:`~SearchAPIMixIn.search_stop`"""
         return self._client.search_stop(search_id=search_id, **kwargs)
 
     def status(self, search_id=None, **kwargs):
+        """Implements :meth:`~SearchAPIMixIn.search_status`"""
         return self._client.search_status(search_id=search_id, **kwargs)
 
     def results(self, search_id=None, limit=None, offset=None, **kwargs):
+        """Implements :meth:`~SearchAPIMixIn.search_results`"""
         return self._client.search_results(
             search_id=search_id, limit=limit, offset=offset, **kwargs
         )
 
     def delete(self, search_id=None, **kwargs):
+        """Implements :meth:`~SearchAPIMixIn.search_delete`"""
         return self._client.search_delete(search_id=search_id, **kwargs)
 
     def categories(self, plugin_name=None, **kwargs):
+        """Implements :meth:`~SearchAPIMixIn.search_categories`"""
         return self._client.search_categories(plugin_name=plugin_name, **kwargs)
 
     @property
     def plugins(self):
+        """Implements :meth:`~SearchAPIMixIn.search_plugins`"""
         return self._client.search_plugins()
 
     @Alias("installPlugin")
     def install_plugin(self, sources=None, **kwargs):
+        """Implements :meth:`~SearchAPIMixIn.search_install_plugin`"""
         return self._client.search_install_plugin(sources=sources, **kwargs)
 
     @Alias("uninstallPlugin")
     def uninstall_plugin(self, sources=None, **kwargs):
+        """Implements :meth:`~SearchAPIMixIn.search_uninstall_plugin`"""
         return self._client.search_uninstall_plugin(sources=sources, **kwargs)
 
     @Alias("enablePlugin")
     def enable_plugin(self, plugins=None, enable=None, **kwargs):
+        """Implements :meth:`~SearchAPIMixIn.search_enable_plugin`"""
         return self._client.search_enable_plugin(
             plugins=plugins, enable=enable, **kwargs
         )
 
     @Alias("updatePlugins")
     def update_plugins(self, **kwargs):
+        """Implements :meth:`~SearchAPIMixIn.search_update_plugins`"""
         return self._client.search_update_plugins(**kwargs)
 
 
 @aliased
 class SearchAPIMixIn(Request):
-    """Implementation for all Search API methods."""
+    """
+    Implementation for all Search API methods.
+
+    :Usage:
+        >>> from qbittorrentapi import Client
+        >>> client = Client(host='localhost:8080', username='admin', password='adminadmin')
+        >>> search_job = client.search_start(pattern='Ubuntu', plugins='all', category='all')
+        >>> client.search_stop(search_id=search_job.id)
+        >>> # or
+        >>> search_job.stop()
+        >>>
+    """
 
     @property
     def search(self):
@@ -164,7 +198,7 @@ class SearchAPIMixIn(Request):
         :param pattern: term to search for
         :param plugins: list of plugins to use for searching (supports 'all' and 'enabled')
         :param category: categories to limit search; dependent on plugins. (supports 'all')
-        :return: search job
+        :return: :class:`SearchJobDictionary`
         """
         data = {
             "pattern": pattern,
@@ -197,8 +231,7 @@ class SearchAPIMixIn(Request):
         :raises NotFound404Error:
 
         :param search_id: ID of search to get status; leave emtpy for status of all jobs
-        :return: dictionary of searches
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-search-status
+        :return: :class:`SearchStatusesList` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-search-status
         """
         params = {"id": search_id}
         return self._get(
@@ -218,8 +251,7 @@ class SearchAPIMixIn(Request):
         :param search_id: ID of search job
         :param limit: number of results to return
         :param offset: where to start returning results
-        :return: Dictionary of results
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-search-results
+        :return: :class:`SearchResultsDictionary` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-search-results
         """
         data = {"id": search_id, "limit": limit, "offset": offset}
         return self._post(_name=APINames.Search, _method="results", data=data, **kwargs)
@@ -248,7 +280,7 @@ class SearchAPIMixIn(Request):
         Note: endpoint was removed in qBittorrent v4.3.0
 
         :param plugin_name: Limit categories returned by plugin(s) (supports 'all' and 'enabled')
-        :return: list of categories
+        :return: :class:`SearchCategoriesList`
         """
         data = {"pluginName": plugin_name}
         return self._post(
@@ -262,8 +294,7 @@ class SearchAPIMixIn(Request):
         """
         Retrieve details of search plugins.
 
-        :return: List of plugins.
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-search-plugins
+        :return: :class:`SearchPluginsList` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-search-plugins
         """
         return self._get(_name=APINames.Search, _method="plugins", **kwargs)
 

--- a/qbittorrentapi/sync.py
+++ b/qbittorrentapi/sync.py
@@ -1,5 +1,6 @@
 from qbittorrentapi.decorators import Alias
 from qbittorrentapi.decorators import aliased
+from qbittorrentapi.decorators import handle_hashes
 from qbittorrentapi.decorators import login_required
 from qbittorrentapi.decorators import response_json
 from qbittorrentapi.definitions import APINames
@@ -114,6 +115,7 @@ class SyncAPIMixIn(Request):
         return self._post(_name=APINames.Sync, _method="maindata", data=data, **kwargs)
 
     @Alias("sync_torrentPeers")
+    @handle_hashes
     @response_json(SyncTorrentPeersDictionary)
     @login_required
     def sync_torrent_peers(self, torrent_hash=None, rid=0, **kwargs):
@@ -126,7 +128,7 @@ class SyncAPIMixIn(Request):
         :param rid: response ID
         :return: :class:`SyncTorrentPeersDictionary` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-peers-data
         """
-        data = {"hash": torrent_hash or kwargs.pop("hash"), "rid": rid}
+        data = {"hash": torrent_hash, "rid": rid}
         return self._post(
             _name=APINames.Sync, _method="torrentPeers", data=data, **kwargs
         )

--- a/qbittorrentapi/sync.py
+++ b/qbittorrentapi/sync.py
@@ -9,11 +9,11 @@ from qbittorrentapi.request import Request
 
 
 class SyncMainDataDictionary(Dictionary):
-    pass
+    """Response for :meth:`~SyncAPIMixIn.sync_maindata`"""
 
 
 class SyncTorrentPeersDictionary(Dictionary):
-    pass
+    """Response for :meth:`~SyncAPIMixIn.sync_torrent_peers`"""
 
 
 class Sync(ClientCache):
@@ -30,7 +30,7 @@ class Sync(ClientCache):
         >>> # this will automatically request the changes since the last call
         >>> md = client.sync.maindata.delta()
         >>> #
-        >>> torrentPeers= client.sync.torrentPeers(hash="...'", rid='...')
+        >>> torrentPeers = client.sync.torrentPeers(hash="...'", rid='...')
         >>> torrent_peers = client.sync.torrent_peers(hash="...'", rid='...')
     """
 
@@ -79,7 +79,15 @@ class Sync(ClientCache):
 
 @aliased
 class SyncAPIMixIn(Request):
-    """Implementation of all Sync API Methods."""
+    """
+    Implementation of all Sync API Methods.
+
+    :Usage:
+        >>> from qbittorrentapi import Client
+        >>> client = Client(host='localhost:8080', username='admin', password='adminadmin')
+        >>> maindata = client.sync_maindata(rid="...")
+        >>> torrent_peers = client.sync_torrent_peers(torrent_hash="...'", rid='...')
+    """
 
     @property
     def sync(self):
@@ -100,8 +108,7 @@ class SyncAPIMixIn(Request):
         Retrieves sync data.
 
         :param rid: response ID
-        :return: dictionary response
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-main-data
+        :return: :class:`SyncMainDataDictionary` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-main-data
         """
         data = {"rid": rid}
         return self._post(_name=APINames.Sync, _method="maindata", data=data, **kwargs)
@@ -117,8 +124,7 @@ class SyncAPIMixIn(Request):
 
         :param torrent_hash: hash for torrent
         :param rid: response ID
-        :return: Dictionary of torrent sync data.
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-peers-data
+        :return: :class:`SyncTorrentPeersDictionary` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-peers-data
         """
         data = {"hash": torrent_hash or kwargs.pop("hash"), "rid": rid}
         return self._post(

--- a/qbittorrentapi/torrents.py
+++ b/qbittorrentapi/torrents.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 @aliased
 class TorrentDictionary(Dictionary):
     """
+    Item in :class:`TorrentInfoList`.
     Alows interaction with individual torrents via the "Torrents" API endpoints.
 
     :Usage:
@@ -81,6 +82,7 @@ class TorrentDictionary(Dictionary):
 
     @property
     def info(self):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_info`"""
         api_version = self._client.app.web_api_version
         if self._client._is_version_less_than(api_version, "2.0.1", lteq=False):
             info = [
@@ -93,46 +95,56 @@ class TorrentDictionary(Dictionary):
         return AttrDict()
 
     def resume(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_resume`"""
         self._client.torrents_resume(torrent_hashes=self._torrent_hash, **kwargs)
 
     def pause(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_pause`"""
         self._client.torrents_pause(torrent_hashes=self._torrent_hash, **kwargs)
 
     def delete(self, delete_files=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_delete`"""
         self._client.torrents_delete(
             delete_files=delete_files, torrent_hashes=self._torrent_hash, **kwargs
         )
 
     def recheck(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_recheck`"""
         self._client.torrents_recheck(torrent_hashes=self._torrent_hash, **kwargs)
 
     def reannounce(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_reannounce`"""
         self._client.torrents_reannounce(torrent_hashes=self._torrent_hash, **kwargs)
 
     @Alias("increasePrio")
     def increase_priority(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_increase_priority`"""
         self._client.torrents_increase_priority(
             torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @Alias("decreasePrio")
     def decrease_priority(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_decrease_priority`"""
         self._client.torrents_decrease_priority(
             torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @Alias("topPrio")
     def top_priority(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_top_priority`"""
         self._client.torrents_top_priority(torrent_hashes=self._torrent_hash, **kwargs)
 
     @Alias("bottomPrio")
     def bottom_priority(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_bottom_priority`"""
         self._client.torrents_bottom_priority(
             torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @Alias("setShareLimits")
     def set_share_limits(self, ratio_limit=None, seeding_time_limit=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_share_limits`"""
         self._client.torrents_set_share_limits(
             ratio_limit=ratio_limit,
             seeding_time_limit=seeding_time_limit,
@@ -142,6 +154,7 @@ class TorrentDictionary(Dictionary):
 
     @property
     def download_limit(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.set_download_limit`"""
         return self._client.torrents_download_limit(
             torrent_hashes=self._torrent_hash, **kwargs
         ).get(self._torrent_hash)
@@ -150,20 +163,24 @@ class TorrentDictionary(Dictionary):
 
     @downloadLimit.setter
     def downloadLimit(self, v):
+        """Implements :meth:`~TorrentsAPIMixIn.set_download_limit`"""
         self.download_limit = v
 
     @download_limit.setter
     def download_limit(self, v):
+        """Implements :meth:`~TorrentsAPIMixIn.set_download_limit`"""
         self.set_download_limit(limit=v)
 
     @Alias("setDownloadLimit")
     def set_download_limit(self, limit=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_download_limit`"""
         self._client.torrents_set_download_limit(
             limit=limit, torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @property
     def upload_limit(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_upload_limit`"""
         return self._client.torrents_upload_limit(
             torrent_hashes=self._torrent_hash, **kwargs
         ).get(self._torrent_hash)
@@ -172,84 +189,100 @@ class TorrentDictionary(Dictionary):
 
     @uploadLimit.setter
     def uploadLimit(self, v):
+        """Implements :meth:`~TorrentsAPIMixIn.set_upload_limit`"""
         self.upload_limit = v
 
     @upload_limit.setter
     def upload_limit(self, v):
+        """Implements :meth:`~TorrentsAPIMixIn.set_upload_limit`"""
         self.set_upload_limit(limit=v)
 
     @Alias("setUploadLimit")
     def set_upload_limit(self, limit=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_upload_limit`"""
         self._client.torrents_set_upload_limit(
             limit=limit, torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @Alias("setLocation")
     def set_location(self, location=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_location`"""
         self._client.torrents_set_location(
             location=location, torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @Alias("setCategory")
     def set_category(self, category=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_category`"""
         self._client.torrents_set_category(
             category=category, torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @Alias("setAutoManagement")
     def set_auto_management(self, enable=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_auto_management`"""
         self._client.torrents_set_auto_management(
             enable=enable, torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @Alias("toggleSequentialDownload")
     def toggle_sequential_download(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_toggle_sequential_download`"""
         self._client.torrents_toggle_sequential_download(
             torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @Alias("toggleFirstLastPiecePrio")
     def toggle_first_last_piece_priority(self, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_toggle_first_last_piece_priority`"""
         self._client.torrents_toggle_first_last_piece_priority(
             torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @Alias("setForceStart")
     def set_force_start(self, enable=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_force_start`"""
         self._client.torrents_set_force_start(
             enable=enable, torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @Alias("setSuperSeeding")
     def set_super_seeding(self, enable=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_super_seeding`"""
         self._client.torrents_set_super_seeding(
             enable=enable, torrent_hashes=self._torrent_hash, **kwargs
         )
 
     @property
     def properties(self):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_properties`"""
         return self._client.torrents_properties(torrent_hash=self._torrent_hash)
 
     @property
     def trackers(self):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_trackers`"""
         return self._client.torrents_trackers(torrent_hash=self._torrent_hash)
 
     @trackers.setter
     def trackers(self, v):
+        """Implements :meth:`~TorrentsAPIMixIn.add_trackers`"""
         self.add_trackers(urls=v)
 
     @property
     def webseeds(self):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_webseeds`"""
         return self._client.torrents_webseeds(torrent_hash=self._torrent_hash)
 
     @property
     def files(self):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_files`"""
         return self._client.torrents_files(torrent_hash=self._torrent_hash)
 
     @Alias("renameFile")
     def rename_file(
         self, file_id=None, new_file_name=None, old_path=None, new_path=None, **kwargs
     ):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_rename_file`"""
         self._client.torrents_rename_file(
             torrent_hash=self._torrent_hash,
             file_id=file_id,
@@ -261,6 +294,7 @@ class TorrentDictionary(Dictionary):
 
     @Alias("renameFolder")
     def rename_folder(self, old_path=None, new_path=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_rename_folder`"""
         self._client.torrents_rename_folder(
             torrent_hash=self._torrent_hash,
             old_path=old_path,
@@ -270,24 +304,28 @@ class TorrentDictionary(Dictionary):
 
     @property
     def piece_states(self):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_piece_states`"""
         return self._client.torrents_piece_states(torrent_hash=self._torrent_hash)
 
     pieceStates = piece_states
 
     @property
     def piece_hashes(self):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_piece_hashes`"""
         return self._client.torrents_piece_hashes(torrent_hash=self._torrent_hash)
 
     pieceHashes = piece_hashes
 
     @Alias("addTrackers")
     def add_trackers(self, urls=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_add_trackers`"""
         self._client.torrents_add_trackers(
             torrent_hash=self._torrent_hash, urls=urls, **kwargs
         )
 
     @Alias("editTracker")
     def edit_tracker(self, orig_url=None, new_url=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_edit_tracker`"""
         self._client.torrents_edit_tracker(
             torrent_hash=self._torrent_hash,
             original_url=orig_url,
@@ -297,12 +335,14 @@ class TorrentDictionary(Dictionary):
 
     @Alias("removeTrackers")
     def remove_trackers(self, urls=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_trackers`"""
         self._client.torrents_remove_trackers(
             torrent_hash=self._torrent_hash, urls=urls, **kwargs
         )
 
     @Alias("filePriority")
     def file_priority(self, file_ids=None, priority=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_file_priority`"""
         self._client.torrents_file_priority(
             torrent_hash=self._torrent_hash,
             file_ids=file_ids,
@@ -311,40 +351,45 @@ class TorrentDictionary(Dictionary):
         )
 
     def rename(self, new_name=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_rename`"""
         self._client.torrents_rename(
             torrent_hash=self._torrent_hash, new_torrent_name=new_name, **kwargs
         )
 
     @Alias("addTags")
     def add_tags(self, tags=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_add_tags`"""
         self._client.torrents_add_tags(
             torrent_hashes=self._torrent_hash, tags=tags, **kwargs
         )
 
     @Alias("removeTags")
     def remove_tags(self, tags=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_tags`"""
         self._client.torrents_remove_tags(
             torrent_hashes=self._torrent_hash, tags=tags, **kwargs
         )
 
 
 class TorrentPropertiesDictionary(Dictionary):
-    pass
+    """Response to :meth:`~TorrentsAPIMixIn.torrents_properties`"""
 
 
 class TorrentLimitsDictionary(Dictionary):
-    pass
+    """Response to :meth:`~TorrentsAPIMixIn.torrents_download_limit`"""
 
 
 class TorrentCategoriesDictionary(Dictionary):
-    pass
+    """Response to :meth:`~TorrentsAPIMixIn.torrents_categories`"""
 
 
 class TorrentsAddPeersDictionary(Dictionary):
-    pass
+    """Response to :meth:`~TorrentsAPIMixIn.torrents_add_peers`"""
 
 
 class TorrentFilesList(List):
+    """Response to :meth:`~TorrentsAPIMixIn.torrents_files`"""
+
     def __init__(self, list_entries=None, client=None):
         super(TorrentFilesList, self).__init__(
             list_entries, entry_class=TorrentFile, client=client
@@ -354,10 +399,12 @@ class TorrentFilesList(List):
 
 
 class TorrentFile(ListEntry):
-    pass
+    """Item in :class:`TorrentFilesList`"""
 
 
 class WebSeedsList(List):
+    """Response to :meth:`~TorrentsAPIMixIn.torrents_webseeds`"""
+
     def __init__(self, list_entries=None, client=None):
         super(WebSeedsList, self).__init__(
             list_entries, entry_class=WebSeed, client=client
@@ -365,10 +412,12 @@ class WebSeedsList(List):
 
 
 class WebSeed(ListEntry):
-    pass
+    """Item in :class:`WebSeedsList`"""
 
 
 class TrackersList(List):
+    """Response to :meth:`~TorrentsAPIMixIn.torrents_trackers`"""
+
     def __init__(self, list_entries=None, client=None):
         super(TrackersList, self).__init__(
             list_entries, entry_class=Tracker, client=client
@@ -376,10 +425,12 @@ class TrackersList(List):
 
 
 class Tracker(ListEntry):
-    pass
+    """Item in :class:`TrackersList`"""
 
 
 class TorrentInfoList(List):
+    """Response to :meth:`~TorrentsAPIMixIn.torrents_info`"""
+
     def __init__(self, list_entries=None, client=None):
         super(TorrentInfoList, self).__init__(
             list_entries, entry_class=TorrentDictionary, client=client
@@ -387,6 +438,8 @@ class TorrentInfoList(List):
 
 
 class TorrentPieceInfoList(List):
+    """Response to :meth:`~TorrentsAPIMixIn.torrents_piece_states` and :meth:`~TorrentsAPIMixIn.torrents_piece_hashes`"""
+
     def __init__(self, list_entries=None, client=None):
         super(TorrentPieceInfoList, self).__init__(
             list_entries, entry_class=TorrentPieceData, client=client
@@ -394,16 +447,18 @@ class TorrentPieceInfoList(List):
 
 
 class TorrentPieceData(ListEntry):
-    pass
+    """Item in :class:`TorrentPieceInfoList`"""
 
 
 class TagList(List):
+    """Response to :meth:`~TorrentsAPIMixIn.torrents_tags`"""
+
     def __init__(self, list_entries=None, client=None):
         super(TagList, self).__init__(list_entries, entry_class=Tag, client=client)
 
 
 class Tag(ListEntry):
-    pass
+    """Item in :class:`TagList`"""
 
 
 class Torrents(ClientCache):
@@ -819,10 +874,12 @@ class TorrentCategories(ClientCache):
 
     @property
     def categories(self):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_categories`"""
         return self._client.torrents_categories()
 
     @categories.setter
     def categories(self, v):
+        """Implements :meth:`~TorrentsAPIMixIn.edit_category` or :meth:`~TorrentsAPIMixIn.create_category`"""
         if v.get("name", "") in self.categories:
             self.edit_category(**v)
         else:
@@ -830,18 +887,21 @@ class TorrentCategories(ClientCache):
 
     @Alias("createCategory")
     def create_category(self, name=None, save_path=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_create_category`"""
         return self._client.torrents_create_category(
             name=name, save_path=save_path, **kwargs
         )
 
     @Alias("editCategory")
     def edit_category(self, name=None, save_path=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_edit_category`"""
         return self._client.torrents_edit_category(
             name=name, save_path=save_path, **kwargs
         )
 
     @Alias("removeCategories")
     def remove_categories(self, categories=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_categories`"""
         return self._client.torrents_remove_categories(categories=categories, **kwargs)
 
 
@@ -861,36 +921,50 @@ class TorrentTags(ClientCache):
 
     @property
     def tags(self):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_tags`"""
         return self._client.torrents_tags()
 
     @tags.setter
     def tags(self, v):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_create_tags`"""
         self._client.torrents_create_tags(tags=v)
 
     @Alias("addTags")
     def add_tags(self, tags=None, torrent_hashes=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_add_tags`"""
         self._client.torrents_add_tags(
             tags=tags, torrent_hashes=torrent_hashes, **kwargs
         )
 
     @Alias("removeTags")
     def remove_tags(self, tags=None, torrent_hashes=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_tags`"""
         self._client.torrents_remove_tags(
             tags=tags, torrent_hashes=torrent_hashes, **kwargs
         )
 
     @Alias("createTags")
     def create_tags(self, tags=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_create_tags`"""
         self._client.torrents_create_tags(tags=tags, **kwargs)
 
     @Alias("deleteTags")
     def delete_tags(self, tags=None, **kwargs):
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_delete_tags`"""
         self._client.torrents_delete_tags(tags=tags, **kwargs)
 
 
 @aliased
 class TorrentsAPIMixIn(Request):
-    """Implementation of all Torrents API methods."""
+    """
+    Implementation of all Torrents API methods.
+
+    :Usage:
+        >>> from qbittorrentapi import Client
+        >>> client = Client(host='localhost:8080', username='admin', password='adminadmin')
+        >>> client.torrents_add(urls='...')
+        >>> client.torrents_reannounce()
+    """
 
     @property
     def torrents(self):
@@ -1095,8 +1169,7 @@ class TorrentsAPIMixIn(Request):
         :raises NotFound404Error:
 
         :param torrent_hash: hash for torrent
-        :return: Dictionary of torrent properties
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-generic-properties
+        :return: :class:`TorrentPropertiesDictionary` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-generic-properties
         """
         data = {"hash": torrent_hash or kwargs.pop("hash")}
         return self._post(
@@ -1112,8 +1185,7 @@ class TorrentsAPIMixIn(Request):
         :raises NotFound404Error:
 
         :param torrent_hash: hash for torrent
-        :return: List of torrent's trackers
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-trackers
+        :return: :class:`TrackersList` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-trackers
         """
         data = {"hash": torrent_hash or kwargs.pop("hash")}
         return self._post(
@@ -1129,8 +1201,7 @@ class TorrentsAPIMixIn(Request):
         :raises NotFound404Error:
 
         :param torrent_hash: hash for torrent
-        :return: List of torrent's web seeds
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-web-seeds
+        :return: :class:`WebSeedsList` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-web-seeds
         """
         data = {"hash": torrent_hash or kwargs.pop("hash")}
         return self._post(
@@ -1146,8 +1217,7 @@ class TorrentsAPIMixIn(Request):
         :raises NotFound404Error:
 
         :param torrent_hash: hash for torrent
-        :return: List of torrent's files
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-contents
+        :return: :class:`TorrentFilesList` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-contents
         """
         data = {"hash": torrent_hash or kwargs.pop("hash")}
         return self._post(_name=APINames.Torrents, _method="files", data=data, **kwargs)
@@ -1162,7 +1232,7 @@ class TorrentsAPIMixIn(Request):
         :raises NotFound404Error:
 
         :param torrent_hash: hash for torrent
-        :return: list of torrent's pieces' states
+        :return: :class:`TorrentPieceInfoList`
         """
         data = {"hash": torrent_hash or kwargs.pop("hash")}
         return self._post(
@@ -1179,7 +1249,7 @@ class TorrentsAPIMixIn(Request):
         :raises NotFound404Error:
 
         :param torrent_hash: hash for torrent
-        :return: List of torrent's pieces' hashes
+        :return: :class:`TorrentPieceInfoList`
         """
         data = {"hash": torrent_hash or kwargs.pop("hash")}
         return self._post(
@@ -1261,11 +1331,10 @@ class TorrentsAPIMixIn(Request):
 
         :raises InvalidRequest400: if priority is invalid or at least one file ID is not an integer
         :raises NotFound404Error:
-        :raises Conflict409: if torrent metadata has not finished downloading or at least one file was not found
+        :raises Conflict409Error: if torrent metadata has not finished downloading or at least one file was not found
         :param torrent_hash: hash for torrent
         :param file_ids: single file ID or a list.
-        :param priority: priority for file(s)
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-file-priority
+        :param priority: priority for file(s) - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-file-priority
         :return: None
         """
         data = {
@@ -1410,8 +1479,7 @@ class TorrentsAPIMixIn(Request):
         :param limit: Limit length of list
         :param offset: Start of list (if < 0, offset from end of list)
         :param torrent_hashes: Filter list by hash (separate multiple hashes with a '|')
-        :return: List of torrents
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-list
+        :return: :class:`TorrentInfoList` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-list
         """
         data = {
             "filter": status_filter,
@@ -1500,7 +1568,7 @@ class TorrentsAPIMixIn(Request):
         """
         Increase the priority of a torrent. Torrent Queuing must be enabled. (alias: torrents_increasePrio)
 
-        :raises Conflict409:
+        :raises Conflict409Error:
 
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
@@ -1516,7 +1584,7 @@ class TorrentsAPIMixIn(Request):
         """
         Decrease the priority of a torrent. Torrent Queuing must be enabled. (alias: torrents_decreasePrio)
 
-        :raises Conflict409:
+        :raises Conflict409Error:
 
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
@@ -1532,7 +1600,7 @@ class TorrentsAPIMixIn(Request):
         """
         Set torrent as highest priority. Torrent Queuing must be enabled. (alias: torrents_topPrio)
 
-        :raises Conflict409:
+        :raises Conflict409Error:
 
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
@@ -1548,7 +1616,7 @@ class TorrentsAPIMixIn(Request):
         """
         Set torrent as highest priority. Torrent Queuing must be enabled. (alias: torrents_bottomPrio)
 
-        :raises Conflict409:
+        :raises Conflict409Error:
 
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
@@ -1565,7 +1633,7 @@ class TorrentsAPIMixIn(Request):
         """
         Retrieve the download limit for one or more torrents. (alias: torrents_downloadLimit)
 
-        :return: dictioanry {hash: limit} (-1 represents no limit)
+        :return: :class:`TorrentLimitsDictionary` - {hash: limit} (-1 represents no limit)
         """
         data = {
             "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
@@ -1623,7 +1691,7 @@ class TorrentsAPIMixIn(Request):
         Retrieve the upload limit for one or more torrents. (alias: torrents_uploadLimit)
 
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
-        :return: dictionary of limits
+        :return: :class:`TorrentLimitsDictionary`
         """
         data = {
             "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
@@ -1657,7 +1725,7 @@ class TorrentsAPIMixIn(Request):
         Set location for torrents's files. (alias: torrents_setLocation)
 
         :raises Forbidden403Error: if the user doesn't have permissions to write to the location
-        :raises Conflict409: if the directory cannot be created at the location
+        :raises Conflict409Error: if the directory cannot be created at the location
 
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :param location: disk location to move torrent's files
@@ -1675,7 +1743,7 @@ class TorrentsAPIMixIn(Request):
         """
         Set a category for one or more torrents. (alias: torrents_setCategory)
 
-        :raises Conflict409: for bad category
+        :raises Conflict409Error: for bad category
 
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :param category: category to assign to torrent
@@ -1789,7 +1857,7 @@ class TorrentsAPIMixIn(Request):
 
         :param peers: one or more peers to add. each peer should take the form 'host:port'
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
-        :return: dictionary - {<hash>: {'added': #, 'failed': #}}
+        :return: :class:`TorrentsAddPeersDictionary` - {<hash>: {'added': #, 'failed': #}}
         """
         data = {
             "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
@@ -1808,7 +1876,7 @@ class TorrentsAPIMixIn(Request):
         Retrieve all category definitions
 
         Note: torrents/categories is not available until v2.1.0
-        :return: dictionary of categories
+        :return: :class:`TorrentCategoriesDictionary`
         """
         return self._get(_name=APINames.Torrents, _method="categories", **kwargs)
 
@@ -1820,7 +1888,7 @@ class TorrentsAPIMixIn(Request):
 
         Note: save_path is not available until web API version 2.1.0
 
-        :raises Conflict409: if category name is not valid or unable to create
+        :raises Conflict409Error: if category name is not valid or unable to create
 
         :param name: name for new category
         :param save_path: location to save torrents for this category
@@ -1840,7 +1908,7 @@ class TorrentsAPIMixIn(Request):
 
         Note: torrents/editCategory not available until web API version 2.1.0
 
-        :raises Conflict409:
+        :raises Conflict409Error:
 
         :param name: category to edit
         :param save_path: new location to save files for this category
@@ -1871,7 +1939,7 @@ class TorrentsAPIMixIn(Request):
         """
         Retrieve all tag definitions.
 
-        :return: list of tags
+        :return: :class:`TagList`
         """
         return self._get(_name=APINames.Torrents, _method="tags", **kwargs)
 

--- a/qbittorrentapi/torrents.py
+++ b/qbittorrentapi/torrents.py
@@ -22,6 +22,7 @@ from qbittorrentapi.decorators import Alias
 from qbittorrentapi.decorators import aliased
 from qbittorrentapi.decorators import _check_for_raise
 from qbittorrentapi.decorators import endpoint_introduced
+from qbittorrentapi.decorators import handle_hashes
 from qbittorrentapi.decorators import login_required
 from qbittorrentapi.decorators import response_json
 from qbittorrentapi.decorators import response_text
@@ -1159,6 +1160,7 @@ class TorrentsAPIMixIn(Request):
     ##########################################################################
     # INDIVIDUAL TORRENT ENDPOINTS
     ##########################################################################
+    @handle_hashes
     @response_json(TorrentPropertiesDictionary)
     @login_required
     def torrents_properties(self, torrent_hash=None, **kwargs):
@@ -1170,11 +1172,12 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hash: hash for torrent
         :return: :class:`TorrentPropertiesDictionary` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-generic-properties
         """
-        data = {"hash": torrent_hash or kwargs.pop("hash")}
+        data = {"hash": torrent_hash}
         return self._post(
             _name=APINames.Torrents, _method="properties", data=data, **kwargs
         )
 
+    @handle_hashes
     @response_json(TrackersList)
     @login_required
     def torrents_trackers(self, torrent_hash=None, **kwargs):
@@ -1186,11 +1189,12 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hash: hash for torrent
         :return: :class:`TrackersList` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-trackers
         """
-        data = {"hash": torrent_hash or kwargs.pop("hash")}
+        data = {"hash": torrent_hash}
         return self._post(
             _name=APINames.Torrents, _method="trackers", data=data, **kwargs
         )
 
+    @handle_hashes
     @response_json(WebSeedsList)
     @login_required
     def torrents_webseeds(self, torrent_hash=None, **kwargs):
@@ -1202,11 +1206,12 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hash: hash for torrent
         :return: :class:`WebSeedsList` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-web-seeds
         """
-        data = {"hash": torrent_hash or kwargs.pop("hash")}
+        data = {"hash": torrent_hash}
         return self._post(
             _name=APINames.Torrents, _method="webseeds", data=data, **kwargs
         )
 
+    @handle_hashes
     @response_json(TorrentFilesList)
     @login_required
     def torrents_files(self, torrent_hash=None, **kwargs):
@@ -1218,10 +1223,11 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hash: hash for torrent
         :return: :class:`TorrentFilesList` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-contents
         """
-        data = {"hash": torrent_hash or kwargs.pop("hash")}
+        data = {"hash": torrent_hash}
         return self._post(_name=APINames.Torrents, _method="files", data=data, **kwargs)
 
     @Alias("torrents_pieceStates")
+    @handle_hashes
     @response_json(TorrentPieceInfoList)
     @login_required
     def torrents_piece_states(self, torrent_hash=None, **kwargs):
@@ -1233,12 +1239,13 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hash: hash for torrent
         :return: :class:`TorrentPieceInfoList`
         """
-        data = {"hash": torrent_hash or kwargs.pop("hash")}
+        data = {"hash": torrent_hash}
         return self._post(
             _name=APINames.Torrents, _method="pieceStates", data=data, **kwargs
         )
 
     @Alias("torrents_pieceHashes")
+    @handle_hashes
     @response_json(TorrentPieceInfoList)
     @login_required
     def torrents_piece_hashes(self, torrent_hash=None, **kwargs):
@@ -1250,12 +1257,13 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hash: hash for torrent
         :return: :class:`TorrentPieceInfoList`
         """
-        data = {"hash": torrent_hash or kwargs.pop("hash")}
+        data = {"hash": torrent_hash}
         return self._post(
             _name=APINames.Torrents, _method="pieceHashes", data=data, **kwargs
         )
 
     @Alias("torrents_addTrackers")
+    @handle_hashes
     @login_required
     def torrents_add_trackers(self, torrent_hash=None, urls=None, **kwargs):
         """
@@ -1268,13 +1276,14 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hash": torrent_hash or kwargs.pop("hash"),
+            "hash": torrent_hash,
             "urls": self._list2string(urls, "\n"),
         }
         self._post(_name=APINames.Torrents, _method="addTrackers", data=data, **kwargs)
 
-    @endpoint_introduced("2.2.0", "torrents/editTracker")
     @Alias("torrents_editTracker")
+    @handle_hashes
+    @endpoint_introduced("2.2.0", "torrents/editTracker")
     @login_required
     def torrents_edit_tracker(
         self, torrent_hash=None, original_url=None, new_url=None, **kwargs
@@ -1292,14 +1301,15 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hash": torrent_hash or kwargs.pop("hash"),
+            "hash": torrent_hash,
             "origUrl": original_url,
             "newUrl": new_url,
         }
         self._post(_name=APINames.Torrents, _method="editTracker", data=data, **kwargs)
 
-    @endpoint_introduced("2.2.0", "torrents/removeTrackers")
     @Alias("torrents_removeTrackers")
+    @handle_hashes
+    @endpoint_introduced("2.2.0", "torrents/removeTrackers")
     @login_required
     def torrents_remove_trackers(self, torrent_hash=None, urls=None, **kwargs):
         """
@@ -1313,7 +1323,7 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hash": torrent_hash or kwargs.pop("hash"),
+            "hash": torrent_hash,
             "urls": self._list2string(urls, "|"),
         }
         self._post(
@@ -1321,6 +1331,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     @Alias("torrents_filePrio")
+    @handle_hashes
     @login_required
     def torrents_file_priority(
         self, torrent_hash=None, file_ids=None, priority=None, **kwargs
@@ -1337,12 +1348,13 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hash": torrent_hash or kwargs.pop("hash"),
+            "hash": torrent_hash,
             "id": self._list2string(file_ids, "|"),
             "priority": priority,
         }
         self._post(_name=APINames.Torrents, _method="filePrio", data=data, **kwargs)
 
+    @handle_hashes
     @login_required
     def torrents_rename(self, torrent_hash=None, new_torrent_name=None, **kwargs):
         """
@@ -1354,11 +1366,12 @@ class TorrentsAPIMixIn(Request):
         :param new_torrent_name: new name for torrent
         :return: None
         """
-        data = {"hash": torrent_hash or kwargs.pop("hash"), "name": new_torrent_name}
+        data = {"hash": torrent_hash, "name": new_torrent_name}
         self._post(_name=APINames.Torrents, _method="rename", data=data, **kwargs)
 
-    @endpoint_introduced("2.4.0", "torrents/renameFile")
     @Alias("torrents_renameFile")
+    @handle_hashes
+    @endpoint_introduced("2.4.0", "torrents/renameFile")
     @login_required
     def torrents_rename_file(
         self,
@@ -1383,7 +1396,7 @@ class TorrentsAPIMixIn(Request):
         :param new_path: new path of file to rename (added in Web API v2.7)
         :return: None
         """
-        torrent_hash = torrent_hash or kwargs.pop("hash")
+        torrent_hash = torrent_hash
 
         # convert pre-v2.7 params to post-v2.7 params if a newer qBittorrent is being used
         # HACK: v4.3.2 and v4.3.3 both use web api v2.7 but old/new_path were introduced in v4.3.3
@@ -1412,8 +1425,9 @@ class TorrentsAPIMixIn(Request):
         }
         self._post(_name=APINames.Torrents, _method="renameFile", data=data, **kwargs)
 
-    @endpoint_introduced("2.7", "torrents/renameFolder")
     @Alias("torrents_renameFolder")
+    @handle_hashes
+    @endpoint_introduced("2.7", "torrents/renameFolder")
     @login_required
     def torrents_rename_folder(
         self, torrent_hash=None, old_path=None, new_path=None, **kwargs
@@ -1433,7 +1447,7 @@ class TorrentsAPIMixIn(Request):
         # HACK: v4.3.2 and v4.3.3 both use web api v2.7 but rename_folder was introduced in v4.3.3
         if self._is_version_less_than("v4.3.3", self.app.version, lteq=True):
             data = {
-                "hash": torrent_hash or kwargs.pop("hash"),
+                "hash": torrent_hash,
                 "oldPath": old_path,
                 "newPath": new_path,
             }
@@ -1453,6 +1467,7 @@ class TorrentsAPIMixIn(Request):
     ##########################################################################
     # MULTIPLE TORRENT ENDPOINTS
     ##########################################################################
+    @handle_hashes
     @response_json(TorrentInfoList)
     @login_required
     def torrents_info(
@@ -1487,10 +1502,11 @@ class TorrentsAPIMixIn(Request):
             "reverse": reverse,
             "limit": limit,
             "offset": offset,
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
         }
         return self._post(_name=APINames.Torrents, _method="info", data=data, **kwargs)
 
+    @handle_hashes
     @login_required
     def torrents_resume(self, torrent_hashes=None, **kwargs):
         """
@@ -1499,11 +1515,10 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         self._post(_name=APINames.Torrents, _method="resume", data=data, **kwargs)
 
+    @handle_hashes
     @login_required
     def torrents_pause(self, torrent_hashes=None, **kwargs):
         """
@@ -1512,11 +1527,10 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         self._post(_name=APINames.Torrents, _method="pause", data=data, **kwargs)
 
+    @handle_hashes
     @login_required
     def torrents_delete(self, delete_files=False, torrent_hashes=None, **kwargs):
         """
@@ -1527,11 +1541,12 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "deleteFiles": delete_files,
         }
         self._post(_name=APINames.Torrents, _method="delete", data=data, **kwargs)
 
+    @handle_hashes
     @login_required
     def torrents_recheck(self, torrent_hashes=None, **kwargs):
         """
@@ -1540,11 +1555,10 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         self._post(_name=APINames.Torrents, _method="recheck", data=data, **kwargs)
 
+    @handle_hashes
     @endpoint_introduced("2.0.2", "torrents/reannounce")
     @login_required
     def torrents_reannounce(self, torrent_hashes=None, **kwargs):
@@ -1556,12 +1570,11 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         self._post(_name=APINames.Torrents, _method="reannounce", data=data, **kwargs)
 
     @Alias("torrents_increasePrio")
+    @handle_hashes
     @login_required
     def torrents_increase_priority(self, torrent_hashes=None, **kwargs):
         """
@@ -1572,12 +1585,11 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         self._post(_name=APINames.Torrents, _method="increasePrio", data=data, **kwargs)
 
     @Alias("torrents_decreasePrio")
+    @handle_hashes
     @login_required
     def torrents_decrease_priority(self, torrent_hashes=None, **kwargs):
         """
@@ -1588,12 +1600,11 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         self._post(_name=APINames.Torrents, _method="decreasePrio", data=data, **kwargs)
 
     @Alias("torrents_topPrio")
+    @handle_hashes
     @login_required
     def torrents_top_priority(self, torrent_hashes=None, **kwargs):
         """
@@ -1604,12 +1615,11 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         self._post(_name=APINames.Torrents, _method="topPrio", data=data, **kwargs)
 
     @Alias("torrents_bottomPrio")
+    @handle_hashes
     @login_required
     def torrents_bottom_priority(self, torrent_hashes=None, **kwargs):
         """
@@ -1620,12 +1630,11 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         self._post(_name=APINames.Torrents, _method="bottomPrio", data=data, **kwargs)
 
     @Alias("torrents_downloadLimit")
+    @handle_hashes
     @response_json(TorrentLimitsDictionary)
     @login_required
     def torrents_download_limit(self, torrent_hashes=None, **kwargs):
@@ -1634,14 +1643,13 @@ class TorrentsAPIMixIn(Request):
 
         :return: :class:`TorrentLimitsDictionary` - {hash: limit} (-1 represents no limit)
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         return self._post(
             _name=APINames.Torrents, _method="downloadLimit", data=data, **kwargs
         )
 
     @Alias("torrents_setDownloadLimit")
+    @handle_hashes
     @login_required
     def torrents_set_download_limit(self, limit=None, torrent_hashes=None, **kwargs):
         """
@@ -1652,15 +1660,16 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "limit": limit,
         }
         self._post(
             _name=APINames.Torrents, _method="setDownloadLimit", data=data, **kwargs
         )
 
-    @endpoint_introduced("2.0.1", "torrents/setShareLimits")
     @Alias("torrents_setShareLimits")
+    @handle_hashes
+    @endpoint_introduced("2.0.1", "torrents/setShareLimits")
     @login_required
     def torrents_set_share_limits(
         self, ratio_limit=None, seeding_time_limit=None, torrent_hashes=None, **kwargs
@@ -1674,7 +1683,7 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "ratioLimit": ratio_limit,
             "seedingTimeLimit": seeding_time_limit,
         }
@@ -1683,6 +1692,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     @Alias("torrents_uploadLimit")
+    @handle_hashes
     @response_json(TorrentLimitsDictionary)
     @login_required
     def torrents_upload_limit(self, torrent_hashes=None, **kwargs):
@@ -1692,14 +1702,13 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: :class:`TorrentLimitsDictionary`
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         return self._post(
             _name=APINames.Torrents, _method="uploadLimit", data=data, **kwargs
         )
 
     @Alias("torrents_setUploadLimit")
+    @handle_hashes
     @login_required
     def torrents_set_upload_limit(self, limit=None, torrent_hashes=None, **kwargs):
         """
@@ -1710,7 +1719,7 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "limit": limit,
         }
         self._post(
@@ -1718,6 +1727,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     @Alias("torrents_setLocation")
+    @handle_hashes
     @login_required
     def torrents_set_location(self, location=None, torrent_hashes=None, **kwargs):
         """
@@ -1731,12 +1741,13 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "location": location,
         }
         self._post(_name=APINames.Torrents, _method="setLocation", data=data, **kwargs)
 
     @Alias("torrents_setCategory")
+    @handle_hashes
     @login_required
     def torrents_set_category(self, category=None, torrent_hashes=None, **kwargs):
         """
@@ -1749,12 +1760,13 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "category": category,
         }
         self._post(_name=APINames.Torrents, _method="setCategory", data=data, **kwargs)
 
     @Alias("torrents_setAutoManagement")
+    @handle_hashes
     @login_required
     def torrents_set_auto_management(self, enable=None, torrent_hashes=None, **kwargs):
         """
@@ -1765,7 +1777,7 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "enable": enable,
         }
         self._post(
@@ -1773,6 +1785,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     @Alias("torrents_toggleSequentialDownload")
+    @handle_hashes
     @login_required
     def torrents_toggle_sequential_download(self, torrent_hashes=None, **kwargs):
         """
@@ -1781,7 +1794,7 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
         """
-        data = {"hashes": self._list2string(torrent_hashes or kwargs.get("hashes"))}
+        data = {"hashes": self._list2string(torrent_hashes)}
         self._post(
             _name=APINames.Torrents,
             _method="toggleSequentialDownload",
@@ -1790,6 +1803,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     @Alias("torrents_toggleFirstLastPiecePrio")
+    @handle_hashes
     @login_required
     def torrents_toggle_first_last_piece_priority(self, torrent_hashes=None, **kwargs):
         """
@@ -1798,9 +1812,7 @@ class TorrentsAPIMixIn(Request):
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or 'all' for all torrents.
         :return: None
         """
-        data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|")
-        }
+        data = {"hashes": self._list2string(torrent_hashes, "|")}
         self._post(
             _name=APINames.Torrents,
             _method="toggleFirstLastPiecePrio",
@@ -1809,6 +1821,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     @Alias("torrents_setForceStart")
+    @handle_hashes
     @login_required
     def torrents_set_force_start(self, enable=None, torrent_hashes=None, **kwargs):
         """
@@ -1819,7 +1832,7 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "value": enable,
         }
         self._post(
@@ -1827,6 +1840,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     @Alias("torrents_setSuperSeeding")
+    @handle_hashes
     @login_required
     def torrents_set_super_seeding(self, enable=None, torrent_hashes=None, **kwargs):
         """
@@ -1837,7 +1851,7 @@ class TorrentsAPIMixIn(Request):
         :return:
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "value": enable,
         }
         self._post(
@@ -1845,6 +1859,7 @@ class TorrentsAPIMixIn(Request):
         )
 
     @Alias("torrents_addPeers")
+    @handle_hashes
     @endpoint_introduced("2.3.0", "torrents/addPeers")
     @response_json(TorrentsAddPeersDictionary)
     @login_required
@@ -1859,7 +1874,7 @@ class TorrentsAPIMixIn(Request):
         :return: :class:`TorrentsAddPeersDictionary` - {<hash>: {'added': #, 'failed': #}}
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "peers": self._list2string(peers, "|"),
         }
         return self._post(
@@ -1943,6 +1958,7 @@ class TorrentsAPIMixIn(Request):
         return self._get(_name=APINames.Torrents, _method="tags", **kwargs)
 
     @Alias("torrents_addTags")
+    @handle_hashes
     @endpoint_introduced("2.3.0", "torrents/addTags")
     @login_required
     def torrents_add_tags(self, tags=None, torrent_hashes=None, **kwargs):
@@ -1955,12 +1971,13 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "tags": self._list2string(tags, ","),
         }
         self._post(_name=APINames.Torrents, _method="addTags", data=data, **kwargs)
 
     @Alias("torrents_removeTags")
+    @handle_hashes
     @endpoint_introduced("2.3.0", "torrents/removeTags")
     @login_required
     def torrents_remove_tags(self, tags=None, torrent_hashes=None, **kwargs):
@@ -1972,7 +1989,7 @@ class TorrentsAPIMixIn(Request):
         :return: None
         """
         data = {
-            "hashes": self._list2string(torrent_hashes or kwargs.get("hashes"), "|"),
+            "hashes": self._list2string(torrent_hashes, "|"),
             "tags": self._list2string(tags, ","),
         }
         self._post(_name=APINames.Torrents, _method="removeTags", data=data, **kwargs)

--- a/qbittorrentapi/torrents.py
+++ b/qbittorrentapi/torrents.py
@@ -1,5 +1,5 @@
 import errno
-import logging
+from logging import getLogger
 from os import path
 from os import strerror as os_strerror
 
@@ -10,8 +10,7 @@ except ImportError:
     from collections import Iterable
     from collections import Mapping
 
-import six
-from attrdict import AttrDict
+from six import text_type as six_text_type
 
 from qbittorrentapi.definitions import APINames
 from qbittorrentapi.definitions import ClientCache
@@ -31,7 +30,7 @@ from qbittorrentapi.exceptions import TorrentFileNotFoundError
 from qbittorrentapi.exceptions import TorrentFilePermissionError
 from qbittorrentapi.request import Request
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 @aliased
@@ -92,7 +91,7 @@ class TorrentDictionary(Dictionary):
             info = self._client.torrents_info(torrent_hashes=self._torrent_hash)
         if len(info) == 1:
             return info[0]
-        return AttrDict()
+        return TorrentDictionary(data={}, client=self._client)
 
     def resume(self, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_resume`"""
@@ -1098,7 +1097,7 @@ class TorrentsAPIMixIn(Request):
         prefix = "torrent__"
         # if it's string-like and not a list|set|tuple, then make it a list
         # checking for 'read' attr since a single file handle is iterable but also needs to be in a list
-        is_string_like = isinstance(user_files, (bytes, six.text_type))
+        is_string_like = isinstance(user_files, (bytes, six_text_type))
         is_file_like = hasattr(user_files, "read")
         if is_string_like or is_file_like or not isinstance(user_files, Iterable):
             user_files = [user_files]

--- a/qbittorrentapi/transfer.py
+++ b/qbittorrentapi/transfer.py
@@ -11,12 +11,11 @@ from qbittorrentapi.request import Request
 
 
 class TransferInfoDictionary(Dictionary):
-    pass
+    """Response to :meth:`~TransferAPIMixIn.transfer_info`"""
 
 
 @aliased
 class Transfer(ClientCache):
-
     """
     Alows interaction with the "Transfer" API endpoints.
 
@@ -36,73 +35,94 @@ class Transfer(ClientCache):
 
     @property
     def info(self):
+        """Implements :meth:`~TransferAPIMixIn.transfer_info`"""
         return self._client.transfer_info()
 
     @property
     def speed_limits_mode(self):
+        """Implements :meth:`~TransferAPIMixIn.transfer_speed_limits_mode`"""
         return self._client.transfer_speed_limits_mode()
 
     speedLimitsMode = speed_limits_mode
 
     @speedLimitsMode.setter
     def speedLimitsMode(self, v):
+        """Implements :meth:`~TransferAPIMixIn.transfer_toggle_speed_limits_mode`"""
         self.speed_limits_mode = v
 
     @speed_limits_mode.setter
     def speed_limits_mode(self, v):
+        """Implements :meth:`~TransferAPIMixIn.transfer_toggle_speed_limits_mode`"""
         self.toggle_speed_limits_mode(intended_state=v)
 
     @Alias("toggleSpeedLimitsMode")
     def toggle_speed_limits_mode(self, intended_state=None, **kwargs):
+        """Implements :meth:`~TransferAPIMixIn.transfer_toggle_speed_limits_mode`"""
         return self._client.transfer_toggle_speed_limits_mode(
             intended_state=intended_state, **kwargs
         )
 
     @property
     def download_limit(self):
+        """Implements :meth:`~TransferAPIMixIn.transfer_download_limit`"""
         return self._client.transfer_download_limit()
 
     downloadLimit = download_limit
 
     @downloadLimit.setter
     def downloadLimit(self, v):
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_download_limit`"""
         self.download_limit = v
 
     @download_limit.setter
     def download_limit(self, v):
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_download_limit`"""
         self.set_download_limit(limit=v)
 
     @property
     def upload_limit(self):
+        """Implements :meth:`~TransferAPIMixIn.transfer_upload_limit`"""
         return self._client.transfer_upload_limit()
 
     uploadLimit = upload_limit
 
     @uploadLimit.setter
     def uploadLimit(self, v):
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_upload_limit`"""
         self.upload_limit = v
 
     @upload_limit.setter
     def upload_limit(self, v):
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_upload_limit`"""
         self.set_upload_limit(limit=v)
 
     @Alias("setDownloadLimit")
     def set_download_limit(self, limit=None, **kwargs):
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_download_limit`"""
         return self._client.transfer_set_download_limit(limit=limit, **kwargs)
 
     @Alias("setUploadLimit")
     def set_upload_limit(self, limit=None, **kwargs):
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_upload_limit`"""
         return self._client.transfer_set_upload_limit(limit=limit, **kwargs)
 
     @Alias("banPeers")
     def ban_peers(self, peers=None, **kwargs):
+        """Implements :meth:`~TransferAPIMixIn.transfer_ban_peers`"""
         return self._client.transfer_ban_peers(peers=peers, **kwargs)
 
 
 @aliased
 class TransferAPIMixIn(Request):
+    """
+    Implementation of all Transfer API methods
 
-    """Implementation of all Transfer API methods"""
+    :Usage:
+        >>> from qbittorrentapi import Client
+        >>> client = Client(host='localhost:8080', username='admin', password='adminadmin')
+        >>> transfer_info = client.transfer_info()
+        >>> client.transfer_set_download_limit(limit=1024000)
+    """
 
     @property
     def transfer(self):
@@ -122,8 +142,7 @@ class TransferAPIMixIn(Request):
         """
         Retrieves the global transfer info usually found in qBittorrent status bar.
 
-        :return: dictionary of status items
-            Properties: https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-global-transfer-info
+        :return: :class:`TransferInfoDictionary` - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-global-transfer-info
         """
         return self._get(_name=APINames.Transfer, _method="info", **kwargs)
 
@@ -148,9 +167,8 @@ class TransferAPIMixIn(Request):
                                Leaving None will toggle the current state.
         :return: None
         """
-        if (
-            self.transfer_speed_limits_mode() == "1"
-        ) is not intended_state or intended_state is None:
+        is_enabled = lambda: self.transfer_speed_limits_mode() == "1"
+        if intended_state is None or is_enabled() is not intended_state:
             self._post(
                 _name=APINames.Transfer, _method="toggleSpeedLimitsMode", **kwargs
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-attrdict>=2.0.0
 enum34
 requests>=2.16.0
 urllib3>=1.24.2

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     install_requires=[
-        "attrdict>=2.0.0",
         "requests>=2.16.0",
         "urllib3>=1.24.2",
         "six",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="qbittorrent-api",
-    version="2021.1.16",
+    version="2021.2.17",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     install_requires=[

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,8 +1,6 @@
 import logging
 from json import dumps
 
-from attrdict import AttrDict
-
 import pytest
 
 from qbittorrentapi import Client
@@ -11,6 +9,7 @@ from qbittorrentapi.decorators import (
     response_json,
     response_text,
 )
+from qbittorrentapi._attrdict import AttrDict
 from qbittorrentapi.decorators import endpoint_introduced, version_removed
 from qbittorrentapi import APIError
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -171,7 +171,8 @@ def test_http404(client, params):
 
     response = MockResponse(status_code=404, text="")
     with pytest.raises(HTTPError):
-        Request.handle_error_responses(data={}, params=params, response=response)
+        p = dict(data={}, params=params)
+        Request.handle_error_responses(params=p, response=response)
 
 
 def test_http409(client, api_version):
@@ -189,14 +190,16 @@ def test_http415(client):
 def test_http500(status_code):
     response = MockResponse(status_code=status_code, text="asdf")
     with pytest.raises(InternalServerError500Error):
-        Request.handle_error_responses(data={}, params={}, response=response)
+        p = dict(data={}, params={})
+        Request.handle_error_responses(params=p, response=response)
 
 
 @pytest.mark.parametrize("status_code", (402, 406))
 def test_http_error(status_code):
     response = MockResponse(status_code=status_code, text="asdf")
     with pytest.raises(HTTPError):
-        Request.handle_error_responses(data={}, params={}, response=response)
+        p = dict(data={}, params={})
+        Request.handle_error_responses(params=p, response=response)
 
 
 def test_verbose_logging(caplog):


### PR DESCRIPTION
 - Generally refactor requests.py so it's better and easier to read
 - Persist a Requests Session between API calls instead of always creating a new one...small perf benefit
 - Move `auth` endpoints back to a dedicated module
 - Since attrdict is apparently going to break in Python 3.10 and it is no longer maintained, i've vendored a modified version (fixes #45).
 - Created `handle_hashes` decorator to hide the cruft of continuing to support hash and hashes arguments

TODO
 - ~~Ensure `auth` documentation exists~~
 - ~~Consider additional tests around special functionality with Requests~~
 - ~~Shore up testing in the few places it's lacking as long as we're here~~