### PR TITLE
Drop testing for PyPy3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
           - "2.7"
           - "pypy3.9"
           - "pypy3.8"
-          - "pypy3.7"
           - "pypy2.7"
         include:
           - OS_VER: "ubuntu-latest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ filterwarnings = [
     # this'll need to be addressed eventually...
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
     "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",
+    # Work around https://github.com/pytest-dev/pytest/issues/10977 for Python 3.12
+    'ignore:(ast\.Str|ast\.NameConstant|ast\.Num|Attribute s) is deprecated and will be removed.*:DeprecationWarning:',
 ]
 markers = [
     "skipif_before_api_version(api_version): skips test for current api version",


### PR DESCRIPTION
- PyCA cryptography 41.0.0 requires PyPy 7.3.10
- PyPy ended support for 3.7 with 7.3.9