### PR TITLE
Bump pre-commit hook for isort from 5.11.5 to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.5
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `isort` from 5.11.5 to 5.12.0 and ran the update against the repo.