### PR TITLE
Bump pre-commit hook for mirrors-mypy from v1.4.1 to v1.5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.5.0
     hooks:
       - id: mypy
         files: '.*\.pyi'


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `mirrors-mypy` from v1.4.1 to v1.5.0 and ran the update against the repo.