### PR TITLE
Support qBittorrent 4.4.1

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,21 +20,21 @@ jobs:
     continue-on-error: true
     env:
       LATEST_PYTHON_VERSION: "3.10"
-      LATEST_QBT_VERSION: 4.4.0
-      QBT_ALWAYS_TEST: 4.4.0, 4.3.9, 4.3.8, 4.3.5, 4.3.4.1, 4.3.3, 4.3.2, 4.3.1, 4.3.0.1, 4.2.0
+      LATEST_QBT_VERSION: 4.4.1
+      QBT_ALWAYS_TEST: 4.4.1, 4.4.0, 4.3.9, 4.3.8, 4.3.6, 4.3.4.1, 4.3.3, 4.3.2, 4.2.5, 4.2.0
       QT_USE_DEFAULT_PAA: 4.3.9, 4.3.8, 4.3.7, 4.3.6, 4.3.5, 4.3.4.1, 4.3.3, 4.3.2, 4.3.1, 4.3.0.1, 4.2.5, 4.2.0
       SUBMIT_COVERAGE_VERSIONS: 2.7, 3.10
       COMPREHENSIVE_TESTS_BRANCH: comprehensive_tests
       PYTHON_QBITTORRENTAPI_HOST: localhost:8080
       PYTHON_QBITTORRENTAPI_PASSWORD: adminadmin
       PYTHON_QBITTORRENTAPI_USERNAME: admin
-      LIBTOR_VER: 1.2.14
+      LIBTOR_VER: 1.2.15
       QBT_LEGACY_INSTALL: 4.2.5, 4.2.0
     strategy:
       matrix:
-        QBT_VER: [4.4.0, 4.3.9, 4.3.8, 4.3.7, 4.3.6, 4.3.5, 4.3.4.1, 4.3.3, 4.3.2, 4.3.1, 4.3.0.1, 4.2.5, 4.2.0]
+        QBT_VER: [4.4.1, 4.4.0, 4.3.9, 4.3.8, 4.3.7, 4.3.6, 4.3.5, 4.3.4.1, 4.3.3, 4.3.2, 4.3.1, 4.3.0.1, 4.2.5, 4.2.0]
         # QBT_VER: [4.4.0]
-        python-version: ["3.10", "3.9", "3.8", "3.7", "3.6", "2.7", "pypy2", "pypy3", "3.11.0-alpha.2"]
+        python-version: ["3.10", "3.9", "3.8", "3.7", "3.6", "2.7", "pypy-3.8", "pypy-3.7", "pypy2"]
         # python-version: [3.9]
 
     # TODO: each step currently has an over-complicated conditional to prevent always running all tests.
@@ -232,18 +232,19 @@ jobs:
           #  run: coveralls
 
   install-dev:
+    name: "Verify Dev Env"
+    runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-
-    name: "Verify Dev Env"
-    runs-on: "${{ matrix.os }}"
+        python-version: ["3.10", "3.9", "3.8", "3.7", "3.6", "2.7", "pypy-3.8", "pypy-3.7", "pypy2"]
 
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
+
       - name: "Install in dev mode"
         run: "python -m pip install -e .[dev]"
       - name: "Import package"
@@ -257,7 +258,7 @@ jobs:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: "Install twine"
         run: "python -m pip install --upgrade pip setuptools wheel twine"

--- a/.github/workflows/qbt-dev-tests.yml
+++ b/.github/workflows/qbt-dev-tests.yml
@@ -2,12 +2,10 @@ name: qBittorrent Dev Testing
 
 on:
   schedule:
-    # run every few days so caches aren't evicted
     - cron: "0 0 1-30/3 * *"
   push:
     branches:
       - master
-      - comprehensive_tests
   pull_request:
     branches:
       - master
@@ -19,21 +17,15 @@ jobs:
     runs-on: ubuntu-20.04  # update Qt PPA when moving beyond 20.04
     continue-on-error: true
     env:
-      QBT_ALWAYS_TEST: master, v4_4_x
-      COMPREHENSIVE_TESTS_BRANCH: comprehensive_tests
       PYTHON_QBITTORRENTAPI_HOST: localhost:8080
       PYTHON_QBITTORRENTAPI_PASSWORD: adminadmin
       PYTHON_QBITTORRENTAPI_USERNAME: admin
-      LIBTOR_VER: 1.2.14
+      LIBTOR_VER: 1.2.15
       IS_QBT_DEV: True
     strategy:
       matrix:
         QBT_VER: ["master", "v4_4_x", "v4_3_x"]
-        # python-version: ["3.10", "3.9", "3.8", "3.7", "3.6", "2.7", "pypy2", "pypy3", "3.11.0-alpha.2"]
         python-version: ["3.10"]
-
-    # TODO: each step currently has an over-complicated conditional to prevent always running all tests.
-    # TODO: this can be removed once the matrix supports conditions
 
     steps:
       - name: Branch
@@ -67,7 +59,6 @@ jobs:
 
       - name: Build libtorrent
         # if cache missed, build libtorrent library.
-        # right now, all relevant qBittorrent versions can be compiled using libtorrent 1.2.12
         if: steps.cache-libtorrent.outputs.cache-hit != 'true'
         run: |
           set -x
@@ -130,19 +121,13 @@ jobs:
         if: failure()
         uses: dawidd6/action-send-mail@v2
         with:
-          # mail server settings
           server_address: smtp.gmail.com
           server_port: 587
-          # user credentials
           username: ${{ secrets.EMAIL_USERNAME }}
           password: ${{ secrets.EMAIL_PASSWORD }}
-          # email subject
           subject: ${{ github.job }} job of ${{ github.repository }} failed
-          # email body as text
           body: |
             ${{ github.job }} job in worflow ${{ github.workflow }} of ${{ github.repository }} failed.
             https://github.com/rmartin16/qbittorrent-api/actions/runs/${{ github.run_id }}
-          # comma-separated string, send email to
-          to: rmartin16@gmail.com
-          # from email name
-          from: rmartin16@gmail.com
+          to: rmartin16+github-action@gmail.com   # comma-separated string
+          from: rmartin16+github-action@gmail.com

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Version 2022.2.28 (17 feb 2022)
+ - Advertise support for qBittorrent v4.4.1
+ - qBittorrent reverted the category dictionary key "savePath" back to "save_path"
+
 Version 2022.1.27 (9 jan 2022)
  - Support for qBittorrent v4.4.0
  - torrents/info results can now be filtered by a torrent tag

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ qBittorrent Web API Client
 
 Python client implementation for qBittorrent Web API. Supports qBittorrent v4.1.0+ (i.e. Web API v2.0+).
 
-Currently supports up to qBittorrent [v4.4.0](https://github.com/qbittorrent/qBittorrent/releases/tag/release-4.4.0) (Web API v2.8.4) released on Jan 6, 2022.
+Currently supports up to qBittorrent [v4.4.1](https://github.com/qbittorrent/qBittorrent/releases/tag/release-4.4.1) (Web API v2.8.5) released on Feb 15, 2022.
 
 [Find the full documentation for this client on RTD.](https://qbittorrent-api.readthedocs.io/)
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -21,7 +21,7 @@ Introduction
 
 Python client implementation for qBittorrent Web API.
 
-Currently supports up to qBittorrent `v4.4.0 <https://github.com/qbittorrent/qBittorrent/releases/tag/release-4.4.0>`_ (Web API v2.8.4) released on Jan 6, 2022.
+Currently supports up to qBittorrent `v4.4.1 <https://github.com/qbittorrent/qBittorrent/releases/tag/release-4.4.1>`_ (Web API v2.8.5) released on Feb 15, 2022.
 
 The full qBittorrent Web API documentation is available on their `wiki <https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)>`_.
 

--- a/qbittorrentapi/_version_support.py
+++ b/qbittorrentapi/_version_support.py
@@ -1,6 +1,3 @@
-MOST_RECENT_SUPPORTED_APP_VERSION = "v4.4.0"
-MOST_RECENT_SUPPORTED_API_VERSION = "2.8.4"
-
 APP_VERSION_2_API_VERSION_MAP = {
     "v4.1.0": "2.0",
     "v4.1.1": "2.0.1",
@@ -31,7 +28,11 @@ APP_VERSION_2_API_VERSION_MAP = {
     "v4.3.8": "2.8.2",
     "v4.3.9": "2.8.2",
     "v4.4.0": "2.8.4",
+    "v4.4.1": "2.8.5",
 }
+
+MOST_RECENT_SUPPORTED_APP_VERSION = "v4.4.1"
+MOST_RECENT_SUPPORTED_API_VERSION = "2.8.5"
 
 
 class Version(object):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="qbittorrent-api",
-    version="2022.1.27",
+    version="2022.2.28",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
- Bump version to advertise support for qBittorrent v4.4.1
- qBittorrent reverted category dictionary key from  "savePath" to "save_path"
- Some TLC for tests.....notably, remove python 3.11 until beta released

**Release Checklist**
- [x] Bump version number
- [x] Update version_support.py
- [x] Update CHANGELOG
- [x] Update qBittorrent version/link in docs
- [x] Update qBittorrent version/link in README