### PR TITLE
Bump pre-commit hook for ruff-pre-commit from v0.0.276 to v0.0.277

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: [--in-place, --pre-summary-newline, --black, --non-cap=qBittorrent]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.276
+    rev: v0.0.277
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `ruff-pre-commit` from v0.0.276 to v0.0.277 and ran the update against the repo.