### PR TITLE
Add setuptools as an Explicit Dependency

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+Version 2022.8.34 (11 aug 2022)
+ - Add setuptools as an explicit dependency for pkg_resources.parse_version
+
 Version 2022.7.33 (27 jul 2022)
  - Reorder class hierarchy to allow independent MixIn use
  - Clean up typing annotations

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = qbittorrent-api
-version = 2022.7.33
+version = 2022.8.34
 url = https://github.com/rmartin16/qbittorrent-api
 author = Russell Martin
 author_email = rmartin16@gmail.com
@@ -46,6 +46,8 @@ install_requires =
     requests >= 2.16.0
     six
     urllib3 >= 1.24.2
+    # required for pkg_resources.parse_version
+    setuptools
 
 [options.extras_require]
 test =


### PR DESCRIPTION
`pkg_resources.parse_version()` is provided by `setuptools` but was not explicitly required by `qbittorrent-api`. `setuptools` will almost always be installed and available but that is not guaranteed.