### PR TITLE
Fix License and Update Tests for qBittorrent 4.3.4.1 Release

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,8 +20,8 @@ jobs:
     continue-on-error: true
     env:
       LATEST_PYTHON_VERSION: 3.9
-      LATEST_QBT_VERSION: 4.3.3
-      QBT_ALWAYS_TEST: 4.3.3, 4.3.2, 4.3.1
+      LATEST_QBT_VERSION: 4.3.4.1
+      QBT_ALWAYS_TEST: 4.3.4.1, 4.3.3, 4.3.2
       SUBMIT_COVERAGE_VERSIONS: 2.7, 3.9
       COMPREHENSIVE_TESTS_BRANCH: comprehensive_tests
       PYTHON_QBITTORRENTAPI_HOST: localhost:8080
@@ -31,7 +31,7 @@ jobs:
       QBT_LEGACY_INSTALL: 4.2.5, 4.2.0
     strategy:
       matrix:
-        QBT_VER: [4.3.3, 4.3.2, 4.3.1, 4.3.0.1, 4.2.5, 4.2.0]
+        QBT_VER: [4.3.4.1, 4.3.3, 4.3.2, 4.3.1, 4.3.0.1, 4.2.5, 4.2.0]
         python-version: [3.9, 3.8, 3.7, 3.6, 3.5, 2.7, 3.10-dev, pypy2, pypy3]
         # python-version: [3.9]
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+Version 2021.4.19 (8 apr 2021)
+ - Update license in setup to match gpl->mit license change on github
+
 Version 2021.3.18 (13 mar 2021)
  - Replace TorrentStates.FORCE_DOWNLOAD='forceDL' with TorrentStates.FORCED_DOWNLOAD='forcedDL'
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="qbittorrent-api",
-    version="2021.3.18",
+    version="2021.4.19",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     install_requires=[
@@ -21,7 +21,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords="python qbittorrent api client torrent torrents",
     zip_safe=False,
-    license="GPL-3",
+    license="MIT",
     classifiers=[
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.8",
@@ -35,7 +35,7 @@ setup(
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "License :: OSI Approved :: MIT License",
         "Topic :: Communications :: File Sharing",
         "Topic :: Utilities",
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ api_version_map = {
     "v4.3.1": "2.6.1",
     "v4.3.2": "2.7",
     "v4.3.3": "2.7",
+    "v4.3.4.1": "2.8.1",
 }
 
 _check_limit = 10
@@ -44,13 +45,13 @@ _orig_torrent_url = (
 )
 _orig_torrent_hash = "d1101a2b9d202811a05e8c57c557a20bf974dc8a"
 
-torrent1_url = "http://cdimage.ubuntu.com/kubuntu/releases/20.04.1/release/kubuntu-20.04.1-desktop-amd64.iso.torrent"
+torrent1_url = "http://cdimage.ubuntu.com/kubuntu/releases/20.04.1/release/kubuntu-20.04.2.0-desktop-amd64.iso.torrent"
 torrent1_filename = torrent1_url.split("/")[-1]
-torrent1_hash = "08d23eefbb35253773a8dc18eb77854a87ccda9a"
+torrent1_hash = "2ea1327a1758400827fe091a9bb2a35dee9ea5e8"
 
-torrent2_url = "http://cdimage.ubuntu.com/xubuntu/releases/20.04.1/release/xubuntu-20.04.1-desktop-amd64.iso.torrent"
+torrent2_url = "http://cdimage.ubuntu.com/xubuntu/releases/20.04.1/release/xubuntu-20.04.2.0-desktop-amd64.iso.torrent"
 torrent2_filename = torrent2_url.split("/")[-1]
-torrent2_hash = "35eb6295e8e260b81c7ddcb4f5019a96064ff904"
+torrent2_hash = "3d75247029ffa408e52714d371b6c0f15a63ff41"
 
 is_version_less_than = Request._is_version_less_than
 suppress_context = Request._suppress_context


### PR DESCRIPTION
* Update License in setup.py to match the move from GPL to MIT on github
* Update tests for release of qBittorrent 4.3.4.1
* Update test torrent files since Canonical keeps moving/deleting them...