### PR TITLE
Avoid requiring `client` to instantiate a `List`

### DIFF
--- a/src/qbittorrentapi/definitions.py
+++ b/src/qbittorrentapi/definitions.py
@@ -192,18 +192,18 @@ class Dictionary(ClientCache, AttrDict):
         return data
 
 
-class List(ClientCache, UserList):
+class List(UserList):
     """Base definition for list-like objects returned from qBittorrent."""
 
     def __init__(self, list_entries=None, entry_class=None, client=None):
+        is_safe_cast = None not in {client, entry_class}
         super(List, self).__init__(
             [
                 entry_class(data=entry, client=client)
-                if isinstance(entry, dict)
+                if is_safe_cast and isinstance(entry, dict)
                 else entry
                 for entry in list_entries or ()
-            ],
-            client=client,
+            ]
         )
 
 

--- a/src/qbittorrentapi/log.py
+++ b/src/qbittorrentapi/log.py
@@ -9,9 +9,9 @@ from qbittorrentapi.definitions import ListEntry
 class LogPeersList(List):
     """Response for :meth:`~LogAPIMixIn.log_peers`"""
 
-    def __init__(self, list_entries, client):
+    def __init__(self, list_entries, client=None):
         super(LogPeersList, self).__init__(
-            client=client, entry_class=LogPeer, list_entries=list_entries
+            list_entries, entry_class=LogPeer, client=client
         )
 
 
@@ -22,9 +22,9 @@ class LogPeer(ListEntry):
 class LogMainList(List):
     """Response to :meth:`~LogAPIMixIn.log_main`"""
 
-    def __init__(self, list_entries, client):
+    def __init__(self, list_entries, client=None):
         super(LogMainList, self).__init__(
-            client=client, entry_class=LogEntry, list_entries=list_entries
+            list_entries, entry_class=LogEntry, client=client
         )
 
 

--- a/src/qbittorrentapi/log.pyi
+++ b/src/qbittorrentapi/log.pyi
@@ -14,7 +14,7 @@ class LogPeersList(List[LogPeer]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: LogAPIMixIn,
+        client: Optional[LogAPIMixIn] = None,
     ) -> None: ...
 
 class LogEntry(ListEntry): ...
@@ -23,7 +23,7 @@ class LogMainList(List[LogEntry]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: LogAPIMixIn,
+        client: Optional[LogAPIMixIn] = None,
     ) -> None: ...
 
 class Log(ClientCache):

--- a/src/qbittorrentapi/search.py
+++ b/src/qbittorrentapi/search.py
@@ -44,9 +44,9 @@ class SearchResultsDictionary(Dictionary):
 class SearchStatusesList(List):
     """Response for :meth:`~SearchAPIMixIn.search_status`"""
 
-    def __init__(self, list_entries, client):
+    def __init__(self, list_entries, client=None):
         super(SearchStatusesList, self).__init__(
-            client=client, entry_class=SearchStatus, list_entries=list_entries
+            list_entries, entry_class=SearchStatus, client=client
         )
 
 
@@ -57,9 +57,9 @@ class SearchStatus(ListEntry):
 class SearchCategoriesList(List):
     """Response for :meth:`~SearchAPIMixIn.search_categories`"""
 
-    def __init__(self, list_entries, client):
+    def __init__(self, list_entries, client=None):
         super(SearchCategoriesList, self).__init__(
-            client=client, entry_class=SearchCategory, list_entries=list_entries
+            list_entries, entry_class=SearchCategory, client=client
         )
 
 
@@ -70,9 +70,9 @@ class SearchCategory(ListEntry):
 class SearchPluginsList(List):
     """Response for :meth:`~SearchAPIMixIn.search_plugins`"""
 
-    def __init__(self, list_entries, client):
+    def __init__(self, list_entries, client=None):
         super(SearchPluginsList, self).__init__(
-            client=client, entry_class=SearchPlugin, list_entries=list_entries
+            list_entries, entry_class=SearchPlugin, client=client
         )
 
 

--- a/src/qbittorrentapi/search.pyi
+++ b/src/qbittorrentapi/search.pyi
@@ -34,7 +34,7 @@ class SearchStatusesList(List[SearchStatus]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: SearchAPIMixIn,
+        client: Optional[SearchAPIMixIn] = None,
     ) -> None: ...
 
 class SearchCategory(ListEntry): ...
@@ -43,7 +43,7 @@ class SearchCategoriesList(List[SearchCategory]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: SearchAPIMixIn,
+        client: Optional[SearchAPIMixIn] = None,
     ) -> None: ...
 
 class SearchPlugin(ListEntry): ...
@@ -52,7 +52,7 @@ class SearchPluginsList(List[SearchPlugin]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: SearchAPIMixIn,
+        client: Optional[SearchAPIMixIn] = None,
     ) -> None: ...
 
 class Search(ClientCache):

--- a/src/qbittorrentapi/torrents.py
+++ b/src/qbittorrentapi/torrents.py
@@ -408,9 +408,9 @@ class TorrentsAddPeersDictionary(Dictionary):
 class TorrentFilesList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_files`"""
 
-    def __init__(self, list_entries, client):
+    def __init__(self, list_entries, client=None):
         super(TorrentFilesList, self).__init__(
-            client=client, entry_class=TorrentFile, list_entries=list_entries
+            list_entries, entry_class=TorrentFile, client=client
         )
         # until v4.3.5, the index key wasn't returned...default it to ID for older versions.
         # when index is returned, maintain backwards compatibility and populate id with index value.
@@ -425,9 +425,9 @@ class TorrentFile(ListEntry):
 class WebSeedsList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_webseeds`"""
 
-    def __init__(self, list_entries, client):
+    def __init__(self, list_entries, client=None):
         super(WebSeedsList, self).__init__(
-            client=client, entry_class=WebSeed, list_entries=list_entries
+            list_entries, entry_class=WebSeed, client=client
         )
 
 
@@ -438,9 +438,9 @@ class WebSeed(ListEntry):
 class TrackersList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_trackers`"""
 
-    def __init__(self, list_entries, client):
+    def __init__(self, list_entries, client=None):
         super(TrackersList, self).__init__(
-            client=client, entry_class=Tracker, list_entries=list_entries
+            list_entries, entry_class=Tracker, client=client
         )
 
 
@@ -451,9 +451,9 @@ class Tracker(ListEntry):
 class TorrentInfoList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_info`"""
 
-    def __init__(self, list_entries, client):
+    def __init__(self, list_entries, client=None):
         super(TorrentInfoList, self).__init__(
-            client=client, entry_class=TorrentDictionary, list_entries=list_entries
+            list_entries, entry_class=TorrentDictionary, client=client
         )
 
 
@@ -461,9 +461,9 @@ class TorrentPieceInfoList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_piece_states` and
     :meth:`~TorrentsAPIMixIn.torrents_piece_hashes`"""
 
-    def __init__(self, list_entries, client):
+    def __init__(self, list_entries, client=None):
         super(TorrentPieceInfoList, self).__init__(
-            client=client, entry_class=TorrentPieceData, list_entries=list_entries
+            list_entries, entry_class=TorrentPieceData, client=client
         )
 
 
@@ -474,10 +474,8 @@ class TorrentPieceData(ListEntry):
 class TagList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_tags`"""
 
-    def __init__(self, list_entries, client):
-        super(TagList, self).__init__(
-            client=client, entry_class=Tag, list_entries=list_entries
-        )
+    def __init__(self, list_entries, client=None):
+        super(TagList, self).__init__(list_entries, entry_class=Tag, client=client)
 
 
 class Tag(ListEntry):

--- a/src/qbittorrentapi/torrents.pyi
+++ b/src/qbittorrentapi/torrents.pyi
@@ -237,7 +237,7 @@ class TorrentFilesList(List[TorrentFile]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: TorrentsAPIMixIn,
+        client: Optional[TorrentsAPIMixIn] = None,
     ) -> None: ...
 
 class WebSeed(ListEntry): ...
@@ -246,7 +246,7 @@ class WebSeedsList(List[WebSeed]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: TorrentsAPIMixIn,
+        client: Optional[TorrentsAPIMixIn] = None,
     ) -> None: ...
 
 class Tracker(ListEntry): ...
@@ -255,14 +255,14 @@ class TrackersList(List[Tracker]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: TorrentsAPIMixIn,
+        client: Optional[TorrentsAPIMixIn] = None,
     ) -> None: ...
 
 class TorrentInfoList(List[TorrentDictionary]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: TorrentsAPIMixIn,
+        client: Optional[TorrentsAPIMixIn] = None,
     ) -> None: ...
 
 class TorrentPieceData(ListEntry): ...
@@ -271,7 +271,7 @@ class TorrentPieceInfoList(List[TorrentPieceData]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: TorrentsAPIMixIn,
+        client: Optional[TorrentsAPIMixIn] = None,
     ) -> None: ...
 
 class Tag(ListEntry): ...
@@ -280,7 +280,7 @@ class TagList(List[Tag]):
     def __init__(
         self,
         list_entries: ListInputT,
-        client: TorrentsAPIMixIn,
+        client: Optional[TorrentsAPIMixIn] = None,
     ) -> None: ...
 
 class Torrents(ClientCache):

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,3 +1,4 @@
+import sys
 from enum import Enum
 
 import pytest
@@ -155,10 +156,44 @@ def test_dictionary():
     assert Dictionary({"three": 3})["three"] == 3
 
 
-def test_list():
+def test_list(client):
     assert len(List()) == 0
-    list_entries = ({"one": "1"}, {"two": "2"}, {"three": "3"})
-    test_list = List(list_entries=list_entries, entry_class=ListEntry)
+    list_entries = [{"one": "1"}, {"two": "2"}, {"three": "3"}]
+    test_list = List(list_entries, entry_class=ListEntry, client=client)
     assert len(test_list) == 3
     assert issubclass(type(test_list[0]), ListEntry)
     assert test_list[0].one == "1"
+
+
+def test_list_without_client():
+    list_one = List([{"one": "1"}, {"two": "2"}], entry_class=ListEntry)
+    # without client, the entries will not be converted
+    assert not isinstance(list_one[0], ListEntry)
+    assert isinstance(list_one[0], dict)
+
+
+def test_list_actions(client):
+    list_one = List(
+        [{"one": "1"}, {"two": "2"}, {"three": "3"}],
+        entry_class=ListEntry,
+        client=client,
+    )
+    list_two = List([{"four": "4"}], entry_class=ListEntry, client=client)
+
+    assert list_one[1:3] == [
+        ListEntry({"two": "2"}, client=client),
+        ListEntry({"three": "3"}, client=client),
+    ]
+    assert list_one + list_two == [
+        ListEntry({"one": "1"}, client=client),
+        ListEntry({"two": "2"}, client=client),
+        ListEntry({"three": "3"}, client=client),
+    ] + [ListEntry({"four": "4"}, client=client)]
+
+    # UserList doesn't have copy in 2.7
+    if sys.version_info > (3,):
+        assert list_one.copy() == [
+            ListEntry({"one": "1"}, client=client),
+            ListEntry({"two": "2"}, client=client),
+            ListEntry({"three": "3"}, client=client),
+        ]

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from qbittorrentapi.log import LogMainList
@@ -30,6 +32,10 @@ def test_main(client, normal, info, warning, critical, last_known_id):
         ),
         LogMainList,
     )
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(
+            client.log.main(last_known_id=last_known_id)[1:2], LogMainList
+        )
     assert isinstance(client.log.main.info(last_known_id=last_known_id), LogMainList)
     assert isinstance(client.log.main.normal(last_known_id=last_known_id), LogMainList)
     assert isinstance(client.log.main.warning(last_known_id=last_known_id), LogMainList)
@@ -40,5 +46,9 @@ def test_main(client, normal, info, warning, critical, last_known_id):
 
 @pytest.mark.parametrize("last_known_id", (None, 0, 100000))
 def test_log_peers(client, last_known_id):
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(
+            client.log_peers(last_known_id=last_known_id)[1:2], LogPeersList
+        )
     assert isinstance(client.log_peers(last_known_id=last_known_id), LogPeersList)
     assert isinstance(client.log.peers(last_known_id=last_known_id), LogPeersList)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,9 +1,12 @@
+import sys
 from time import sleep
 
 import pytest
 
 from qbittorrentapi import NotFound404Error
+from qbittorrentapi.search import SearchCategoriesList
 from qbittorrentapi.search import SearchJobDictionary
+from qbittorrentapi.search import SearchPluginsList
 from qbittorrentapi.search import SearchResultsDictionary
 from qbittorrentapi.search import SearchStatusesList
 from tests.utils import check
@@ -55,6 +58,9 @@ def test_enable_plugin(client, client_func):
             plugins = get_func(client, client_func[0])()
         except TypeError:
             plugins = get_func(client, client_func[0])
+        assert isinstance(plugins, SearchPluginsList)
+        if sys.version_info < (3,) or sys.version_info >= (3, 7):
+            assert isinstance(plugins[1:2], SearchPluginsList)
         get_func(client, client_func[1])(
             plugins=(p["name"] for p in plugins), enable=False
         )
@@ -137,6 +143,9 @@ def test_install_uninstall_plugin_not_implemented(client, client_func):
 @pytest.mark.skipif_after_api_version("2.6")
 @pytest.mark.parametrize("client_func", ("search_categories", "search.categories"))
 def test_categories(client, client_func):
+    assert isinstance(get_func(client, client_func)(), SearchCategoriesList)
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(get_func(client, client_func)()[1:2], SearchCategoriesList)
     check(lambda: get_func(client, client_func)(), "All categories", reverse=True)
 
 
@@ -175,6 +184,8 @@ def test_search(client, client_func):
     assert statuses[0]["status"] == "Running"
     assert isinstance(job, SearchJobDictionary)
     assert isinstance(statuses, SearchStatusesList)
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(statuses[1:2], SearchStatusesList)
     results = get_func(client, client_func[2])(search_id=job["id"], limit=1)
     assert isinstance(results, SearchResultsDictionary)
     results = job.results()

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -1,7 +1,7 @@
 import errno
 import logging
 import platform
-from sys import version_info
+import sys
 from time import sleep
 
 try:
@@ -117,7 +117,7 @@ def test_add_delete(client, client_func):
         download_file(url=TORRENT1_URL, filename=TORRENT1_FILENAME)
         download_file(url=TORRENT2_URL, filename=TORRENT2_FILENAME)
         # send bytes as a proxy for testing python 2
-        kw = {} if version_info.major == 2 else dict(encoding="utf-8")
+        kw = {} if sys.version_info.major == 2 else dict(encoding="utf-8")
         files = ("~/%s" % TORRENT1_FILENAME, bytes("~/%s" % TORRENT2_FILENAME, **kw))
 
         if single:
@@ -196,7 +196,7 @@ def test_add_delete(client, client_func):
 
 def test_add_torrent_file_fail(client, monkeypatch):
     # torrent add is wonky in python2 because of support for raw bytes...
-    if version_info[0] > 2:
+    if sys.version_info[0] > 2:
         with pytest.raises(TorrentFileNotFoundError):
             client.torrents_add(torrent_files="/tmp/asdfasdfasdfasdf")
 
@@ -221,7 +221,7 @@ def test_close_file_fail(client, monkeypatch, caplog):
     def post(*args, **kwargs):
         return "OK"
 
-    if version_info[0] > 2:
+    if sys.version_info[0] > 2:
         with monkeypatch.context() as m:
             m.setattr(client, "_normalize_torrent_files", fake_norm_files)
             m.setattr(client, "_post", post)
@@ -338,16 +338,22 @@ def test_properties(client, orig_torrent):
 def test_trackers(client, orig_torrent):
     trackers = client.torrents_trackers(torrent_hash=orig_torrent.hash)
     assert isinstance(trackers, TrackersList)
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(trackers[1:2], TrackersList)
 
 
 def test_webseeds(client, orig_torrent):
     web_seeds = client.torrents_webseeds(torrent_hash=orig_torrent.hash)
     assert isinstance(web_seeds, WebSeedsList)
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(web_seeds[1:2], WebSeedsList)
 
 
 def test_files(client, orig_torrent):
     files = client.torrents_files(torrent_hash=orig_torrent.hash)
     assert isinstance(files, TorrentFilesList)
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(files[1:2], TorrentFilesList)
     assert "availability" in files[0]
 
     assert all(file["id"] == file["index"] for file in files)
@@ -359,6 +365,8 @@ def test_files(client, orig_torrent):
 def test_piece_states(client, orig_torrent, client_func):
     piece_states = get_func(client, client_func)(torrent_hash=orig_torrent.hash)
     assert isinstance(piece_states, TorrentPieceInfoList)
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(piece_states[1:2], TorrentPieceInfoList)
 
 
 @pytest.mark.parametrize(
@@ -367,6 +375,8 @@ def test_piece_states(client, orig_torrent, client_func):
 def test_piece_hashes(client, orig_torrent, client_func):
     piece_hashes = get_func(client, client_func)(torrent_hash=orig_torrent.hash)
     assert isinstance(piece_hashes, TorrentPieceInfoList)
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(piece_hashes[1:2], TorrentPieceInfoList)
 
 
 @pytest.mark.parametrize("trackers", ("127.0.0.1", ("127.0.0.2", "127.0.0.3")))
@@ -552,6 +562,8 @@ def test_export_not_implemented(client):
 @pytest.mark.parametrize("client_func", ("torrents_info", "torrents.info"))
 def test_torrents_info(client, client_func):
     assert isinstance(get_func(client, client_func)(), TorrentInfoList)
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(get_func(client, client_func)()[1:2], TorrentInfoList)
     if "." in client_func:
         assert isinstance(get_func(client, client_func).all(), TorrentInfoList)
         assert isinstance(get_func(client, client_func).downloading(), TorrentInfoList)
@@ -1274,8 +1286,12 @@ def test_remove_category(client, api_version, orig_torrent, client_func, categor
 def test_tags(client, client_func):
     try:
         assert isinstance(get_func(client, client_func)(), TagList)
+        if sys.version_info < (3,) or sys.version_info >= (3, 7):
+            assert isinstance(get_func(client, client_func)()[1:2], TagList)
     except TypeError:
         assert isinstance(get_func(client, client_func), TagList)
+        if sys.version_info < (3,) or sys.version_info >= (3, 7):
+            assert isinstance(get_func(client, client_func)[1:2], TagList)
 
 
 @pytest.mark.skipif_after_api_version("2.3.0")


### PR DESCRIPTION
## Changes
- `List`s, such as `TorrentInfoList`, will no longer bind the relevant `Client`
- This avoids problems when a `List` method creates a new instance such as when slicing or copying.