### PR TITLE
Add context manager for automatically logging out of sessions

### DIFF
--- a/src/qbittorrentapi/auth.py
+++ b/src/qbittorrentapi/auth.py
@@ -144,3 +144,10 @@ class AuthAPIMixIn(Request):
     def auth_log_out(self, **kwargs):
         """End session with qBittorrent."""
         self._post(_name=APINames.Authorization, _method="logout", **kwargs)
+
+    def __enter__(self):
+        self.auth_log_in()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.auth_log_out()

--- a/src/qbittorrentapi/auth.pyi
+++ b/src/qbittorrentapi/auth.pyi
@@ -1,6 +1,8 @@
 from logging import Logger
 from typing import Optional
 from typing import Text
+from typing import TracebackType
+from typing import Type
 
 from qbittorrentapi._types import KwargsT
 from qbittorrentapi.definitions import ClientCache
@@ -36,3 +38,10 @@ class AuthAPIMixIn(Request):
     def _SID(self) -> Optional[Text]: ...
     def _session_cookie(self, cookie_name: Text = "SID") -> Optional[Text]: ...
     def auth_log_out(self, **kwargs: KwargsT) -> None: ...
+    def __enter__(self) -> "AuthAPIMixIn": ...
+    def __exit__(
+        self,
+        exctype: Optional[Type[BaseException]],
+        excinst: Optional[BaseException],
+        exctb: Optional[TracebackType],
+    ) -> bool: ...

--- a/src/qbittorrentapi/auth.pyi
+++ b/src/qbittorrentapi/auth.pyi
@@ -1,7 +1,7 @@
 from logging import Logger
+from types import TracebackType
 from typing import Optional
 from typing import Text
-from typing import TracebackType
 from typing import Type
 
 from qbittorrentapi._types import KwargsT

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,3 +29,12 @@ def test_session_cookie(app_version):
     curr_sess_cookie = client._http_session.cookies["SID"]
     assert client._SID == curr_sess_cookie
     assert client._session_cookie() == curr_sess_cookie
+
+
+def test_login_context_manager():
+    with Client(
+        RAISE_NOTIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS=True,
+        VERIFY_WEBUI_CERTIFICATE=False,
+    ) as client:
+        assert client.is_logged_in
+    assert not client.is_logged_in


### PR DESCRIPTION
I recently ran into an issue using `qbittorrent-api` with my qBittorrent instances. I was causing large memory leaks because I was leaving behind a lot of unused sessions. I had no idea it was necessary to clean up sessions by making sure to explicitly logout

I added a context manager for logging in and out just as a convenience. It's a little nicer than using large try/finally blocks

Example:
```python
login_info = {
    'host':'localhost',
    'port':8080,
    'username':'admin',
    'password':'adminadmin',
}

with Client(**login_info) as client:
    for torrent in client.torrents_info():
        print(torrent.name)
```

