### PR TITLE
Tighten handling for boolean API inputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ on:
         type: string
 
 env:
-  DOCKER_IMAGE_NAME: "ghcr.io/rmartin16/qbittorrent-nox"
-  DOCKER_ARGS: "--name qbt --detach --publish 8080:8080 --volume ${{ github.workspace }}/tests/_resources:/tmp/_resources"
   FORCE_COLOR: "1"
 
 jobs:
@@ -44,6 +42,9 @@ jobs:
       QBITTORRENTAPI_USERNAME: "${{ inputs.qbittorrent-username }}"
       QBITTORRENTAPI_PASSWORD: "${{ inputs.qbittorrent-password }}"
       IS_QBT_DEV: ${{ inputs.is-qbt-dev }}
+      DOCKER_QBT_IMAGE_NAME: "ghcr.io/rmartin16/qbittorrent-nox"
+      DOCKER_QBT_IMAGE_TAG: "${{ inputs.qbittorrent-version }}-debug"
+      DOCKER_ARGS: "--name qbt-tox-testing --detach --publish 8080:8080 --volume ${{ github.workspace }}/tests/_resources:/tmp/_resources"
 
     steps:
       - name: Checkout Repo
@@ -65,10 +66,10 @@ jobs:
 
       - name: Start qBittorrent ${{ inputs.qbittorrent-version }}
         id: start-qbittorrent
-        run: docker run ${{ env.DOCKER_ARGS }} ${{ env.DOCKER_IMAGE_NAME }}:${{ inputs.qbittorrent-version }}-debug
+        run: docker run ${DOCKER_ARGS} ${DOCKER_QBT_IMAGE_NAME}:${DOCKER_QBT_IMAGE_TAG}
 
       - name: qBittorrent Build Commits
-        run: docker exec qbt /bin/sh -c "tail -n+1 /build_commit.*"
+        run: docker exec qbt-tox-testing /bin/sh -c "tail -n+1 /build_commit.*"
 
       - name: Install
         run: |
@@ -77,7 +78,7 @@ jobs:
 
       - name: Test
         if: ${{ !contains(fromJSON('["3.6", "3.5", "2.7", "pypy2.7"]'), inputs.python-version) }}
-        run: tox -e py --installpkg dist/qbittorrent_api-*.whl
+        run: tox -e py-ci --installpkg dist/qbittorrent_api-*.whl
 
       - name: Test (legacy)
         if: contains(fromJSON('["3.6", "3.5", "2.7", "pypy2.7"]'), inputs.python-version)
@@ -85,7 +86,7 @@ jobs:
 
       - name: qBittorrent Log
         if: (steps.start-qbittorrent.outcome == 'success') && (success() || failure())
-        run: docker logs qbt
+        run: docker logs qbt-tox-testing
 
       - name: Store coverage data
         if: success() || failure()

--- a/src/qbittorrentapi/log.py
+++ b/src/qbittorrentapi/log.py
@@ -77,10 +77,10 @@ class Log(ClientCache):
 
         def __call__(
             self,
-            normal=None,
-            info=None,
-            warning=None,
-            critical=None,
+            normal=True,
+            info=True,
+            warning=True,
+            critical=True,
             last_known_id=None,
             **kwargs
         ):
@@ -88,7 +88,7 @@ class Log(ClientCache):
                 normal=normal,
                 info=info,
                 warning=warning,
-                critial=critical,
+                critical=critical,
                 last_known_id=last_known_id,
                 **kwargs
             )
@@ -157,17 +157,17 @@ class LogAPIMixIn(AppAPIMixIn):
         :param last_known_id: only entries with an ID greater than this value will be returned
         :return: :class:`LogMainList`
         """
-        parameters = {
-            "normal": normal,
-            "info": info,
-            "warning": warning,
-            "critical": critical,
+        params = {
+            "normal": None if normal is None else bool(normal),
+            "info": None if info is None else bool(info),
+            "warning": None if warning is None else bool(warning),
+            "critical": None if critical is None else bool(critical),
             "last_known_id": last_known_id,
         }
         return self._get(
             _name=APINames.Log,
             _method="main",
-            params=parameters,
+            params=params,
             response_class=LogMainList,
             **kwargs
         )
@@ -180,11 +180,11 @@ class LogAPIMixIn(AppAPIMixIn):
         :param last_known_id: only entries with an ID greater than this value will be returned
         :return: :class:`LogPeersList`
         """
-        parameters = {"last_known_id": last_known_id}
+        params = {"last_known_id": last_known_id}
         return self._get(
             _name=APINames.Log,
             _method="peers",
-            params=parameters,
+            params=params,
             response_class=LogPeersList,
             **kwargs
         )

--- a/src/qbittorrentapi/log.pyi
+++ b/src/qbittorrentapi/log.pyi
@@ -47,10 +47,10 @@ class Log(ClientCache):
         ) -> LogMainList: ...
         def __call__(
             self,
-            normal: Optional[bool] = None,
-            info: Optional[bool] = None,
-            warning: Optional[bool] = None,
-            critical: Optional[bool] = None,
+            normal: Optional[bool] = True,
+            info: Optional[bool] = True,
+            warning: Optional[bool] = True,
+            critical: Optional[bool] = True,
             last_known_id: Optional[bool] = None,
             **kwargs: KwargsT
         ) -> LogMainList: ...

--- a/src/qbittorrentapi/rss.py
+++ b/src/qbittorrentapi/rss.py
@@ -230,7 +230,9 @@ class RSSAPIMixIn(AppAPIMixIn):
         :param include_feed_data: True or false to include feed data
         :return: :class:`RSSitemsDictionary`
         """
-        params = {"withData": include_feed_data}
+        params = {
+            "withData": None if include_feed_data is None else bool(include_feed_data)
+        }
         return self._get(
             _name=APINames.RSS,
             _method="items",

--- a/src/qbittorrentapi/search.py
+++ b/src/qbittorrentapi/search.py
@@ -353,10 +353,13 @@ class SearchAPIMixIn(AppAPIMixIn):
         Enable or disable search plugin(s).
 
         :param plugins: list of plugin names
-        :param enable: True or False
+        :param enable: Defaults to ``True`` if ``None`` or unset; use ``False`` to disable
         :return: None
         """
-        data = {"names": self._list2string(plugins, "|"), "enable": enable}
+        data = {
+            "names": self._list2string(plugins, "|"),
+            "enable": True if enable is None else bool(enable),
+        }
         self._post(_name=APINames.Search, _method="enablePlugin", data=data, **kwargs)
 
     @endpoint_introduced("2.1.1", "search/updatePlugin")

--- a/src/qbittorrentapi/torrents.py
+++ b/src/qbittorrentapi/torrents.py
@@ -1844,7 +1844,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         """
         data = {
             "hashes": self._list2string(torrent_hashes, "|"),
-            "deleteFiles": delete_files,
+            "deleteFiles": bool(delete_files),
         }
         self._post(_name=APINames.Torrents, _method="delete", data=data, **kwargs)
 
@@ -2126,12 +2126,12 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         Enable or disable automatic torrent management for one or more torrents.
 
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or ``all`` for all torrents.
-        :param enable: True or False
+        :param enable: Defaults to ``True`` if ``None`` or unset; use ``False`` to disable
         :return: None
         """
         data = {
             "hashes": self._list2string(torrent_hashes, "|"),
-            "enable": enable,
+            "enable": True if enable is None else bool(enable),
         }
         self._post(
             _name=APINames.Torrents, _method="setAutoManagement", data=data, **kwargs
@@ -2181,12 +2181,13 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         Force start one or more torrents.
 
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or ``all`` for all torrents.
-        :param enable: True or False (False makes this equivalent to torrents_resume())
+        :param enable: Defaults to ``True`` if ``None`` or unset; ``False`` is equivalent to
+            :meth:`~TorrentsAPIMixIn.torrents_resume()`.
         :return: None
         """
         data = {
             "hashes": self._list2string(torrent_hashes, "|"),
-            "value": enable,
+            "value": True if enable is None else bool(enable),
         }
         self._post(
             _name=APINames.Torrents, _method="setForceStart", data=data, **kwargs
@@ -2200,12 +2201,12 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         Set one or more torrents as super seeding.
 
         :param torrent_hashes: single torrent hash or list of torrent hashes. Or ``all`` for all torrents.
-        :param enable: True or False
+        :param enable: Defaults to ``True`` if ``None`` or unset; ``False`` to disable
         :return:
         """
         data = {
             "hashes": self._list2string(torrent_hashes, "|"),
-            "value": enable,
+            "value": True if enable is None else bool(enable),
         }
         self._post(
             _name=APINames.Torrents, _method="setSuperSeeding", data=data, **kwargs

--- a/src/qbittorrentapi/torrents.pyi
+++ b/src/qbittorrentapi/torrents.pyi
@@ -754,7 +754,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
     ) -> None: ...
     def torrents_delete(
         self,
-        delete_files: bool = False,
+        delete_files: Optional[bool] = False,
         torrent_hashes: Optional[Iterable[Text]] = None,
         **kwargs: KwargsT
     ) -> None: ...

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,6 +13,7 @@ def test_version(client, app_version):
 @pytest.mark.skipif(IS_QBT_DEV, reason="testing devel version of qBittorrent")
 def test_web_api_version(client, api_version):
     assert client.app_web_api_version() == api_version
+    assert client.app_webapiVersion() == api_version
     assert client.app.web_api_version == api_version
     assert client.application.web_api_version == api_version
 
@@ -20,6 +21,7 @@ def test_web_api_version(client, api_version):
 @pytest.mark.skipif_before_api_version("2.3")
 def test_build_info(client):
     assert "libtorrent" in client.app_build_info()
+    assert "libtorrent" in client.app_buildInfo()
     assert "libtorrent" in client.app.build_info
 
 
@@ -44,4 +46,5 @@ def test_preferences(client):
 
 def test_default_save_path(client):
     assert "download" in client.app_default_save_path().lower()
+    assert "download" in client.app_defaultSavePath().lower()
     assert "download" in client.app.default_save_path.lower()

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -2,53 +2,146 @@ import sys
 
 import pytest
 
+from qbittorrentapi.definitions import APINames
 from qbittorrentapi.log import LogMainList
 from qbittorrentapi.log import LogPeersList
 
 
-@pytest.mark.parametrize("normal", (True, False))
-@pytest.mark.parametrize("info", (True, False))
-@pytest.mark.parametrize("warning", (True, False))
-@pytest.mark.parametrize("critical", (True, False))
-@pytest.mark.parametrize("last_known_id", (None, 0, 100000))
-def test_main(client, normal, info, warning, critical, last_known_id):
-    assert isinstance(
-        client.log_main(
-            normal=normal,
-            info=info,
-            warning=warning,
-            critical=critical,
-            last_known_id=last_known_id,
-        ),
-        LogMainList,
-    )
-    assert isinstance(
-        client.log.main(
-            normal=normal,
-            info=info,
-            warning=warning,
-            critical=critical,
-            last_known_id=last_known_id,
-        ),
-        LogMainList,
-    )
+@pytest.mark.parametrize("main_func", ["log_main", "log.main"])
+@pytest.mark.parametrize("last_known_id", (None, 0))
+def test_log_main_id(client, main_func, last_known_id):
+    log_main = client.func(main_func)(last_known_id=last_known_id)
+    assert isinstance(log_main, LogMainList)
+
+    last_id = log_main[-1].id if log_main else 0
+    log_main = client.func(main_func)(last_known_id=last_id)
+    assert isinstance(log_main, LogMainList)
+    assert not log_main or log_main[-1].id != last_id
+
+
+@pytest.mark.parametrize("main_func", ["log_main", "log.main"])
+def test_log_main_large_id(client, main_func):
+    assert client.func(main_func)(last_known_id=99999999) == []
+
+
+@pytest.mark.parametrize("main_func", ["log_main", "log.main"])
+def test_log_main_slice(client, main_func):
     if sys.version_info < (3,) or sys.version_info >= (3, 7):
-        assert isinstance(
-            client.log.main(last_known_id=last_known_id)[1:2], LogMainList
-        )
-    assert isinstance(client.log.main.info(last_known_id=last_known_id), LogMainList)
-    assert isinstance(client.log.main.normal(last_known_id=last_known_id), LogMainList)
-    assert isinstance(client.log.main.warning(last_known_id=last_known_id), LogMainList)
-    assert isinstance(
-        client.log.main.critical(last_known_id=last_known_id), LogMainList
+        assert isinstance(client.func(main_func)()[1:2], LogMainList)
+    else:
+        assert isinstance(client.func(main_func)()[1:2], list)
+
+
+def test_log_main_info(client):
+    assert isinstance(client.log.main.info(), LogMainList)
+    client._get.assert_called_with(
+        _name=APINames.Log,
+        _method="main",
+        params={
+            "info": None,
+            "normal": None,
+            "warning": None,
+            "critical": None,
+            "last_known_id": None,
+        },
+        response_class=LogMainList,
     )
 
 
-@pytest.mark.parametrize("last_known_id", (None, 0, 100000))
-def test_log_peers(client, last_known_id):
+def test_log_main_normal(client):
+    assert isinstance(client.log.main.normal(), LogMainList)
+    client._get.assert_called_with(
+        _name=APINames.Log,
+        _method="main",
+        params={
+            "info": False,
+            "normal": None,
+            "warning": None,
+            "critical": None,
+            "last_known_id": None,
+        },
+        response_class=LogMainList,
+    )
+
+
+def test_log_main_warning(client):
+    assert isinstance(client.log.main.warning(), LogMainList)
+    client._get.assert_called_with(
+        _name=APINames.Log,
+        _method="main",
+        params={
+            "info": False,
+            "normal": False,
+            "warning": None,
+            "critical": None,
+            "last_known_id": None,
+        },
+        response_class=LogMainList,
+    )
+
+
+def test_log_main_critical(client):
+    assert isinstance(client.log.main.critical(), LogMainList)
+    client._get.assert_called_with(
+        _name=APINames.Log,
+        _method="main",
+        params={
+            "info": False,
+            "normal": False,
+            "warning": False,
+            "critical": None,
+            "last_known_id": None,
+        },
+        response_class=LogMainList,
+    )
+
+
+@pytest.mark.parametrize("main_func", ["log_main", "log.main"])
+@pytest.mark.parametrize("include_level", (True, False, None, 1, 0))
+def test_log_main_levels(client, main_func, include_level):
+    client.func(main_func)(
+        normal=include_level,
+        info=include_level,
+        warning=include_level,
+        critical=include_level,
+    )
+
+    actual_include = None if include_level is None else bool(include_level)
+    client._get.assert_called_with(
+        _name=APINames.Log,
+        _method="main",
+        params={
+            "normal": actual_include,
+            "info": actual_include,
+            "warning": actual_include,
+            "critical": actual_include,
+            "last_known_id": None,
+        },
+        response_class=LogMainList,
+    )
+
+
+@pytest.mark.parametrize("peers_func", ["log_peers", "log.peers"])
+@pytest.mark.parametrize("last_known_id", (None, 0))
+def test_log_peers_id(client, peers_func, last_known_id):
+    log_peers = client.func(peers_func)(last_known_id=last_known_id)
+    assert isinstance(log_peers, LogPeersList)
+
+    last_id = log_peers[-1].id if log_peers else 0
+    log_peers = client.func(peers_func)(last_known_id=last_id)
+    assert isinstance(log_peers, LogPeersList)
+    assert not log_peers or log_peers[-1].id != last_id
+
+
+@pytest.mark.parametrize("peers_func", ["log_peers", "log.peers"])
+def test_log_peers(client, peers_func):
+    assert client.func(peers_func)(last_known_id=99999999) == []
+    assert client.func(peers_func)(last_known_id=99999999) == []
+
+
+@pytest.mark.parametrize("peers_func", ["log_peers", "log.peers"])
+def test_log_peers_slice(client, peers_func):
     if sys.version_info < (3,) or sys.version_info >= (3, 7):
-        assert isinstance(
-            client.log_peers(last_known_id=last_known_id)[1:2], LogPeersList
-        )
-    assert isinstance(client.log_peers(last_known_id=last_known_id), LogPeersList)
-    assert isinstance(client.log.peers(last_known_id=last_known_id), LogPeersList)
+        assert isinstance(client.func(peers_func)()[1:2], LogPeersList)
+    else:
+        assert isinstance(client.func(peers_func)()[1:2], list)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -4,27 +4,28 @@ from qbittorrentapi.sync import SyncMainDataDictionary
 from qbittorrentapi.sync import SyncTorrentPeersDictionary
 
 
-@pytest.mark.parametrize("rid", (None, 0, 1, 100000))
-def test_maindata1(client, rid):
-    assert isinstance(client.sync_maindata(rid=rid), SyncMainDataDictionary)
+@pytest.mark.parametrize("maindata_func", ["sync_maindata", "sync.maindata"])
+@pytest.mark.parametrize("rid", [None, 0, 1, 100000])
+def test_sync_maindata(client, maindata_func, rid):
+    assert isinstance(client.func(maindata_func)(rid=rid), SyncMainDataDictionary)
 
 
 @pytest.mark.parametrize("rid", (None, 0, 1, 100000))
-def test_maindata2(client, rid):
+def test_sync_maindata_delta(client, rid):
     assert isinstance(client.sync.maindata(rid=rid), SyncMainDataDictionary)
     assert isinstance(client.sync.maindata.delta(), SyncMainDataDictionary)
     assert isinstance(client.sync.maindata.delta(), SyncMainDataDictionary)
 
 
-def test_maindata3(client):
-    client.sync.maindata()
+def test_sync_maindata_reset(client):
+    client.sync.maindata.delta()
     assert client.sync.maindata._rid != 0
     client.sync.maindata.reset_rid()
     assert client.sync.maindata._rid == 0
 
 
 @pytest.mark.parametrize("rid", (None, 0, 1, 100000))
-def test_torrent_peers(client, rid, orig_torrent):
+def test_sync_torrent_peers(client, rid, orig_torrent):
     assert isinstance(
         client.sync_torrent_peers(rid=rid, torrent_hash=orig_torrent.hash),
         SyncTorrentPeersDictionary,
@@ -33,7 +34,6 @@ def test_torrent_peers(client, rid, orig_torrent):
         client.sync.torrent_peers(rid=rid, torrent_hash=orig_torrent.hash),
         SyncTorrentPeersDictionary,
     )
-
     assert isinstance(
         client.sync.torrent_peers.delta(torrent_hash=orig_torrent.hash),
         SyncTorrentPeersDictionary,

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -39,7 +39,6 @@ from tests.conftest import TORRENT2_HASH
 from tests.conftest import TORRENT2_URL
 from tests.conftest import new_torrent_standalone
 from tests.utils import check
-from tests.utils import get_func
 from tests.utils import mkpath
 from tests.utils import retry
 
@@ -57,10 +56,10 @@ def enable_queueing(client):
 # something was wrong with torrents_add on v2.0.0 (the initial version)
 @pytest.mark.skipif_before_api_version("2.0.1")
 @pytest.mark.parametrize(
-    "client_func",
-    (("torrents_add", "torrents_delete"), ("torrents.add", "torrents.delete")),
+    "add_func, delete_func",
+    [("torrents_add", "torrents_delete"), ("torrents.add", "torrents.delete")],
 )
-def test_add_delete(client, client_func):
+def test_add_delete(client, add_func, delete_func, tmp_path):
     def download_file(url, filename=None, return_bytes=False):
         max_attempts = 3
         for attempt in range(max_attempts):
@@ -69,7 +68,7 @@ def test_add_delete(client, client_func):
                     r.raise_for_status()
                     if return_bytes:
                         return r.content
-                    with open(mkpath("~/%s" % filename), "wb") as f:
+                    with open(mkpath(tmp_path, filename), "wb") as f:
                         for chunk in r.iter_content(chunk_size=1024):
                             f.write(chunk)
             except Exception if attempt < (max_attempts - 1) else ZeroDivisionError:
@@ -79,12 +78,8 @@ def test_add_delete(client, client_func):
         raise Exception("Download failed: %s" % url)
 
     def delete():
-        get_func(client, client_func[1])(
-            delete_files=True, torrent_hashes=TORRENT1_HASH
-        )
-        get_func(client, client_func[1])(
-            delete_files=True, torrent_hashes=TORRENT2_HASH
-        )
+        client.func(delete_func)(delete_files=True, torrent_hashes=TORRENT1_HASH)
+        client.func(delete_func)(delete_files=True, torrent_hashes=TORRENT2_HASH)
         check(
             lambda: [t.hash for t in client.torrents_info()],
             TORRENT2_HASH,
@@ -118,12 +113,15 @@ def test_add_delete(client, client_func):
         download_file(url=TORRENT2_URL, filename=TORRENT2_FILENAME)
         # send bytes as a proxy for testing python 2
         kw = {} if sys.version_info.major == 2 else dict(encoding="utf-8")
-        files = ("~/%s" % TORRENT1_FILENAME, bytes("~/%s" % TORRENT2_FILENAME, **kw))
+        files = (
+            mkpath(tmp_path, TORRENT1_FILENAME),
+            bytes(mkpath(tmp_path, TORRENT2_FILENAME), **kw),
+        )
 
         if single:
-            assert get_func(client, client_func[0])(torrent_files=files[0]) == "Ok."
+            assert client.func(add_func)(torrent_files=files[0]) == "Ok."
         else:
-            assert get_func(client, client_func[0])(torrent_files=files) == "Ok."
+            assert client.func(add_func)(torrent_files=files) == "Ok."
 
     @check_torrents_added
     def add_by_filename_dict(single):
@@ -132,31 +130,33 @@ def test_add_delete(client, client_func):
 
         if single:
             assert (
-                get_func(client, client_func[0])(
-                    torrent_files={TORRENT1_FILENAME: "~/%s" % TORRENT1_FILENAME}
+                client.func(add_func)(
+                    torrent_files={
+                        TORRENT1_FILENAME: mkpath(tmp_path, TORRENT1_FILENAME)
+                    }
                 )
                 == "Ok."
             )
         else:
             files = {
-                TORRENT1_FILENAME: "~/%s" % TORRENT1_FILENAME,
-                TORRENT2_FILENAME: "~/%s" % TORRENT2_FILENAME,
+                TORRENT1_FILENAME: mkpath(tmp_path, TORRENT1_FILENAME),
+                TORRENT2_FILENAME: mkpath(tmp_path, TORRENT2_FILENAME),
             }
-            assert get_func(client, client_func[0])(torrent_files=files) == "Ok."
+            assert client.func(add_func)(torrent_files=files) == "Ok."
 
     @check_torrents_added
     def add_by_filehandles(single):
         download_file(url=TORRENT1_URL, filename=TORRENT1_FILENAME)
         download_file(url=TORRENT2_URL, filename=TORRENT2_FILENAME)
         files = (
-            open(mkpath("~/" + TORRENT1_FILENAME), "rb"),
-            open(mkpath("~/" + TORRENT2_FILENAME), "rb"),
+            open(mkpath(tmp_path, TORRENT1_FILENAME), "rb"),
+            open(mkpath(tmp_path, TORRENT2_FILENAME), "rb"),
         )
 
         if single:
-            assert get_func(client, client_func[0])(torrent_files=files[0]) == "Ok."
+            assert client.func(add_func)(torrent_files=files[0]) == "Ok."
         else:
-            assert get_func(client, client_func[0])(torrent_files=files) == "Ok."
+            assert client.func(add_func)(torrent_files=files) == "Ok."
 
         for file in files:
             file.close()
@@ -169,18 +169,18 @@ def test_add_delete(client, client_func):
         )
 
         if single:
-            assert get_func(client, client_func[0])(torrent_files=files[0]) == "Ok."
+            assert client.func(add_func)(torrent_files=files[0]) == "Ok."
         else:
-            assert get_func(client, client_func[0])(torrent_files=files) == "Ok."
+            assert client.func(add_func)(torrent_files=files) == "Ok."
 
     @check_torrents_added
     def add_by_url(single):
         urls = (TORRENT1_URL, TORRENT2_URL)
 
         if single:
-            get_func(client, client_func[0])(urls=urls[0])
+            client.func(add_func)(urls=urls[0])
         else:
-            get_func(client, client_func[0])(urls=urls)
+            client.func(add_func)(urls=urls)
 
     add_by_filename(single=False)
     add_by_filename(single=True)
@@ -230,18 +230,18 @@ def test_close_file_fail(client, monkeypatch, caplog):
                 assert "Failed to close file" in caplog.text
 
 
-@pytest.mark.parametrize("keep_root_folder", (True, False, None))
+@pytest.mark.parametrize("keep_root_folder", [True, False, None])
 @pytest.mark.parametrize(
-    "content_layout", (None, "Original", "Subfolder", "NoSubfolder")
+    "content_layout", [None, "Original", "Subfolder", "NoSubfolder"]
 )
-def test_add_options(client, api_version, keep_root_folder, content_layout):
+def test_add_options(client, api_version, keep_root_folder, content_layout, tmp_path):
     if v(api_version) >= v("2.3.0"):
         client.torrents_create_tags("option-tag")
     new_torrent = new_torrent_standalone(
         client=client,
         torrent_files=ROOT_FOLDER_TORRENT_FILE,
         torrent_hash=ROOT_FOLDER_TORRENT_HASH,
-        save_path=mkpath("~/test_download/"),
+        save_path=mkpath(tmp_path, "test_download"),
         category="test_category",
         is_paused=True,
         upload_limit=1024,
@@ -265,7 +265,7 @@ def test_add_options(client, api_version, keep_root_folder, content_layout):
             reverse=True,
             any=True,
         )
-        check(lambda: mkpath(torrent.info.save_path), mkpath("~/test_download/"))
+        check(lambda: mkpath(torrent.info.save_path), mkpath(tmp_path, "test_download"))
         check(lambda: torrent.info.up_limit, 1024)
         check(lambda: torrent.info.dl_limit, 2048)
         check(lambda: torrent.info.seq_dl, True)
@@ -304,11 +304,11 @@ def test_add_options(client, api_version, keep_root_folder, content_layout):
 
 
 @pytest.mark.skipif_before_api_version("2.8.4")
-@pytest.mark.parametrize("use_download_path", (None, True, False))
-def test_torrents_add_download_path(client, use_download_path):
+@pytest.mark.parametrize("use_download_path", [None, True, False])
+def test_torrents_add_download_path(client, use_download_path, tmp_path):
     client.torrents_delete(torrent_hashes=ROOT_FOLDER_TORRENT_HASH, delete_files=True)
-    save_path = mkpath("/tmp", "down_path_save_path_test")
-    download_path = mkpath("/tmp", "down_path_test")
+    save_path = mkpath(tmp_path, "down_path_save_path_test")
+    download_path = mkpath(tmp_path, "down_path_test")
     new_torrent = new_torrent_standalone(
         client=client,
         torrent_hash=ROOT_FOLDER_TORRENT_HASH,
@@ -327,8 +327,6 @@ def test_torrents_add_download_path(client, use_download_path):
         else:
             check(lambda: mkpath(torrent.info.download_path), download_path)
 
-    # client.torrents_delete(torrent_hashes=ROOT_FOLDER_TORRENT_HASH, delete_files=True)
-
 
 def test_properties(client, orig_torrent):
     props = client.torrents_properties(torrent_hash=orig_torrent.hash)
@@ -338,96 +336,123 @@ def test_properties(client, orig_torrent):
 def test_trackers(client, orig_torrent):
     trackers = client.torrents_trackers(torrent_hash=orig_torrent.hash)
     assert isinstance(trackers, TrackersList)
+
+
+def test_trackers_slice(client, orig_torrent):
+    trackers = client.torrents_trackers(torrent_hash=orig_torrent.hash)
     if sys.version_info < (3,) or sys.version_info >= (3, 7):
         assert isinstance(trackers[1:2], TrackersList)
+    else:
+        assert isinstance(trackers[1:2], list)
 
 
 def test_webseeds(client, orig_torrent):
     web_seeds = client.torrents_webseeds(torrent_hash=orig_torrent.hash)
     assert isinstance(web_seeds, WebSeedsList)
+
+
+def test_webseeds_slice(client, orig_torrent):
+    web_seeds = client.torrents_webseeds(torrent_hash=orig_torrent.hash)
     if sys.version_info < (3,) or sys.version_info >= (3, 7):
         assert isinstance(web_seeds[1:2], WebSeedsList)
+    else:
+        assert isinstance(web_seeds[1:2], list)
 
 
 def test_files(client, orig_torrent):
     files = client.torrents_files(torrent_hash=orig_torrent.hash)
     assert isinstance(files, TorrentFilesList)
-    if sys.version_info < (3,) or sys.version_info >= (3, 7):
-        assert isinstance(files[1:2], TorrentFilesList)
     assert "availability" in files[0]
-
     assert all(file["id"] == file["index"] for file in files)
 
 
+def test_files_slice(client, orig_torrent):
+    files = client.torrents_files(torrent_hash=orig_torrent.hash)
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(files[1:2], TorrentFilesList)
+    else:
+        assert isinstance(files[1:2], list)
+
+
 @pytest.mark.parametrize(
-    "client_func", ("torrents_piece_states", "torrents_pieceStates")
+    "piece_state_func", ["torrents_piece_states", "torrents_pieceStates"]
 )
-def test_piece_states(client, orig_torrent, client_func):
-    piece_states = get_func(client, client_func)(torrent_hash=orig_torrent.hash)
+def test_piece_states(client, orig_torrent, piece_state_func):
+    piece_states = client.func(piece_state_func)(torrent_hash=orig_torrent.hash)
     assert isinstance(piece_states, TorrentPieceInfoList)
+
+
+def test_piece_states_slice(client, orig_torrent):
+    piece_states = client.torrents_piece_states(torrent_hash=orig_torrent.hash)
     if sys.version_info < (3,) or sys.version_info >= (3, 7):
         assert isinstance(piece_states[1:2], TorrentPieceInfoList)
+    else:
+        assert isinstance(piece_states[1:2], list)
 
 
 @pytest.mark.parametrize(
-    "client_func", ("torrents_piece_hashes", "torrents_pieceHashes")
+    "piece_hashes_func", ["torrents_piece_hashes", "torrents_pieceHashes"]
 )
-def test_piece_hashes(client, orig_torrent, client_func):
-    piece_hashes = get_func(client, client_func)(torrent_hash=orig_torrent.hash)
+def test_piece_hashes(client, orig_torrent, piece_hashes_func):
+    piece_hashes = client.func(piece_hashes_func)(torrent_hash=orig_torrent.hash)
     assert isinstance(piece_hashes, TorrentPieceInfoList)
+
+
+def test_piece_hashes_slice(client, orig_torrent):
+    piece_hashes = client.torrents_piece_hashes(torrent_hash=orig_torrent.hash)
     if sys.version_info < (3,) or sys.version_info >= (3, 7):
         assert isinstance(piece_hashes[1:2], TorrentPieceInfoList)
+    else:
+        assert isinstance(piece_hashes[1:2], list)
 
 
-@pytest.mark.parametrize("trackers", ("127.0.0.1", ("127.0.0.2", "127.0.0.3")))
+@pytest.mark.parametrize("trackers", ["127.0.0.1", ["127.0.0.2", "127.0.0.3"]])
 @pytest.mark.parametrize(
-    "client_func", ("torrents_add_trackers", "torrents_addTrackers")
+    "add_trackers_func", ["torrents_add_trackers", "torrents_addTrackers"]
 )
-def test_add_trackers(client, trackers, client_func, new_torrent):
-    get_func(client, client_func)(torrent_hash=new_torrent.hash, urls=trackers)
+def test_add_trackers(client, trackers, new_torrent, add_trackers_func):
+    client.func(add_trackers_func)(torrent_hash=new_torrent.hash, urls=trackers)
     check(lambda: (t.url for t in new_torrent.trackers), trackers, reverse=True)
 
 
 @pytest.mark.skipif_before_api_version("2.2.0")
 @pytest.mark.parametrize(
-    "client_func", ("torrents_edit_tracker", "torrents_editTracker")
+    "edit_trackers_func", ["torrents_edit_tracker", "torrents_editTracker"]
 )
-def test_edit_tracker(client, client_func, orig_torrent):
+def test_edit_tracker(client, orig_torrent, edit_trackers_func):
     orig_torrent.add_trackers("127.1.0.1")
-    get_func(client, client_func)(
+    client.func(edit_trackers_func)(
         torrent_hash=orig_torrent.hash,
         original_url="127.1.0.1",
         new_url="127.1.0.2",
     )
     check(lambda: (t.url for t in orig_torrent.trackers), "127.1.0.2", reverse=True)
-    get_func(client, "torrents_remove_trackers")(
-        torrent_hash=orig_torrent.hash, urls="127.1.0.2"
-    )
+    client.torrents_remove_trackers(torrent_hash=orig_torrent.hash, urls="127.1.0.2")
 
 
 @pytest.mark.skipif_after_api_version("2.2.0")
 @pytest.mark.parametrize(
-    "client_func", ("torrents_edit_tracker", "torrents_editTracker")
+    "edit_trackers_func", ["torrents_edit_tracker", "torrents_editTracker"]
 )
-def test_edit_tracker_not_implemented(client, client_func, orig_torrent):
+def test_edit_tracker_not_implemented(client, orig_torrent, edit_trackers_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(edit_trackers_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.2.0")
 @pytest.mark.parametrize(
     "trackers",
-    (
-        ("127.2.0.1",),
-        ("127.2.0.2", "127.2.0.3"),
-    ),
+    [
+        ["127.2.0.1"],
+        ["127.2.0.2", "127.2.0.3"],
+    ],
 )
 @pytest.mark.parametrize(
-    "client_func", ("torrents_remove_trackers", "torrents_removeTrackers")
+    "remove_trackers_func", ["torrents_remove_trackers", "torrents_removeTrackers"]
 )
-def test_remove_trackers(client, trackers, client_func, orig_torrent):
+def test_remove_trackers(client, trackers, orig_torrent, remove_trackers_func):
     orig_torrent.add_trackers(trackers)
-    get_func(client, client_func)(torrent_hash=orig_torrent.hash, urls=trackers)
+    client.func(remove_trackers_func)(torrent_hash=orig_torrent.hash, urls=trackers)
     check(
         lambda: (t.url for t in orig_torrent.trackers),
         trackers,
@@ -438,53 +463,53 @@ def test_remove_trackers(client, trackers, client_func, orig_torrent):
 
 @pytest.mark.skipif_after_api_version("2.2.0")
 @pytest.mark.parametrize(
-    "client_func", ("torrents_remove_trackers", "torrents_removeTrackers")
+    "remove_trackers_func", ["torrents_remove_trackers", "torrents_removeTrackers"]
 )
-def test_remove_trackers_not_implemented(client, client_func, orig_torrent):
+def test_remove_trackers_not_implemented(client, orig_torrent, remove_trackers_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(remove_trackers_func)()
 
 
-@pytest.mark.parametrize("client_func", ("torrents_file_priority", "torrents_filePrio"))
-def test_file_priority(client, orig_torrent, client_func):
-    get_func(client, client_func)(
-        torrent_hash=orig_torrent.hash, file_ids=0, priority=6
-    )
+@pytest.mark.parametrize(
+    "file_prio_func", ["torrents_file_priority", "torrents_filePrio"]
+)
+def test_file_priority(client, orig_torrent, file_prio_func):
+    client.func(file_prio_func)(torrent_hash=orig_torrent.hash, file_ids=0, priority=6)
     check(lambda: orig_torrent.files[0].priority, 6)
-    get_func(client, client_func)(
-        torrent_hash=orig_torrent.hash, file_ids=0, priority=7
-    )
+    client.func(file_prio_func)(torrent_hash=orig_torrent.hash, file_ids=0, priority=7)
     check(lambda: orig_torrent.files[0].priority, 7)
 
 
-@pytest.mark.parametrize("new_name", ("new name 2", "new_name_2"))
+@pytest.mark.parametrize("new_name", ["new name 2", "new_name_2"])
 def test_rename(client, new_torrent, new_name):
     client.torrents_rename(torrent_hash=new_torrent.hash, new_torrent_name=new_name)
     check(lambda: new_torrent.info.name.replace("+", " "), new_name)
 
 
 @pytest.mark.skipif_before_api_version("2.4.0")
-@pytest.mark.parametrize("new_name", ("new name file 2", "new_name_file_2"))
-@pytest.mark.parametrize("client_func", ("torrents_rename_file", "torrents_renameFile"))
+@pytest.mark.parametrize("new_name", ["new name file 2", "new_name_file_2"])
+@pytest.mark.parametrize(
+    "rename_file_func", ["torrents_rename_file", "torrents_renameFile"]
+)
 def test_rename_file(
     client,
     new_torrent,
     new_name,
-    client_func,
+    rename_file_func,
 ):
     # pre-v4.3.3 rename_file signature
-    get_func(client, client_func)(
+    client.func(rename_file_func)(
         torrent_hash=new_torrent.hash, file_id=0, new_file_name=new_name
     )
     check(lambda: new_torrent.files[0].name.replace("+", " "), new_name)
     # test invalid file ID is rejected
     with pytest.raises(Conflict409Error):
-        get_func(client, client_func)(
+        client.func(rename_file_func)(
             torrent_hash=new_torrent.hash, file_id=10, new_file_name=new_name
         )
     # post-v4.3.3 rename_file signature
     new_new_name = new_name + "NEW"
-    get_func(client, client_func)(
+    client.func(rename_file_func)(
         torrent_hash=new_torrent.hash,
         old_path=new_torrent.files[0].name,
         new_path=new_new_name,
@@ -492,28 +517,30 @@ def test_rename_file(
     check(lambda: new_torrent.files[0].name.replace("+", " "), new_new_name)
     # test invalid old_path is rejected
     with pytest.raises(Conflict409Error):
-        get_func(client, client_func)(
+        client.func(rename_file_func)(
             torrent_hash=new_torrent.hash, old_path="asdf", new_path="xcvb"
         )
 
 
 @pytest.mark.skipif_after_api_version("2.4.0")
-@pytest.mark.parametrize("client_func", ("torrents_rename_file", "torrents_renameFile"))
+@pytest.mark.parametrize(
+    "rename_file_func", ["torrents_rename_file", "torrents_renameFile"]
+)
 def test_rename_file_not_implemented(
     client,
     new_torrent,
-    client_func,
+    rename_file_func,
 ):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(rename_file_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.7")
-@pytest.mark.parametrize("new_name", ("asdf zxcv", "asdf_zxcv"))
+@pytest.mark.parametrize("new_name", ["asdf zxcv", "asdf_zxcv"])
 @pytest.mark.parametrize(
-    "client_func", ("torrents_rename_folder", "torrents_renameFolder")
+    "rename_folder_func", ["torrents_rename_folder", "torrents_renameFolder"]
 )
-def test_rename_folder(client, app_version, new_torrent, new_name, client_func):
+def test_rename_folder(client, app_version, new_torrent, new_name, rename_folder_func):
     if v(app_version) >= v("v4.3.3"):
         # move the file in to a new folder
         orig_file_path = new_torrent.files[0].name
@@ -532,7 +559,7 @@ def test_rename_folder(client, app_version, new_torrent, new_name, client_func):
         )
 
         # test rename that new folder
-        get_func(client, client_func)(
+        client.func(rename_folder_func)(
             torrent_hash=new_torrent.hash,
             old_path=new_folder,
             new_path=new_name,
@@ -543,16 +570,16 @@ def test_rename_folder(client, app_version, new_torrent, new_name, client_func):
         )
     elif v(app_version) >= v("v4.3.2"):
         with pytest.raises(NotImplementedError):
-            get_func(client, client_func)()
+            client.func(rename_folder_func)()
 
 
 @pytest.mark.skipif_after_api_version("2.7")
 @pytest.mark.parametrize(
-    "client_func", ("torrents_rename_folder", "torrents_renameFolder")
+    "rename_folder_func", ["torrents_rename_folder", "torrents_renameFolder"]
 )
-def test_rename_folder_not_implemented(client, client_func):
+def test_rename_folder_not_implemented(client, rename_folder_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(rename_folder_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.8.14")
@@ -566,57 +593,56 @@ def test_export_not_implemented(client):
         client.torrents_export()
 
 
-@pytest.mark.parametrize("client_func", ("torrents_info", "torrents.info"))
-def test_torrents_info(client, client_func):
-    assert isinstance(get_func(client, client_func)(), TorrentInfoList)
+@pytest.mark.parametrize("info_func", ["torrents_info", "torrents.info"])
+def test_torrents_info(client, info_func):
+    assert isinstance(client.func(info_func)(), TorrentInfoList)
+    if "." in info_func:
+        assert isinstance(client.func(info_func).all(), TorrentInfoList)
+        assert isinstance(client.func(info_func).downloading(), TorrentInfoList)
+        assert isinstance(client.func(info_func).seeding(), TorrentInfoList)
+        assert isinstance(client.func(info_func).completed(), TorrentInfoList)
+        assert isinstance(client.func(info_func).paused(), TorrentInfoList)
+        assert isinstance(client.func(info_func).active(), TorrentInfoList)
+        assert isinstance(client.func(info_func).inactive(), TorrentInfoList)
+        assert isinstance(client.func(info_func).resumed(), TorrentInfoList)
+        assert isinstance(client.func(info_func).stalled(), TorrentInfoList)
+        assert isinstance(client.func(info_func).stalled_uploading(), TorrentInfoList)
+        assert isinstance(client.func(info_func).stalled_downloading(), TorrentInfoList)
+        assert isinstance(client.func(info_func).checking(), TorrentInfoList)
+        assert isinstance(client.func(info_func).moving(), TorrentInfoList)
+        assert isinstance(client.func(info_func).errored(), TorrentInfoList)
+
+
+def test_torrents_info_slice(client):
     if sys.version_info < (3,) or sys.version_info >= (3, 7):
-        assert isinstance(get_func(client, client_func)()[1:2], TorrentInfoList)
-    if "." in client_func:
-        assert isinstance(get_func(client, client_func).all(), TorrentInfoList)
-        assert isinstance(get_func(client, client_func).downloading(), TorrentInfoList)
-        assert isinstance(get_func(client, client_func).seeding(), TorrentInfoList)
-        assert isinstance(get_func(client, client_func).completed(), TorrentInfoList)
-        assert isinstance(get_func(client, client_func).paused(), TorrentInfoList)
-        assert isinstance(get_func(client, client_func).active(), TorrentInfoList)
-        assert isinstance(get_func(client, client_func).inactive(), TorrentInfoList)
-        assert isinstance(get_func(client, client_func).resumed(), TorrentInfoList)
-        assert isinstance(get_func(client, client_func).stalled(), TorrentInfoList)
-        assert isinstance(
-            get_func(client, client_func).stalled_uploading(), TorrentInfoList
-        )
-        assert isinstance(
-            get_func(client, client_func).stalled_downloading(), TorrentInfoList
-        )
-        assert isinstance(get_func(client, client_func).checking(), TorrentInfoList)
-        assert isinstance(get_func(client, client_func).moving(), TorrentInfoList)
-        assert isinstance(get_func(client, client_func).errored(), TorrentInfoList)
+        assert isinstance(client.torrents_info()[1:2], TorrentInfoList)
+    else:
+        assert isinstance(client.torrents_info()[1:2], list)
 
 
 @pytest.mark.skipif_before_api_version("2.8.3")
-@pytest.mark.parametrize("client_func", ("torrents_info", "torrents.info"))
-def test_torrents_info_tag(client, new_torrent, client_func):
+@pytest.mark.parametrize("info_func", ["torrents_info", "torrents.info"])
+def test_torrents_info_tag(client, new_torrent, info_func):
     tag_name = "tag_filter_name"
     client.torrents_add_tags(tags=tag_name, torrent_hashes=new_torrent.hash)
-    torrents = get_func(client, client_func)(
-        torrent_hashes=new_torrent.hash, tag=tag_name
-    )
+    torrents = client.func(info_func)(torrent_hashes=new_torrent.hash, tag=tag_name)
     assert new_torrent.hash in {t.hash for t in torrents}
 
 
 # test fails on 4.1.0 release
 @pytest.mark.skipif_before_api_version("2.0.1")
 @pytest.mark.parametrize(
-    "client_func",
-    (("torrents_pause", "torrents_resume"), ("torrents.pause", "torrents.resume")),
+    "pause_func, resume_func",
+    [("torrents_pause", "torrents_resume"), ("torrents.pause", "torrents.resume")],
 )
-def test_pause_resume(client, new_torrent, client_func):
-    get_func(client, client_func[0])(torrent_hashes=new_torrent.hash)
+def test_pause_resume(client, new_torrent, pause_func, resume_func):
+    client.func(pause_func)(torrent_hashes=new_torrent.hash)
     check(
         lambda: client.torrents_info(hashes=new_torrent.hash)[0].state_enum.is_paused,
         True,
     )
 
-    get_func(client, client_func[1])(torrent_hashes=new_torrent.hash)
+    client.func(resume_func)(torrent_hashes=new_torrent.hash)
     check(
         lambda: client.torrents_info(hashes=new_torrent.hash)[0].state_enum.is_paused,
         False,
@@ -628,41 +654,45 @@ def test_action_for_all_torrents(client):
     for torrent in client.torrents.info():
         check(
             lambda: client.torrents_info(torrents_hashes=torrent.hash)[0].state,
-            ("pausedDL",),
+            {"pausedDL"},
             negate=True,
         )
     client.torrents.pause.all()
     for torrent in client.torrents.info():
         check(
             lambda: client.torrents_info(torrents_hashes=torrent.hash)[0].state,
-            ("stalledDL", "pausedDL"),
+            {"stalledDL", "pausedDL"},
             any=True,
         )
 
 
-@pytest.mark.parametrize("client_func", ("torrents_recheck", "torrents.recheck"))
-def test_recheck(client, orig_torrent, client_func):
-    get_func(client, client_func)(torrent_hashes=orig_torrent.hash)
+@pytest.mark.parametrize("recheck_func", ["torrents_recheck", "torrents.recheck"])
+def test_recheck(client, orig_torrent, recheck_func):
+    client.func(recheck_func)(torrent_hashes=orig_torrent.hash)
 
 
 @pytest.mark.skipif_before_api_version("2.0.2")
-@pytest.mark.parametrize("client_func", ("torrents_reannounce", "torrents.reannounce"))
-def test_reannounce(client, orig_torrent, client_func):
-    get_func(client, client_func)(torrent_hashes=orig_torrent.hash)
+@pytest.mark.parametrize(
+    "reannounce_func", ["torrents_reannounce", "torrents.reannounce"]
+)
+def test_reannounce(client, orig_torrent, reannounce_func):
+    client.func(reannounce_func)(torrent_hashes=orig_torrent.hash)
 
 
 @pytest.mark.skipif_after_api_version("2.0.2")
-@pytest.mark.parametrize("client_func", ("torrents_reannounce", "torrents.reannounce"))
-def test_reannounce_not_implemented(client, client_func):
+@pytest.mark.parametrize(
+    "reannounce_func", ["torrents_reannounce", "torrents.reannounce"]
+)
+def test_reannounce_not_implemented(client, reannounce_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(reannounce_func)()
 
 
 # priority doesn't seem to work on v4.1.0
 @pytest.mark.skipif_before_api_version("2.0.1")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "inc_prio_func, dec_prio_func, top_prio_func, bottom_prio_func",
+    [
         (
             "torrents_increase_priority",
             "torrents_decrease_priority",
@@ -675,84 +705,82 @@ def test_reannounce_not_implemented(client, client_func):
             "torrents_topPrio",
             "torrents_bottomPrio",
         ),
-    ),
+    ],
 )
-def test_priority(client, new_torrent, client_func):
+def test_priority(
+    client, new_torrent, inc_prio_func, dec_prio_func, top_prio_func, bottom_prio_func
+):
     disable_queueing(client)
 
     with pytest.raises(Conflict409Error):
-        get_func(client, client_func[0])(torrent_hashes=new_torrent.hash)
+        client.func(inc_prio_func)(torrent_hashes=new_torrent.hash)
     with pytest.raises(Conflict409Error):
-        get_func(client, client_func[1])(torrent_hashes=new_torrent.hash)
+        client.func(dec_prio_func)(torrent_hashes=new_torrent.hash)
     with pytest.raises(Conflict409Error):
-        get_func(client, client_func[2])(torrent_hashes=new_torrent.hash)
+        client.func(top_prio_func)(torrent_hashes=new_torrent.hash)
     with pytest.raises(Conflict409Error):
-        get_func(client, client_func[3])(torrent_hashes=new_torrent.hash)
+        client.func(bottom_prio_func)(torrent_hashes=new_torrent.hash)
 
     enable_queueing(client)
 
     @retry()
     def test1(current_priority):
-        get_func(client, client_func[0])(torrent_hashes=new_torrent.hash)
+        client.func(inc_prio_func)(torrent_hashes=new_torrent.hash)
         check(lambda: new_torrent.info.priority < current_priority, True)
 
     @retry()
     def test2(current_priority):
-        get_func(client, client_func[1])(torrent_hashes=new_torrent.hash)
+        client.func(dec_prio_func)(torrent_hashes=new_torrent.hash)
         check(lambda: new_torrent.info.priority > current_priority, True)
 
     @retry()
     def test3(current_priority):
-        get_func(client, client_func[2])(torrent_hashes=new_torrent.hash)
+        client.func(top_prio_func)(torrent_hashes=new_torrent.hash)
         check(lambda: new_torrent.info.priority < current_priority, True)
 
     @retry()
     def test4(current_priority):
-        get_func(client, client_func[3])(torrent_hashes=new_torrent.hash)
+        client.func(bottom_prio_func)(torrent_hashes=new_torrent.hash)
         check(lambda: new_torrent.info.priority > current_priority, True)
 
-    current_priority = new_torrent.info.priority
-    test1(current_priority)
-    current_priority = new_torrent.info.priority
-    test2(current_priority)
-    current_priority = new_torrent.info.priority
-    test3(current_priority)
-    current_priority = new_torrent.info.priority
-    test4(current_priority)
+    test1(current_priority=new_torrent.info.priority)
+    test2(current_priority=new_torrent.info.priority)
+    test3(current_priority=new_torrent.info.priority)
+    test4(current_priority=new_torrent.info.priority)
 
 
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_down_limit_func, down_limit_func",
+    [
         ("torrents_set_download_limit", "torrents_download_limit"),
         ("torrents_setDownloadLimit", "torrents_downloadLimit"),
         ("torrents.set_download_limit", "torrents.download_limit"),
         ("torrents.setDownloadLimit", "torrents.downloadLimit"),
-    ),
+    ],
 )
-def test_download_limit(client, client_func, orig_torrent):
-    orig_download_limit = get_func(client, client_func[1])(
+def test_download_limit(client, orig_torrent, set_down_limit_func, down_limit_func):
+    orig_download_limit = client.func(down_limit_func)(
         torrent_hashes=orig_torrent.hash
     )[orig_torrent.hash]
 
-    get_func(client, client_func[0])(torrent_hashes=orig_torrent.hash, limit=100)
+    client.func(set_down_limit_func)(torrent_hashes=orig_torrent.hash, limit=100)
     assert isinstance(
-        get_func(client, client_func[1])(torrent_hashes=orig_torrent.hash),
+        client.func(down_limit_func)(torrent_hashes=orig_torrent.hash),
         TorrentLimitsDictionary,
     )
     check(
-        lambda: get_func(client, client_func[1])(torrent_hashes=orig_torrent.hash)[
+        lambda: client.func(down_limit_func)(torrent_hashes=orig_torrent.hash)[
             orig_torrent.hash
         ],
         100,
     )
 
     # reset download limit
-    get_func(client, client_func[0])(
+    client.func(set_down_limit_func)(
         torrent_hashes=orig_torrent.hash, limit=orig_download_limit
     )
     check(
-        lambda: get_func(client, client_func[1])(torrent_hashes=orig_torrent.hash)[
+        lambda: client.func(down_limit_func)(torrent_hashes=orig_torrent.hash)[
             orig_torrent.hash
         ],
         orig_download_limit,
@@ -760,37 +788,37 @@ def test_download_limit(client, client_func, orig_torrent):
 
 
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_up_limit_func, up_limit_func",
+    [
         ("torrents_set_upload_limit", "torrents_upload_limit"),
         ("torrents_setUploadLimit", "torrents_uploadLimit"),
         ("torrents.set_upload_limit", "torrents.upload_limit"),
         ("torrents.setUploadLimit", "torrents.uploadLimit"),
-    ),
+    ],
 )
-def test_upload_limit(client, client_func, orig_torrent):
-    orig_upload_limit = get_func(client, client_func[1])(
-        torrent_hashes=orig_torrent.hash
-    )[orig_torrent.hash]
+def test_upload_limit(client, orig_torrent, set_up_limit_func, up_limit_func):
+    orig_upload_limit = client.func(up_limit_func)(torrent_hashes=orig_torrent.hash)[
+        orig_torrent.hash
+    ]
 
-    get_func(client, client_func[0])(torrent_hashes=orig_torrent.hash, limit=100)
+    client.func(set_up_limit_func)(torrent_hashes=orig_torrent.hash, limit=100)
     assert isinstance(
-        get_func(client, client_func[1])(torrent_hashes=orig_torrent.hash),
+        client.func(up_limit_func)(torrent_hashes=orig_torrent.hash),
         TorrentLimitsDictionary,
     )
     check(
-        lambda: get_func(client, client_func[1])(torrent_hashes=orig_torrent.hash)[
+        lambda: client.func(up_limit_func)(torrent_hashes=orig_torrent.hash)[
             orig_torrent.hash
         ],
         100,
     )
 
     # reset upload limit
-    get_func(client, client_func[0])(
+    client.func(set_up_limit_func)(
         torrent_hashes=orig_torrent.hash, limit=orig_upload_limit
     )
     check(
-        lambda: get_func(client, client_func[1])(torrent_hashes=orig_torrent.hash)[
+        lambda: client.func(up_limit_func)(torrent_hashes=orig_torrent.hash)[
             orig_torrent.hash
         ],
         orig_upload_limit,
@@ -799,21 +827,21 @@ def test_upload_limit(client, client_func, orig_torrent):
 
 @pytest.mark.skipif_before_api_version("2.0.1")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_share_limits_func",
+    [
         "torrents_set_share_limits",
         "torrents_setShareLimits",
         "torrents.set_share_limits",
         "torrents.setShareLimits",
-    ),
+    ],
 )
-def test_set_share_limits(client, client_func, orig_torrent):
-    get_func(client, client_func)(
+def test_set_share_limits(client, orig_torrent, set_share_limits_func):
+    client.func(set_share_limits_func)(
         ratio_limit=2, seeding_time_limit=5, torrent_hashes=orig_torrent.hash
     )
     check(lambda: orig_torrent.info.max_ratio, 2)
     check(lambda: orig_torrent.info.max_seeding_time, 5)
-    get_func(client, client_func)(
+    client.func(set_share_limits_func)(
         ratio_limit=3, seeding_time_limit=6, torrent_hashes=orig_torrent.hash
     )
     check(lambda: orig_torrent.info.max_ratio, 3)
@@ -822,274 +850,265 @@ def test_set_share_limits(client, client_func, orig_torrent):
 
 @pytest.mark.skipif_after_api_version("2.0.1")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_share_limits_func",
+    [
         "torrents_set_share_limits",
         "torrents_setShareLimits",
         "torrents.set_share_limits",
         "torrents.setShareLimits",
-    ),
+    ],
 )
-def test_set_share_limits_not_implemented(client, client_func):
+def test_set_share_limits_not_implemented(client, set_share_limits_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(set_share_limits_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.0.2")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_loc_func",
+    [
         "torrents_set_location",
         "torrents_setLocation",
         "torrents.set_location",
         "torrents.setLocation",
-    ),
+    ],
 )
-def test_set_location(client, app_version, client_func, new_torrent):
+def test_set_location(client, app_version, new_torrent, set_loc_func, tmp_path):
     # stopped erroring when the write check was removed for API
     if v(app_version) < v("v4.5.2"):
         with pytest.raises(Forbidden403Error):
-            get_func(client, client_func)(
-                location="/etc/", torrent_hashes=new_torrent.hash
-            )
+            client.func(set_loc_func)(location="/etc/", torrent_hashes=new_torrent.hash)
 
-    sleep(0.5)
-    loc = mkpath("/tmp", "1")
-    get_func(client, client_func)(location=loc, torrent_hashes=new_torrent.hash)
+    sleep(0.25)
+    loc = mkpath(tmp_path, "1")
+    client.func(set_loc_func)(location=loc, torrent_hashes=new_torrent.hash)
     # qBittorrent may return trailing separators depending on version....
     check(lambda: mkpath(new_torrent.info.save_path), loc, any=True)
 
 
 @pytest.mark.skipif_before_api_version("2.8.4")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_save_path_func",
+    [
         "torrents_set_save_path",
         "torrents_setSavePath",
         "torrents.set_save_path",
         "torrents.setSavePath",
-    ),
+    ],
 )
-def test_set_save_path(client, client_func, new_torrent):
+def test_set_save_path(client, new_torrent, set_save_path_func, tmp_path):
     with pytest.raises(Forbidden403Error):
-        get_func(client, client_func)(
+        client.func(set_save_path_func)(
             save_path="/etc/", torrent_hashes=new_torrent.hash
         )
     with pytest.raises(Conflict409Error):
-        get_func(client, client_func)(
+        client.func(set_save_path_func)(
             save_path="/etc/asdf", torrent_hashes=new_torrent.hash
         )
 
-    loc = mkpath("/tmp", "savepath1")
-    get_func(client, client_func)(save_path=loc, torrent_hashes=new_torrent.hash)
+    loc = mkpath(tmp_path, "savepath1")
+    client.func(set_save_path_func)(save_path=loc, torrent_hashes=new_torrent.hash)
     # qBittorrent may return trailing separators depending on version....
     check(lambda: mkpath(new_torrent.info.save_path), loc, any=True)
 
 
 @pytest.mark.skipif_after_api_version("2.8.4")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_save_path_func",
+    [
         "torrents_set_save_path",
         "torrents_setSavePath",
         "torrents.set_save_path",
         "torrents.setSavePath",
-    ),
+    ],
 )
-def test_set_save_path_not_implemented(client, client_func):
+def test_set_save_path_not_implemented(client, set_save_path_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(set_save_path_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.8.4")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_down_path_func",
+    [
         "torrents_set_download_path",
         "torrents_setDownloadPath",
         "torrents.set_download_path",
         "torrents.setDownloadPath",
-    ),
+    ],
 )
-def test_set_download_path(client, client_func, new_torrent):
+def test_set_download_path(client, new_torrent, set_down_path_func, tmp_path):
     with pytest.raises(Forbidden403Error):
-        get_func(client, client_func)(
+        client.func(set_down_path_func)(
             download_path="/etc/", torrent_hashes=new_torrent.hash
         )
     with pytest.raises(Conflict409Error):
-        get_func(client, client_func)(
+        client.func(set_down_path_func)(
             download_path="/etc/asdf", torrent_hashes=new_torrent.hash
         )
 
-    loc = mkpath("/tmp", "savepath1")
-    get_func(client, client_func)(download_path=loc, torrent_hashes=new_torrent.hash)
+    loc = mkpath(tmp_path, "savepath1")
+    client.func(set_down_path_func)(download_path=loc, torrent_hashes=new_torrent.hash)
     # qBittorrent may return trailing separators depending on version....
     check(lambda: mkpath(new_torrent.info.download_path), loc, any=True)
 
 
 @pytest.mark.skipif_after_api_version("2.8.4")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_down_path_func",
+    [
         "torrents_set_download_path",
         "torrents_setDownloadPath",
         "torrents.set_download_path",
         "torrents.setDownloadPath",
-    ),
+    ],
 )
-def test_set_download_path_not_implemented(client, client_func, new_torrent):
+def test_set_download_path_not_implemented(client, new_torrent, set_down_path_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(set_down_path_func)()
 
 
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_cat_func",
+    [
         "torrents_set_category",
         "torrents_setCategory",
         "torrents.set_category",
         "torrents.setCategory",
-    ),
+    ],
 )
-@pytest.mark.parametrize("name", ("awesome cat", "awesome_cat"))
-def test_set_category(client, client_func, name, orig_torrent):
+@pytest.mark.parametrize("name", ["awesome cat", "awesome_cat"])
+def test_set_category(client, orig_torrent, set_cat_func, name):
     with pytest.raises(Conflict409Error):
-        get_func(client, client_func)(
+        client.func(set_cat_func)(
             category="/!@#$%^&*(", torrent_hashes=orig_torrent.hash
         )
 
     client.torrents_create_category(name=name)
     try:
-        get_func(client, client_func)(category=name, torrent_hashes=orig_torrent.hash)
+        client.func(set_cat_func)(category=name, torrent_hashes=orig_torrent.hash)
         check(lambda: orig_torrent.info.category.replace("+", " "), name)
     finally:
         client.torrents_remove_categories(categories=name)
 
 
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_auto_mgmt_func",
+    [
         "torrents_set_auto_management",
         "torrents_setAutoManagement",
         "torrents.set_auto_management",
         "torrents.setAutoManagement",
-    ),
+    ],
 )
-def test_torrents_set_auto_management(client, client_func, orig_torrent):
+def test_torrents_set_auto_management(client, orig_torrent, set_auto_mgmt_func):
     current_setting = orig_torrent.info.auto_tmm
-    get_func(client, client_func)(
+    client.func(set_auto_mgmt_func)(
         enable=(not current_setting), torrent_hashes=orig_torrent.hash
     )
     check(lambda: orig_torrent.info.auto_tmm, (not current_setting))
-    get_func(client, client_func)(
+    client.func(set_auto_mgmt_func)(
         enable=False, torrent_hashes=orig_torrent.hash
     )  # leave on False
 
 
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "toggle_seq_down_func",
+    [
         "torrents_toggle_sequential_download",
         "torrents_toggleSequentialDownload",
         "torrents.toggle_sequential_download",
         "torrents.toggleSequentialDownload",
-    ),
+    ],
 )
-def test_toggle_sequential_download(client, client_func, orig_torrent):
+def test_toggle_sequential_download(client, orig_torrent, toggle_seq_down_func):
     current_setting = orig_torrent.info.seq_dl
-    get_func(client, client_func)(torrent_hashes=orig_torrent.hash)
+    client.func(toggle_seq_down_func)(torrent_hashes=orig_torrent.hash)
     check(lambda: orig_torrent.info.seq_dl, not current_setting)
 
 
 @pytest.mark.skipif_before_api_version("2.0.1")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "toggle_piece_prio_func",
+    [
         "torrents_toggle_first_last_piece_priority",
         "torrents_toggleFirstLastPiecePrio",
         "torrents.toggle_first_last_piece_priority",
         "torrents.toggleFirstLastPiecePrio",
-    ),
+    ],
 )
-def test_toggle_first_last_piece_priority(client, client_func, new_torrent):
+def test_toggle_first_last_piece_priority(client, new_torrent, toggle_piece_prio_func):
     current_setting = new_torrent.info.f_l_piece_prio
-    get_func(client, client_func)(torrent_hashes=new_torrent.hash)
+    client.func(toggle_piece_prio_func)(torrent_hashes=new_torrent.hash)
     check(lambda: new_torrent.info.f_l_piece_prio, not current_setting)
 
 
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_force_start_func",
+    [
         "torrents_set_force_start",
         "torrents_setForceStart",
         "torrents.set_force_start",
         "torrents.setForceStart",
-    ),
+    ],
 )
-def test_set_force_start(client, client_func, orig_torrent):
+def test_set_force_start(client, orig_torrent, set_force_start_func):
     current_setting = orig_torrent.info.force_start
-    get_func(client, client_func)(
+    client.func(set_force_start_func)(
         enable=(not current_setting), torrent_hashes=orig_torrent.hash
     )
     check(lambda: orig_torrent.info.force_start, not current_setting)
 
 
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "set_super_seeding_func",
+    [
         "torrents_set_super_seeding",
         "torrents_setSuperSeeding",
         "torrents.set_super_seeding",
         "torrents.setSuperSeeding",
-    ),
+    ],
 )
-def test_set_super_seeding(client, client_func, orig_torrent):
-    # this may or may not actually be working....
-    get_func(client, client_func)(enable=False, torrent_hashes=orig_torrent.hash)
+def test_set_super_seeding(client, orig_torrent, set_super_seeding_func):
+    client.func(set_super_seeding_func)(enable=False, torrent_hashes=orig_torrent.hash)
     check(lambda: orig_torrent.info.force_start, False)
 
 
 @pytest.mark.skipif_before_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "add_peers_func",
+    [
         "torrents_add_peers",
         "torrents_addPeers",
         "torrents.add_peers",
         "torrents.addPeers",
-    ),
+    ],
 )
 @pytest.mark.parametrize(
-    "peers", ("127.0.0.1:5000", ("127.0.0.1:5000", "127.0.0.2:5000"), "127.0.0.1")
+    "peers", ["127.0.0.1:5000", ["127.0.0.1:5000", "127.0.0.2:5000"], "127.0.0.1"]
 )
-def test_torrents_add_peers(client, orig_torrent, client_func, peers):
-    if all(map(lambda p: ":" not in p, peers)):
+def test_torrents_add_peers(client, orig_torrent, add_peers_func, peers):
+    if all(":" not in p for p in peers):
         with pytest.raises(InvalidRequest400Error):
-            get_func(client, client_func)(peers=peers, torrent_hashes=orig_torrent.hash)
+            client.func(add_peers_func)(peers=peers, torrent_hashes=orig_torrent.hash)
     else:
-        p = get_func(client, client_func)(peers=peers, torrent_hashes=orig_torrent.hash)
-        # can only actually verify the peer was added if it's a valid peer  # noqa: E800
-        # check(  # noqa: E800
-        #     lambda: client.sync_torrent_peers(torrent_hash=orig_torrent.hash)['peers'],  # noqa: E800
-        #     peers,  # noqa: E800
-        #     reverse=True  # noqa: E800
-        # )  # noqa: E800
+        p = client.func(add_peers_func)(peers=peers, torrent_hashes=orig_torrent.hash)
         assert isinstance(p, TorrentsAddPeersDictionary)
 
 
 @pytest.mark.skipif_after_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "add_peers_func",
+    [
         "torrents_add_peers",
         "torrents_addPeers",
         "torrents.add_peers",
         "torrents.addPeers",
-    ),
+    ],
 )
-def test_torrents_add_peers_not_implemented(client, client_func):
+def test_torrents_add_peers_not_implemented(client, add_peers_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(add_peers_func)()
 
 
 def _categories_save_path_key(api_version):
@@ -1112,14 +1131,17 @@ def test_categories1_not_implemented(client, api_version):
 
 
 @pytest.mark.skipif_before_api_version("2.1.1")
-def test_categories2(client, api_version):
+def test_categories2(client, api_version, tmp_path):
     save_path_key = _categories_save_path_key(api_version)
     name = "new_category"
-    client.torrent_categories.categories = {"name": name, save_path_key: "/tmp"}
+    client.torrent_categories.categories = {"name": name, save_path_key: tmp_path}
     assert name in client.torrent_categories.categories
-    client.torrent_categories.categories = {"name": name, save_path_key: "/tmp/new"}
+    client.torrent_categories.categories = {
+        "name": name,
+        save_path_key: mkpath(tmp_path, "new"),
+    }
     assert mkpath(client.torrent_categories.categories[name][save_path_key]) == mkpath(
-        "/tmp/new"
+        tmp_path, "new"
     )
     client.torrents_remove_categories(categories=name)
 
@@ -1131,19 +1153,25 @@ def test_categories2_not_implemented(client):
 
 
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "create_cat_func",
+    [
         "torrents_create_category",
         "torrents_createCategory",
         "torrent_categories.create_category",
         "torrent_categories.createCategory",
-    ),
+    ],
 )
-@pytest.mark.parametrize("filepath", (None, "", "/tmp/"))
-@pytest.mark.parametrize("name", ("name", "name 1"))
-@pytest.mark.parametrize("enable_download_path", (None, True, False))
+@pytest.mark.parametrize("filepath", [None, "", "/tmp/"])
+@pytest.mark.parametrize("name", ["name", "name 1"])
+@pytest.mark.parametrize("enable_download_path", [None, True, False])
 def test_create_categories(
-    client, api_version, orig_torrent, client_func, filepath, name, enable_download_path
+    client,
+    api_version,
+    orig_torrent,
+    create_cat_func,
+    filepath,
+    name,
+    enable_download_path,
 ):
     save_path = download_path = filepath
     if filepath:
@@ -1151,7 +1179,7 @@ def test_create_categories(
         download_path += "download"
 
     try:
-        get_func(client, client_func)(
+        client.func(create_cat_func)(
             name=name,
             save_path=save_path,
             download_path=download_path,
@@ -1189,19 +1217,19 @@ def test_create_categories(
 
 @pytest.mark.skipif_before_api_version("2.1.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "edit_cat_func",
+    [
         "torrents_edit_category",
         "torrents_editCategory",
         "torrent_categories.edit_category",
         "torrent_categories.editCategory",
-    ),
+    ],
 )
-@pytest.mark.parametrize("filepath", ("", "/tmp/"))
-@pytest.mark.parametrize("name", ("editcategory",))
-@pytest.mark.parametrize("enable_download_path", (None, True, False))
+@pytest.mark.parametrize("filepath", ["", "/tmp/"])
+@pytest.mark.parametrize("name", ["editcategory"])
+@pytest.mark.parametrize("enable_download_path", [None, True, False])
 def test_edit_category(
-    client, api_version, client_func, filepath, name, enable_download_path
+    client, api_version, edit_cat_func, filepath, name, enable_download_path
 ):
     try:
         client.torrents_create_category(
@@ -1209,7 +1237,7 @@ def test_edit_category(
         )
         save_path = mkpath(filepath + "save/")
         download_path = mkpath(filepath + "down/")
-        get_func(client, client_func)(
+        client.func(edit_cat_func)(
             name=name,
             save_path=save_path,
             download_path=download_path,
@@ -1244,7 +1272,7 @@ def test_edit_category(
 
 @pytest.mark.skipif_after_api_version("2.1.0")
 @pytest.mark.parametrize(
-    "client_func",
+    "edit_cat_func",
     (
         "torrents_edit_category",
         "torrents_editCategory",
@@ -1252,26 +1280,28 @@ def test_edit_category(
         "torrent_categories.editCategory",
     ),
 )
-def test_edit_category_not_implemented(client, client_func):
+def test_edit_category_not_implemented(client, edit_cat_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(edit_cat_func)()
 
 
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "remove_cat_func",
+    [
         "torrents_remove_categories",
         "torrents_removeCategories",
         "torrent_categories.remove_categories",
         "torrent_categories.removeCategories",
-    ),
+    ],
 )
-@pytest.mark.parametrize("categories", (("category1",), ("category1", "category 2")))
-def test_remove_category(client, api_version, orig_torrent, client_func, categories):
+@pytest.mark.parametrize("categories", [["category1"], ["category1", "category 2"]])
+def test_remove_category(
+    client, api_version, orig_torrent, remove_cat_func, categories
+):
     for name in categories:
         client.torrents_create_category(name=name)
     orig_torrent.set_category(category=categories[0])
-    get_func(client, client_func)(categories=categories)
+    client.func(remove_cat_func)(categories=categories)
     if v(api_version) >= v("2.2"):
         check(
             lambda: [n.replace("+", " ") for n in client.torrents_categories()],
@@ -1284,34 +1314,38 @@ def test_remove_category(client, api_version, orig_torrent, client_func, categor
 
 @pytest.mark.skipif_before_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "tags_func",
+    [
         "torrents_tags",
         "torrent_tags.tags",
-    ),
+    ],
 )
-def test_tags(client, client_func):
+def test_tags(client, tags_func):
     try:
-        assert isinstance(get_func(client, client_func)(), TagList)
-        if sys.version_info < (3,) or sys.version_info >= (3, 7):
-            assert isinstance(get_func(client, client_func)()[1:2], TagList)
+        assert isinstance(client.func(tags_func)(), TagList)
     except TypeError:
-        assert isinstance(get_func(client, client_func), TagList)
-        if sys.version_info < (3,) or sys.version_info >= (3, 7):
-            assert isinstance(get_func(client, client_func)[1:2], TagList)
+        assert isinstance(client.func(tags_func), TagList)
+
+
+@pytest.mark.skipif_before_api_version("2.3.0")
+def test_tags_slice(client):
+    if sys.version_info < (3,) or sys.version_info >= (3, 7):
+        assert isinstance(client.torrents_tags()[1:2], TagList)
+    else:
+        assert isinstance(client.torrents_tags()[1:2], list)
 
 
 @pytest.mark.skipif_after_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "tags_func",
+    [
         "torrents_tags",
         "torrent_tags.tags",
-    ),
+    ],
 )
-def test_tags_not_implemented(client, client_func):
+def test_tags_not_implemented(client, tags_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(tags_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.3.0")
@@ -1331,18 +1365,18 @@ def test_add_tag_though_property_not_implemented(client):
 
 @pytest.mark.skipif_before_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "add_tags_func",
+    [
         "torrents_add_tags",
         "torrents_addTags",
         "torrent_tags.add_tags",
         "torrent_tags.addTags",
-    ),
+    ],
 )
-@pytest.mark.parametrize("tags", (("tag1",), ("tag1", "tag 2")))
-def test_add_tags(client, orig_torrent, client_func, tags):
+@pytest.mark.parametrize("tags", [["tag1"], ["tag1", "tag 2"]])
+def test_add_tags(client, orig_torrent, add_tags_func, tags):
     try:
-        get_func(client, client_func)(tags=tags, torrent_hashes=orig_torrent.hash)
+        client.func(add_tags_func)(tags=tags, torrent_hashes=orig_torrent.hash)
         check(lambda: orig_torrent.info.tags, tags, reverse=True)
     finally:
         client.torrents_delete_tags(tags=tags)
@@ -1350,34 +1384,34 @@ def test_add_tags(client, orig_torrent, client_func, tags):
 
 @pytest.mark.skipif_after_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "add_tags_func",
+    [
         "torrents_add_tags",
         "torrents_addTags",
         "torrent_tags.add_tags",
         "torrent_tags.addTags",
-    ),
+    ],
 )
-def test_add_tags_not_implemented(client, client_func):
+def test_add_tags_not_implemented(client, add_tags_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(add_tags_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "remove_tags_func",
+    [
         "torrents_remove_tags",
         "torrents_removeTags",
         "torrent_tags.remove_tags",
         "torrent_tags.removeTags",
-    ),
+    ],
 )
-@pytest.mark.parametrize("tags", (("tag1",), ("tag1", "tag 2")))
-def test_remove_tags(client, orig_torrent, client_func, tags):
+@pytest.mark.parametrize("tags", [["tag1"], ["tag1", "tag 2"]])
+def test_remove_tags(client, orig_torrent, remove_tags_func, tags):
     try:
         orig_torrent.add_tags(tags=tags)
-        get_func(client, client_func)(tags=tags, torrent_hashes=orig_torrent.hash)
+        client.func(remove_tags_func)(tags=tags, torrent_hashes=orig_torrent.hash)
         check(lambda: orig_torrent.info.tags, tags, reverse=True, negate=True)
     finally:
         client.torrents_delete_tags(tags=tags)
@@ -1385,33 +1419,33 @@ def test_remove_tags(client, orig_torrent, client_func, tags):
 
 @pytest.mark.skipif_after_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "remove_tags_func",
+    [
         "torrents_remove_tags",
         "torrents_removeTags",
         "torrent_tags.remove_tags",
         "torrent_tags.removeTags",
-    ),
+    ],
 )
-def test_remove_tags_not_implemented(client, client_func):
+def test_remove_tags_not_implemented(client, remove_tags_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(remove_tags_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "create_tags_func",
+    [
         "torrents_create_tags",
         "torrents_createTags",
         "torrent_tags.create_tags",
         "torrent_tags.createTags",
-    ),
+    ],
 )
-@pytest.mark.parametrize("tags", (("tag1",), ("tag1", "tag 2")))
-def test_create_tags(client, client_func, tags):
+@pytest.mark.parametrize("tags", [["tag1"], ["tag1", "tag 2"]])
+def test_create_tags(client, create_tags_func, tags):
     try:
-        get_func(client, client_func)(tags=tags)
+        client.func(create_tags_func)(tags=tags)
         check(lambda: client.torrents_tags(), tags, reverse=True)
     finally:
         client.torrents_delete_tags(tags=tags)
@@ -1419,46 +1453,46 @@ def test_create_tags(client, client_func, tags):
 
 @pytest.mark.skipif_after_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "create_tags_func",
+    [
         "torrents_create_tags",
         "torrents_createTags",
         "torrent_tags.create_tags",
         "torrent_tags.createTags",
-    ),
+    ],
 )
-def test_create_tags_not_implemented(client, client_func):
+def test_create_tags_not_implemented(client, create_tags_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(create_tags_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "delete_tags_func",
+    [
         "torrents_delete_tags",
         "torrents_deleteTags",
         "torrent_tags.delete_tags",
         "torrent_tags.deleteTags",
-    ),
+    ],
 )
-@pytest.mark.parametrize("tags", (("tag1",), ("tag1", "tag 2")))
-def test_delete_tags(client, client_func, tags):
+@pytest.mark.parametrize("tags", [["tag1"], ["tag1", "tag 2"]])
+def test_delete_tags(client, delete_tags_func, tags):
     client.torrents_create_tags(tags=tags)
-    get_func(client, client_func)(tags=tags)
+    client.func(delete_tags_func)(tags=tags)
     check(lambda: client.torrents_tags(), tags, reverse=True, negate=True)
 
 
 @pytest.mark.skipif_after_api_version("2.3.0")
 @pytest.mark.parametrize(
-    "client_func",
-    (
+    "delete_tags_func",
+    [
         "torrents_delete_tags",
         "torrents_deleteTags",
         "torrent_tags.delete_tags",
         "torrent_tags.deleteTags",
-    ),
+    ],
 )
-def test_delete_tags_not_implemented(client, client_func):
+def test_delete_tags_not_implemented(client, delete_tags_func):
     with pytest.raises(NotImplementedError):
-        get_func(client, client_func)()
+        client.func(delete_tags_func)()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,7 +50,9 @@ def get_func(obj, method_name):
 def mkpath(*user_path):
     """Create the fully qualified path to an iterable of directories and/or file."""
     if any(user_path):
-        return path.abspath(path.realpath(path.expanduser(path.join(*user_path))))
+        return path.abspath(
+            path.realpath(path.expanduser(path.join(*map(str, user_path))))
+        )
     return ""
 
 
@@ -89,7 +91,7 @@ def check(check_func, value, reverse=False, negate=False, any=False, check_time=
                 assert _check_func_val not in (_v,)
         else:
             if _reverse:
-                print("Looking for %s in %s" % (_v, _check_func_val))
+                # print("Looking for %s in %s" % (_v, _check_func_val))
                 assert _v in _check_func_val
             else:
                 # print("Looking for %s in %s" % (_check_func_val, (_v,)))

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,18 @@
 [tox]
 env_list = docs-lint,py
 
-[testenv]
+[testenv:py{,27,34,35,36,37,38,39,310,311,312}{,-ci}]
 extras = dev
-commands = python -m coverage run -m pytest {posargs:-vv --color=yes}
+allowlist_externals = docker
+setenv =
+    DOCKER_ARGS = {env:DOCKER_ARGS:--rm -d --name qbt-tox-testing --pull=always --publish 8080:8080 --volume {tox_root}/tests/_resources:/tmp/_resources}
+    DOCKER_QBT_IMAGE_NAME = {env:DOCKER_IMAGE_NAME:ghcr.io/rmartin16/qbittorrent-nox}
+    DOCKER_QBT_IMAGE_TAG = {env:DOCKER_QBT_IMAGE_TAG:master-debug}
+commands_pre = !ci: -docker stop qbt-tox-testing
+commands =
+    !ci: docker run {env:DOCKER_ARGS} {env:DOCKER_QBT_IMAGE_NAME}:{env:DOCKER_QBT_IMAGE_TAG}
+    python -m coverage run -m pytest {posargs:-vv --color=yes}
+commands_post = !ci: docker stop qbt-tox-testing
 
 [docs]
 source_dir = source


### PR DESCRIPTION
## Changes
- `torrents_delete()` no longer requires `delete_files` param
- These endpoints default `True` now if `enable` is None or not specified:
  - `torrents_set_auto_management()`
  - `torrents_set_force_start()`
  - `torrents_set_super_seeding()`
  - `search_enable_plugin()`
- `torrents_add()` doesn't change default handling so any default behavior in qBittorrent is respected.