### PR TITLE
Rename configuration environment variables

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -25,11 +25,11 @@ env:
   QT_USE_DEFAULT_PAA: "4.3.9, 4.3.8, 4.3.7, 4.3.6, 4.3.5, 4.3.4.1, 4.3.3, 4.3.2, 4.3.1, 4.3.0.1"
   LIBTORRENT_VER: "2.0.7"
   SUBMIT_COVERAGE_VERSIONS: "2.7, 3.10"
-  PYTHON_QBITTORRENTAPI_HOST: localhost:8080
-  PYTHON_QBITTORRENTAPI_PASSWORD: adminadmin
-  PYTHON_QBITTORRENTAPI_USERNAME: admin
-  LIBTORRENT_INSTALLS: ${{ github.workspace }}/resources/libtorrent_installs
-  QBITTORRENT_INSTALLS: ${{ github.workspace }}/resources/qbittorrent_installs
+  QBITTORRENTAPI_HOST: "localhost:8080"
+  QBITTORRENTAPI_PASSWORD: "adminadmin"
+  QBITTORRENTAPI_USERNAME: "admin"
+  LIBTORRENT_INSTALLS: "${{ github.workspace }}/resources/libtorrent_installs"
+  QBITTORRENT_INSTALLS: "${{ github.workspace }}/resources/qbittorrent_installs"
   GH_CI_CACHE_VERSION: "1"  # useful to effectively evict caches
 
 jobs:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+Version 2022.8.35 (13 aug 2022)
+ - Remove PYTHON_ prefix for configuration environment variables
+
 Version 2022.8.34 (11 aug 2022)
  - Add setuptools as an explicit dependency for pkg_resources.parse_version
 

--- a/docs/source/behavior&configuration.rst
+++ b/docs/source/behavior&configuration.rst
@@ -4,7 +4,7 @@ Behavior & Configuration
 Untrusted WebUI Certificate
 ***************************
 * qBittorrent allows you to configure HTTPS with an untrusted certificate; this commonly includes self-signed certificates.
-* When using such a certificate, instantiate Client with ``VERIFY_WEBUI_CERTIFICATE=False`` or set environment variable ``PYTHON_QBITTORRENTAPI_DO_NOT_VERIFY_WEBUI_CERTIFICATE`` to a non-null value.
+* When using such a certificate, instantiate Client with ``VERIFY_WEBUI_CERTIFICATE=False`` or set environment variable ``QBITTORRENTAPI_DO_NOT_VERIFY_WEBUI_CERTIFICATE`` to a non-null value.
 * Failure to do this for will cause connections to qBittorrent to fail.
 * As a word of caution, doing this actually does turn off certificate verification. Therefore, for instance, potential man-in-the-middle attacks will not be detected and reported (since the error is suppressed). However, the connection will remain encrypted.
 
@@ -18,9 +18,9 @@ Host, Username and Password
 
 * Alternatively, set environment variables:
 
-  * ``PYTHON_QBITTORRENTAPI_HOST``
-  * ``PYTHON_QBITTORRENTAPI_USERNAME``
-  * ``PYTHON_QBITTORRENTAPI_PASSWORD``
+  * ``QBITTORRENTAPI_HOST``
+  * ``QBITTORRENTAPI_USERNAME``
+  * ``QBITTORRENTAPI_PASSWORD``
 
 Requests Configuration
 **********************

--- a/qbittorrentapi/request.py
+++ b/qbittorrentapi/request.py
@@ -272,34 +272,37 @@ class Request(object):
                 if getLogger(logger_).level < 20:
                     getLogger(logger_).setLevel("INFO")
 
-        # Environment variables have lowest priority
-        if self.host == "" and environ.get("PYTHON_QBITTORRENTAPI_HOST") is not None:
-            logger.debug(
-                "Using PYTHON_QBITTORRENTAPI_HOST env variable for qBittorrent hostname"
+        # Environment variables have the lowest priority
+        if not self.host:
+            env_host = environ.get(
+                "QBITTORRENTAPI_HOST", environ.get("PYTHON_QBITTORRENTAPI_HOST")
             )
-            self.host = environ["PYTHON_QBITTORRENTAPI_HOST"]
-        if (
-            self.username == ""
-            and environ.get("PYTHON_QBITTORRENTAPI_USERNAME") is not None
-        ):
-            logger.debug(
-                "Using PYTHON_QBITTORRENTAPI_USERNAME env variable for username"
+            if env_host is not None:
+                logger.debug(
+                    "Using QBITTORRENTAPI_HOST env variable for qBittorrent host"
+                )
+                self.host = env_host
+        if not self.username:
+            env_username = environ.get(
+                "QBITTORRENTAPI_USERNAME", environ.get("PYTHON_QBITTORRENTAPI_USERNAME")
             )
-            self.username = environ["PYTHON_QBITTORRENTAPI_USERNAME"]
-        if (
-            self._password == ""
-            and environ.get("PYTHON_QBITTORRENTAPI_PASSWORD") is not None
-        ):
-            logger.debug(
-                "Using PYTHON_QBITTORRENTAPI_PASSWORD env variable for password"
+            if env_username is not None:
+                logger.debug("Using QBITTORRENTAPI_USERNAME env variable for username")
+                self.username = env_username
+        if not self._password:
+            env_password = environ.get(
+                "QBITTORRENTAPI_PASSWORD", environ.get("PYTHON_QBITTORRENTAPI_PASSWORD")
             )
-            self._password = environ["PYTHON_QBITTORRENTAPI_PASSWORD"]
-        if (
-            self._VERIFY_WEBUI_CERTIFICATE is True
-            and environ.get("PYTHON_QBITTORRENTAPI_DO_NOT_VERIFY_WEBUI_CERTIFICATE")
-            is not None
-        ):
-            self._VERIFY_WEBUI_CERTIFICATE = False
+            if env_password is not None:
+                logger.debug("Using QBITTORRENTAPI_PASSWORD env variable for password")
+                self._password = env_password
+        if self._VERIFY_WEBUI_CERTIFICATE is True:
+            env_verify_cert = environ.get(
+                "QBITTORRENTAPI_DO_NOT_VERIFY_WEBUI_CERTIFICATE",
+                environ.get("PYTHON_QBITTORRENTAPI_DO_NOT_VERIFY_WEBUI_CERTIFICATE"),
+            )
+            if env_verify_cert is not None:
+                self._VERIFY_WEBUI_CERTIFICATE = False
 
         # Mocking variables until better unit testing exists
         self._MOCK_WEB_API_VERSION = MOCK_WEB_API_VERSION

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = qbittorrent-api
-version = 2022.8.34
+version = 2022.8.35
 url = https://github.com/rmartin16/qbittorrent-api
 author = Russell Martin
 author_email = rmartin16@gmail.com


### PR DESCRIPTION
 - Drop `PYTHON_` prefix from configuration environment variables
 - Original environment variable names are still supported