### PR TITLE
Rename `reannounce` for `TorrentDictionary` to `reannounce_in`

### DIFF
--- a/src/qbittorrentapi/_types.pyi
+++ b/src/qbittorrentapi/_types.pyi
@@ -2,6 +2,7 @@ from typing import IO
 from typing import Any
 from typing import Iterable
 from typing import Mapping
+from typing import MutableMapping
 from typing import Sequence
 from typing import Text
 from typing import Tuple
@@ -22,6 +23,7 @@ JsonValueT = Union[
 JsonDictionaryT = Dictionary[Text, JsonValueT]
 # Type for inputs to build a Dictionary
 DictInputT = Mapping[Text, JsonValueT]
+DictMutableInputT = MutableMapping[Text, JsonValueT]
 # Type for inputs to build a List
 ListInputT = Iterable[Mapping[Text, JsonValueT]]
 # Type for `files` in requests.get()/post()

--- a/src/qbittorrentapi/definitions.py
+++ b/src/qbittorrentapi/definitions.py
@@ -2,7 +2,9 @@ from enum import Enum
 
 try:
     from collections import UserList
+    from collections.abc import Mapping
 except ImportError:  # pragma: no cover
+    from collections import Mapping
     from UserList import UserList
 
 from qbittorrentapi._attrdict import AttrDict
@@ -187,7 +189,7 @@ class Dictionary(ClientCache, AttrDict):
     @classmethod
     def _normalize(cls, data):
         """Iterate through a dict converting any nested dicts to AttrDicts."""
-        if isinstance(data, dict):
+        if isinstance(data, Mapping):
             return AttrDict({key: cls._normalize(value) for key, value in data.items()})
         return data
 

--- a/src/qbittorrentapi/torrents.py
+++ b/src/qbittorrentapi/torrents.py
@@ -64,6 +64,10 @@ class TorrentDictionary(Dictionary):
 
     def __init__(self, data, client):
         self._torrent_hash = data.get("hash", None)
+        # The countdown to the next announce was added in v5.0.0.
+        # To avoid clashing with `reannounce()`, rename to `reannounce_in`.
+        if "reannounce" in data:
+            data["reannounce_in"] = data.pop("reannounce")
         super(TorrentDictionary, self).__init__(client=client, data=data)
 
     def sync_local(self):

--- a/src/qbittorrentapi/torrents.pyi
+++ b/src/qbittorrentapi/torrents.pyi
@@ -10,7 +10,7 @@ from typing import Text
 from typing import Tuple
 from typing import TypeVar
 
-from qbittorrentapi._types import DictInputT
+from qbittorrentapi._types import DictMutableInputT
 from qbittorrentapi._types import FilesToSendT
 from qbittorrentapi._types import JsonDictionaryT
 from qbittorrentapi._types import KwargsT
@@ -50,7 +50,7 @@ TorrentFilesT = TypeVar(
 )
 
 class TorrentDictionary(JsonDictionaryT):
-    def __init__(self, data: DictInputT, client: TorrentsAPIMixIn) -> None: ...
+    def __init__(self, data: DictMutableInputT, client: TorrentsAPIMixIn) -> None: ...
     def sync_local(self) -> None: ...
     @property
     def state_enum(self) -> TorrentState: ...

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -1,5 +1,6 @@
 import platform
 from time import sleep
+from types import MethodType
 
 import pytest
 
@@ -378,6 +379,17 @@ def test_reannounce(orig_torrent):
 def test_reannounce_not_implemented(orig_torrent):
     with pytest.raises(NotImplementedError):
         orig_torrent.reannounce()
+
+
+@pytest.mark.skipif_before_api_version("2.9.3")
+def test_reannounce_in(orig_torrent):
+    assert "reannounce_in" in orig_torrent.info
+    assert type(orig_torrent.reannounce) is MethodType
+
+
+@pytest.mark.skipif_after_api_version("2.9.2")
+def test_reannounce_in_not_present(orig_torrent):
+    assert "reannounce_in" not in orig_torrent.info
 
 
 @pytest.mark.skipif_before_api_version("2.4.0")


### PR DESCRIPTION
- qBittorrent v5.0.0 adds a `reannounce` attribute for the number of seconds remaining until the next announce.
- To avoid clashing with `reannounce()`, this is renamed to `reannounce_in`.