### PR TITLE
Bump pre-commit hook for ruff-pre-commit from v0.0.271 to v0.0.272

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -69,8 +69,10 @@ jobs:
         run: python -m pip install .[dev]
 
       - name: Update pre-commit hooks
+        id: update
         run: |
-          pre-commit autoupdate --repo ${{ matrix.hook-repo }}
+          pre-commit autoupdate --repo ${{ matrix.hook-repo }} | tee update.log
+          echo "vers-bump-str=$(grep -ohE '(v.* -> v.*)' update.log | sed 's/->/to/')" >> ${GITHUB_OUTPUT}
           pre-commit install-hooks
 
       - name: Run pre-commit
@@ -95,10 +97,10 @@ jobs:
         uses: peter-evans/create-pull-request@v5.0.1
         with:
           token: ${{ secrets.PAT }}
-          title: "Bump pre-commit hook for ${{ steps.pr.outputs.hook-name }}"
+          title: "Bump pre-commit hook for ${{ steps.pr.outputs.hook-name }} from ${{ steps.update.outputs.vers-bump-str }}"
           branch: "${{ env.BRANCH_PREFIX }}/${{ steps.pr.outputs.hook-name }}"
-          commit-message: "Bumped pre-commit hook for ${{ steps.pr.outputs.hook-name }}"
+          commit-message: "Bumped pre-commit hook for ${{ steps.pr.outputs.hook-name }} from ${{ steps.update.outputs.vers-bump-str }}"
           committer: "pre-commit updater <noreply@example.org>"
           author: "pre-commit updater <noreply@example.org>"
-          body: "Automatically bumped `pre-commit` hook for `${{ steps.pr.outputs.hook-name }}` and ran the update against the repo."
+          body: "Automatically bumped `pre-commit` hook for `${{ steps.pr.outputs.hook-name }}` from ${{ steps.update.outputs.vers-bump-str }} and ran the update against the repo."
           labels: "dependencies"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: [--in-place, --pre-summary-newline, --black, --non-cap=qBittorrent]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.272
+    rev: v0.0.271
     hooks:
       - id: ruff
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: [--in-place, --pre-summary-newline, --black, --non-cap=qBittorrent]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.271
+    rev: v0.0.272
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `ruff-pre-commit` from v0.0.271 to v0.0.272 and ran the update against the repo.