### PR TITLE
Bump pre-commit hook for docformatter from v1.7.2 to v1.7.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         additional_dependencies: [toml]
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.2
+    rev: v1.7.3
     hooks:
       - id: docformatter
         exclude: _attrdict.py


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `docformatter` from v1.7.2 to v1.7.3 and ran the update against the repo.