### PR TITLE
Bump pre-commit hook for ruff-pre-commit from v0.0.274 to v0.0.275

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: [--in-place, --pre-summary-newline, --black, --non-cap=qBittorrent]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.274
+    rev: v0.0.275
     hooks:
       - id: ruff
         args:

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -879,7 +879,7 @@ def test_set_location(client, app_version, new_torrent, set_loc_func, tmp_path):
         with pytest.raises(Forbidden403Error):
             client.func(set_loc_func)(location="/etc/", torrent_hashes=new_torrent.hash)
 
-    sleep(0.25)
+    sleep(0.5)
     loc = mkpath(tmp_path, "1")
     client.func(set_loc_func)(location=loc, torrent_hashes=new_torrent.hash)
     # qBittorrent may return trailing separators depending on version....


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `ruff-pre-commit` from v0.0.274 to v0.0.275 and ran the update against the repo.