### PR TITLE
Bump pre-commit hook for ruff-pre-commit from v0.0.289 to v0.0.290

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: [--in-place, --pre-summary-newline, --black, --non-cap=qBittorrent]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.289
+    rev: v0.0.290
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `ruff-pre-commit` from v0.0.289 to v0.0.290 and ran the update against the repo.