### PR TITLE
Stop Sending Origin and Referer Headers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+Version 2021.12.26 (11 dec 2021)
+ - Stop sending Origin and Referer headers (Fixes #63)
+
 Version 2021.12.25 (10 dec 2021)
  - Close files that are opened and sent to Requests when adding torrents from files
  - Enable warnings for tests and explicitly close Requests Sessions to prevent (mostly spurious) ResourceWarnings

--- a/qbittorrentapi/request.py
+++ b/qbittorrentapi/request.py
@@ -567,11 +567,6 @@ class Request(HelpersMixIn):
 
         self._http_session = QbittorrentSession()
 
-        # default headers to prevent qBittorrent throwing any alarms
-        self._http_session.headers.update(
-            {"Referer": self._API_BASE_URL, "Origin": self._API_BASE_URL}
-        )
-
         # add any user-defined headers to be sent in all requests
         self._http_session.headers.update(self._EXTRA_HEADERS)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="qbittorrent-api",
-    version="2021.12.25",
+    version="2021.12.26",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     install_requires=[

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -374,7 +374,9 @@ def test_http401():
     client.app.preferences = dict(web_ui_csrf_protection_enabled=True)
     # simulate a XSS request
     with pytest.raises(exceptions.Unauthorized401Error):
-        client.app_preferences(headers={"X-Forwarded-Host": "http://example.com"})
+        client.app_version(
+            headers={"Origin": "https://example.com", "Referer": "https://example.com"}
+        )
 
 
 @pytest.mark.parametrize("params", ({}, {"hash": "asdf"}, {"hashes": "asdf|asdf"}))


### PR DESCRIPTION
Fixes #63.
This client has populated these headers since its beginning and largely has not been problematic. However, as #63 points out, it can lead to issues if a default port is explicitly specified.
Since qBittorrent will omit CSRF checks altogether if these headers are not included in the request, this change should be transparent to users.
That said, if an intervening proxy (or something else) does get upset, users can use the EXTRA_HEADERS argument to include these headers.