### PR TITLE
Auto-update `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: [--in-place, --pre-summary-newline, --wrap-descriptions=88, --wrap-summaries=88]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.265
+    rev: v0.0.267
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
Updated `pre-commit` hooks to their latest versions and ran updated hooks against the repo.