### PR TITLE
Bump pre-commit hook for docformatter from v1.7.3 to v1.7.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         additional_dependencies: [toml]
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.3
+    rev: v1.7.4
     hooks:
       - id: docformatter
         exclude: _attrdict.py

--- a/src/qbittorrentapi/auth.py
+++ b/src/qbittorrentapi/auth.py
@@ -124,7 +124,8 @@ class AuthAPIMixIn(Request):
         Authorization session cookie from qBittorrent using default cookie name `SID`.
         Backwards compatible for :meth:`~AuthAPIMixIn._session_cookie`.
 
-        :return: Auth cookie value from qBittorrent or None if one isn't already acquired
+        :return: Auth cookie value from qBittorrent or None if one isn't already
+            acquired
         """
         return self._session_cookie()
 

--- a/src/qbittorrentapi/exceptions.py
+++ b/src/qbittorrentapi/exceptions.py
@@ -131,8 +131,7 @@ class Conflict409Error(HTTP409Error):
 
 
 class UnsupportedMediaType415Error(HTTP415Error):
-    """``torrents/add`` endpoint will return this for invalid URL(s) or
-    files."""
+    """``torrents/add`` endpoint will return this for invalid URL(s) or files."""
 
 
 class InternalServerError500Error(HTTP500Error):

--- a/src/qbittorrentapi/request.py
+++ b/src/qbittorrentapi/request.py
@@ -559,9 +559,9 @@ class Request(object):
 
     def _get_requests_kwargs(self, requests_args=None, requests_params=None):
         """
-        Determine the requests_kwargs for the call to Requests. The global
-        configuration in ``self._REQUESTS_ARGS`` is updated by any arguments
-        provided for a specific call.
+        Determine the requests_kwargs for the call to Requests. The global configuration
+        in ``self._REQUESTS_ARGS`` is updated by any arguments provided for a specific
+        call.
 
         :param requests_args: default location to expect Requests ``requests_kwargs``
         :param requests_params: alternative location to expect Requests ``requests_kwargs``
@@ -574,8 +574,8 @@ class Request(object):
     @staticmethod
     def _get_headers(headers=None, more_headers=None):
         """
-        Determine headers specific to this request. Request headers can be
-        specified explicitly or with the requests kwargs. Headers specified in
+        Determine headers specific to this request. Request headers can be specified
+        explicitly or with the requests kwargs. Headers specified in
         ``self._EXTRA_HEADERS`` are merged in Requests itself.
 
         :param headers: headers specified for this specific request

--- a/src/qbittorrentapi/torrents.py
+++ b/src/qbittorrentapi/torrents.py
@@ -36,8 +36,8 @@ logger = getLogger(__name__)
 @aliased
 class TorrentDictionary(Dictionary):
     """
-    Item in :class:`TorrentInfoList`. Allows interaction with individual
-    torrents via the ``Torrents`` API endpoints.
+    Item in :class:`TorrentInfoList`. Allows interaction with individual torrents via
+    the ``Torrents`` API endpoints.
 
     :Usage:
         >>> from qbittorrentapi import Client
@@ -239,8 +239,7 @@ class TorrentDictionary(Dictionary):
 
     @alias("toggleSequentialDownload")
     def toggle_sequential_download(self, **kwargs):
-        """Implements
-        :meth:`~TorrentsAPIMixIn.torrents_toggle_sequential_download`"""
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_toggle_sequential_download`"""
         self._client.torrents_toggle_sequential_download(
             torrent_hashes=self._torrent_hash, **kwargs
         )
@@ -1011,8 +1010,7 @@ class Torrents(ClientCache):
 @aliased
 class TorrentCategories(ClientCache):
     """
-    Allows interaction with torrent categories within the ``Torrents`` API
-    endpoints.
+    Allows interaction with torrent categories within the ``Torrents`` API endpoints.
 
     :Usage:
         >>> from qbittorrentapi import Client

--- a/src/qbittorrentapi/transfer.py
+++ b/src/qbittorrentapi/transfer.py
@@ -48,20 +48,17 @@ class Transfer(ClientCache):
 
     @speedLimitsMode.setter
     def speedLimitsMode(self, v):
-        """Implements
-        :meth:`~TransferAPIMixIn.transfer_set_speed_limits_mode`"""
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_speed_limits_mode`"""
         self.speed_limits_mode = v
 
     @speed_limits_mode.setter
     def speed_limits_mode(self, v):
-        """Implements
-        :meth:`~TransferAPIMixIn.transfer_set_speed_limits_mode`"""
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_speed_limits_mode`"""
         self.set_speed_limits_mode(intended_state=v)
 
     @alias("setSpeedLimitsMode", "toggleSpeedLimitsMode", "toggle_speed_limits_mode")
     def set_speed_limits_mode(self, intended_state=None, **kwargs):
-        """Implements
-        :meth:`~TransferAPIMixIn.transfer_set_speed_limits_mode`"""
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_speed_limits_mode`"""
         return self._client.transfer_set_speed_limits_mode(
             intended_state=intended_state, **kwargs
         )


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `docformatter` from v1.7.3 to v1.7.4 and ran the update against the repo.