### PR TITLE
Misc Fixes/Cleanup

### DIFF
--- a/.github/workflows/package-and-install.yml
+++ b/.github/workflows/package-and-install.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.10", "3.9", "3.8", "3.7", "3.6", "2.7", "pypy-3.8", "pypy-3.7", "pypy2"]
+        python-version: ["3.10", "3.9", "3.8", "3.7", "2.7", "pypy-3.8", "pypy-3.7", "pypy2"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,23 +6,19 @@ on:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Install dependencies
+      - name: Install dependencies and build
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
+          python -m pip install --upgrade setuptools wheel twine
           python setup.py sdist bdist_wheel
-          twine upload dist/*
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -34,8 +34,8 @@ jobs:
       matrix:
         QBT_VER: [4.4.2, 4.4.1, 4.4.0, 4.3.9, 4.3.8, 4.3.7, 4.3.6, 4.3.5, 4.3.4.1, 4.3.3, 4.3.2, 4.3.1, 4.3.0.1, 4.2.5, 4.2.0]
         # QBT_VER: [4.4.0]
-        python-version: ["3.10", "3.9", "3.8", "3.7", "3.6", "2.7", "pypy-3.8", "pypy-3.7", "pypy2"]
-        # python-version: [3.9]
+        python-version: ["3.10", "3.9", "3.8", "3.7", "2.7", "pypy-3.8", "pypy-3.7", "pypy2"]
+        # python-version: [3.10]
 
     # TODO: each step currently has an over-complicated conditional to prevent always running all tests.
     # TODO: this can be removed once the matrix supports conditions

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Version 2022.4.30 (3 apr 2022)
+ - Stop advertising support for Python 3.6 (EOL 12/2021)
+ - Publish to PyPI using API token and cleanup GitHub Action scripts
+
 Version 2022.3.29 (25 mar 2022)
  - Advertise support for qBittorrent v4.4.2
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Russell Martin
+Copyright (c) 2022 Russell Martin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ qBittorrent Web API Client
 [![PyPI](https://img.shields.io/pypi/v/qbittorrent-api?style=flat-square)](https://pypi.org/project/qbittorrent-api/) 
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qbittorrent-api?style=flat-square)
 ![PyPI - Implementation](https://img.shields.io/pypi/implementation/qbittorrent-api?style=flat-square)
+![PyPi - Downloads](https://img.shields.io/pypi/dw/qbittorrent-api?color=blue&style=flat-square)
 
 Python client implementation for qBittorrent Web API. Supports qBittorrent v4.1.0+ (i.e. Web API v2.0+).
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -14,10 +14,11 @@ Introduction
    :target: https://pypi.org/project/qbittorrent-api/
 .. |pypi versions| image:: https://img.shields.io/pypi/pyversions/qbittorrent-api?style=flat-square
 .. |pypi implementations| image:: https://img.shields.io/pypi/implementation/qbittorrent-api?style=flat-square
+.. |pypi downloads| image:: https://img.shields.io/pypi/dw/qbittorrent-api?color=blue&style=flat-square
 
 |travis ci| |codecov| |coverity| |codacy|
 
-|pypi| |pypi versions| |pypi implementations|
+|pypi| |pypi versions| |pypi implementations| |pypi downloads|
 
 Python client implementation for qBittorrent Web API.
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="qbittorrent-api",
-    version="2022.3.29",
+    version="2022.4.30",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Changes
- Update PyPI publish action to use PyPI API token instead of user/pass
- Remove advertised support for Python 3.6 (EOL 12/2021)

**Release Checklist**
- [x] Bump version number
- [ ] Add new version to version_support.py
- [ ] Add new version to tests-release.yml
- [x] Update CHANGELOG
- [ ] Update qBittorrent version/link in docs
- [ ] Update qBittorrent version/link in README