### PR TITLE
Fix torrent state: forceDL -> forcedDL

### DIFF
--- a/qbittorrentapi/definitions.py
+++ b/qbittorrentapi/definitions.py
@@ -61,7 +61,7 @@ class TorrentStates(Enum):
     METADATA_DOWNLOAD = "metaDL"
     PAUSED_DOWNLOAD = "pausedDL"
     QUEUED_DOWNLOAD = "queuedDL"
-    FORCE_DOWNLOAD = "forceDL"
+    FORCED_DOWNLOAD = "forcedDL"
     STALLED_DOWNLOAD = "stalledDL"
     CHECKING_DOWNLOAD = "checkingDL"
     CHECKING_RESUME_DATA = "checkingResumeData"
@@ -78,7 +78,7 @@ class TorrentStates(Enum):
             TorrentStates.CHECKING_DOWNLOAD,
             TorrentStates.PAUSED_DOWNLOAD,
             TorrentStates.QUEUED_DOWNLOAD,
-            TorrentStates.FORCE_DOWNLOAD,
+            TorrentStates.FORCED_DOWNLOAD,
         )
 
     @property

--- a/tests/test_torrent_states.py
+++ b/tests/test_torrent_states.py
@@ -18,7 +18,7 @@ all_states = (
     "metaDL",
     "pausedDL",
     "queuedDL",
-    "forceDL",
+    "forcedDL",
     "stalledDL",
     "checkingDL",
     "checkingResumeData",
@@ -33,7 +33,7 @@ downloading_states = (
     "checkingDL",
     "pausedDL",
     "queuedDL",
-    "forceDL",
+    "forcedDL",
 )
 
 uploading_states = ("uploading", "stalledUP", "checkingUP", "queuedUP", "forcedUP")


### PR DESCRIPTION
cf https://github.com/qbittorrent/qBittorrent/blob/6139d0d65a092a24168e2d7e9b6d67a5ae612ff5/src/webui/api/serialize/serialize_torrent.cpp#L74-L75:

```cpp
        case BitTorrent::TorrentState::ForcedDownloading:
            return QLatin1String("forcedDL");
```

Fix for https://github.com/esanchezm/prometheus-qbittorrent-exporter/issues/3