### PR TITLE
Drop legacy Python support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,30 +2,30 @@ name: Release Tests
 
 on:
   schedule:
-    - cron: "16 6 * * *"
+    - cron: 16 6 * * *
   push:
-    branches:
-      - "main"
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
   workflow_call:
 
+# cancels running CI if new commit is pushed to branch
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  LATEST_PYTHON_VER: "3.11"
-  LATEST_QBT_VER: "v4.5.5"
-  QBITTORRENTAPI_HOST: "localhost:8080"
-  QBITTORRENTAPI_USERNAME: "admin"
-  QBITTORRENTAPI_PASSWORD: "adminadmin"
-  FORCE_COLOR: "1"
+  LATEST_PYTHON_VER: 3.11
+  LATEST_QBT_VER: v4.5.5
+  QBITTORRENTAPI_HOST: localhost:8080
+  QBITTORRENTAPI_USERNAME: admin
+  QBITTORRENTAPI_PASSWORD: adminadmin
+  FORCE_COLOR: 1
 
 jobs:
   verify:
     name: Get Ready
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       python-latest-version: ${{ steps.set-outputs.outputs.python-latest-version }}
@@ -49,8 +49,8 @@ jobs:
       - name: Set up Python ${{ env.LATEST_PYTHON_VER }}
         uses: actions/setup-python@v4.7.0
         with:
-          python-version: "${{ env.LATEST_PYTHON_VER }}"
-          cache: "pip"
+          python-version: ${{ env.LATEST_PYTHON_VER }}
+          cache: pip
           check-latest: true
           cache-dependency-path: ${{ github.workspace }}/setup.cfg
 
@@ -65,7 +65,7 @@ jobs:
     # Verify build and packaging is successful
     #######
     name: Build & Verify Package
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4.1.0
@@ -73,9 +73,9 @@ jobs:
       - name: Set up Python ${{ env.LATEST_PYTHON_VER }}
         uses: actions/setup-python@v4.7.0
         with:
-          python-version: "${{ env.LATEST_PYTHON_VER }}"
-          cache: "pip"
-          cache-dependency-path: "${{ github.workspace }}/setup.cfg"
+          python-version: ${{ env.LATEST_PYTHON_VER }}
+          cache: pip
+          cache-dependency-path: ${{ github.workspace }}/setup.cfg
 
       - name: Install Build Tools
         run: |
@@ -88,95 +88,70 @@ jobs:
       - name: Upload Package
         uses: actions/upload-artifact@v3.1.3
         with:
-          name: "package"
-          path: "./dist"
-          if-no-files-found: "error"
+          name: package
+          path: ./dist
+          if-no-files-found: error
 
   Tests-qBittorrent:
-    name: "Release Test ${{ needs.verify.outputs.python-latest-version }} - ${{ matrix.QBT_VER }}"
-    needs:
-      - verify
-      - package
+    name: Release Test ${{ needs.verify.outputs.python-latest-version }} - ${{ matrix.QBT_VER }}
+    needs: [ verify, package ]
     strategy:
       matrix:
         QBT_VER:
-          - "v4.6.0rc2"
-          - "v4.4.4"
-          - "v4.3.9"
-          - "v4.3.5"
-          - "v4.3.4.1"
-          - "v4.3.3"
-          - "v4.3.2"
-          - "v4.3.1"
-          - "v4.3.0.1"
-          - "v4.2.5"
-          - "v4.2.0"
-          - "v4.1.6"
-          - "v4.1.0"
+          - v4.6.0rc2
+          - v4.4.4
+          - v4.3.9
+          - v4.3.5
+          - v4.3.4.1
+          - v4.3.3
+          - v4.3.2
+          - v4.3.1
+          - v4.3.0.1
+          - v4.2.5
+          - v4.2.0
+          - v4.1.6
+          - v4.1.0
         include:
           - IS_QBT_DEV: false
           # test dev versions of qBittorrent
-          - QBT_VER: "master"
+          - QBT_VER: master
             IS_QBT_DEV: true
-          - QBT_VER: "v4_5_x"
+          - QBT_VER: v4_5_x
             IS_QBT_DEV: true
-          - QBT_VER: "v4_4_x"
+          - QBT_VER: v4_4_x
             IS_QBT_DEV: true
-          - QBT_VER: "v4_3_x"
+          - QBT_VER: v4_3_x
             IS_QBT_DEV: true
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
-      python-version: "${{ needs.verify.outputs.python-latest-version }}"
-      qbittorrent-version: "${{ matrix.QBT_VER }}"
-      qbittorrent-host: "${{ needs.verify.outputs.qbittorrent-host }}"
-      qbittorrent-username: "${{ needs.verify.outputs.qbittorrent-username }}"
-      qbittorrent-password: "${{ needs.verify.outputs.qbittorrent-password }}"
+      python-version: ${{ needs.verify.outputs.python-latest-version }}
+      qbittorrent-version: ${{ matrix.QBT_VER }}
+      qbittorrent-host: ${{ needs.verify.outputs.qbittorrent-host }}
+      qbittorrent-username: ${{ needs.verify.outputs.qbittorrent-username }}
+      qbittorrent-password: ${{ needs.verify.outputs.qbittorrent-password }}
       is-qbt-dev: ${{ matrix.IS_QBT_DEV }}
 
   Tests-Python:
-    name: "Release Test ${{ matrix.PYTHON_VER }} - ${{ needs.verify.outputs.qbittorrent-latest-version }}"
-    needs:
-      - verify
-      - package
+    name: Release Test ${{ matrix.PYTHON_VER }} - ${{ needs.verify.outputs.qbittorrent-latest-version }}
+    needs: [ verify, package ]
     strategy:
       matrix:
-        PYTHON_VER:
-          - "3.12-dev"
-          - "3.11"
-          - "3.10"
-          - "3.9"
-          - "3.8"
-          - "3.7"
-          - "3.6"
-          - "3.5"
-          - "pypy3.9"
-          - "pypy3.8"
-          - "pypy2.7"
-        include:
-          - OS_VER: "ubuntu-latest"
-          # Python 3.5/6 is not available with ubuntu 22.04 or later
-          - PYTHON_VER: "3.6"
-            OS_VER: "ubuntu-20.04"
-          - PYTHON_VER: "3.5"
-            OS_VER: "ubuntu-20.04"
+        PYTHON_VER: [ 3.12-dev, 3.11, "3.10", pypy3.10, 3.9, 3.8 ]
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
-      python-version: "${{ matrix.PYTHON_VER }}"
-      qbittorrent-version: "${{ needs.verify.outputs.qbittorrent-latest-version }}"
-      qbittorrent-host: "${{ needs.verify.outputs.qbittorrent-host }}"
-      qbittorrent-username: "${{ needs.verify.outputs.qbittorrent-username }}"
-      qbittorrent-password: "${{ needs.verify.outputs.qbittorrent-password }}"
+      python-version: ${{ matrix.PYTHON_VER }}
+      qbittorrent-version: ${{ needs.verify.outputs.qbittorrent-latest-version }}
+      qbittorrent-host: ${{ needs.verify.outputs.qbittorrent-host }}
+      qbittorrent-username: ${{ needs.verify.outputs.qbittorrent-username }}
+      qbittorrent-password: ${{ needs.verify.outputs.qbittorrent-password }}
       is-qbt-dev: false
-      runner-os: "${{ matrix.OS_VER }}"
 
   coverage:
     name: Combine & Check Coverage
-    runs-on: "ubuntu-latest"
-    needs:
-      - Tests-qBittorrent
-      - Tests-Python
+    runs-on: ubuntu-latest
+    needs: [ Tests-qBittorrent, Tests-Python ]
     steps:
       - uses: actions/checkout@v4.1.0
         with:
@@ -185,7 +160,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4.7.0
         with:
-          python-version: "3.x"
+          python-version: 3.x
 
       - name: Install dev dependencies
         run: |
@@ -195,7 +170,7 @@ jobs:
       - name: Retrieve coverage data
         uses: actions/download-artifact@v3.0.2
         with:
-          name: "coverage-data"
+          name: coverage-data
 
       - name: Combine coverage
         run: python -m coverage combine
@@ -206,31 +181,30 @@ jobs:
           python -m coverage html --skip-covered --skip-empty
           python -m coverage report --fail-under=100
 
-      - name: Upload HTML report if check failed
+      - name: Upload HTML coverage report
         if: always() && steps.coverage.outcome == 'failure'
         uses: actions/upload-artifact@v3.1.3
         with:
-          name: "html-coverage-report"
-          path: "./htmlcov"
+          name: html-coverage-report
+          path: ./htmlcov
 
       - name: Upload Coverage to Codecov
         if: contains(fromJson('["push", "pull_request"]'), github.event_name)
         uses: codecov/codecov-action@v3.1.4
         with:
           fail_ci_if_error: true
-          token: "${{ secrets.CODECOV_TOKEN }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   install-dev:
     #######
     # Verify package can be installed on all platforms
     #######
     name: Verify Dev Install
-    needs:
-      - verify
-    runs-on: "${{ matrix.os }}"
+    needs: [ verify ]
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4.1.0
@@ -238,8 +212,8 @@ jobs:
       - name: Set up Python ${{ env.LATEST_PYTHON_VER }}
         uses: actions/setup-python@v4.7.0
         with:
-          python-version: "${{ env.LATEST_PYTHON_VER }}"
-          cache: "pip"
+          python-version: ${{ env.LATEST_PYTHON_VER }}
+          cache: pip
           cache-dependency-path: ${{ github.workspace }}/setup.cfg
 
       - name: Install in Dev Mode

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,30 +21,26 @@ on:
       is-qbt-dev:
         required: true
         type: boolean
-      runner-os:
-        required: false
-        default: ubuntu-latest
-        type: string
 
 env:
-  FORCE_COLOR: "1"
+  FORCE_COLOR: 1
 
 jobs:
 
   test:
     name: Test
-    runs-on: "${{ inputs.runner-os }}"
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     continue-on-error: true
     env:
-      QBT_VER: "${{ inputs.qbittorrent-version }}"
-      QBITTORRENTAPI_HOST: "${{ inputs.qbittorrent-host }}"
-      QBITTORRENTAPI_USERNAME: "${{ inputs.qbittorrent-username }}"
-      QBITTORRENTAPI_PASSWORD: "${{ inputs.qbittorrent-password }}"
+      QBT_VER: ${{ inputs.qbittorrent-version }}
+      QBITTORRENTAPI_HOST: ${{ inputs.qbittorrent-host }}
+      QBITTORRENTAPI_USERNAME: ${{ inputs.qbittorrent-username }}
+      QBITTORRENTAPI_PASSWORD: ${{ inputs.qbittorrent-password }}
       IS_QBT_DEV: ${{ inputs.is-qbt-dev }}
-      DOCKER_QBT_IMAGE_NAME: "ghcr.io/rmartin16/qbittorrent-nox"
-      DOCKER_QBT_IMAGE_TAG: "${{ inputs.qbittorrent-version }}-debug"
-      DOCKER_ARGS: "--name qbt-tox-testing --detach --publish 8080:8080 --volume ${{ github.workspace }}/tests/_resources:/tmp/_resources"
+      DOCKER_QBT_IMAGE_NAME: ghcr.io/rmartin16/qbittorrent-nox
+      DOCKER_QBT_IMAGE_TAG: ${{ inputs.qbittorrent-version }}-debug
+      DOCKER_ARGS: --name qbt-tox-testing --detach --publish 8080:8080 --volume ${{ github.workspace }}/tests/_resources:/tmp/_resources
 
     steps:
       - name: Checkout Repo
@@ -53,14 +49,14 @@ jobs:
       - name: Get packages
         uses: actions/download-artifact@v3.0.2
         with:
-          name: "package"
-          path: "./dist"
+          name: package
+          path: ./dist
 
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v4.7.0
         with:
-          python-version: "${{ inputs.python-version }}"
-          cache: "pip"
+          python-version: ${{ inputs.python-version }}
+          cache: pip
           check-latest: true
           cache-dependency-path: ${{ github.workspace }}/setup.cfg
 
@@ -77,12 +73,7 @@ jobs:
           python -m pip install $(ls dist/qbittorrent_api-*.whl)[dev]
 
       - name: Test
-        if: ${{ !contains(fromJSON('["3.7", "3.6", "3.5", "2.7", "pypy2.7"]'), inputs.python-version) }}
         run: tox -e py-ci --installpkg dist/qbittorrent_api-*.whl
-
-      - name: Test (legacy)
-        if: contains(fromJSON('["3.7", "3.6", "3.5", "2.7", "pypy2.7"]'), inputs.python-version)
-        run: python -m coverage run -m pytest -vv
 
       - name: qBittorrent Log
         if: (steps.start-qbittorrent.outcome == 'success') && (success() || failure())
@@ -92,20 +83,20 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v3.1.3
         with:
-          name: "coverage-data"
-          path: "./.coverage.*"
+          name: coverage-data
+          path: ./.coverage.*
 
       - name: Send mail
         if: failure() && github.event_name != 'pull_request'
         uses: dawidd6/action-send-mail@v3.8.0
         with:
-          server_address: "smtp.gmail.com"
+          server_address: smtp.gmail.com
           server_port: 587
-          username: "${{ secrets.EMAIL_USERNAME }}"
-          password: "${{ secrets.EMAIL_PASSWORD }}"
-          subject: "${{ github.job }} job of ${{ github.repository }} failed"
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: ${{ github.job }} job of ${{ github.repository }} failed
           body: |
             ${{ github.job }} job in workflow ${{ github.workflow }} of ${{ github.repository }} failed.
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          to: "${{ secrets.EMAIL_ADDRESS }}"   # comma-separated string
-          from: "${{ secrets.EMAIL_USERNAME }}"
+          to: ${{ secrets.EMAIL_ADDRESS }}  # comma-separated string
+          from: ${{ secrets.EMAIL_USERNAME }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,21 +14,33 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        additional_dependencies: [toml]
+        additional_dependencies:
+          - toml
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.11.0
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py38-plus
 
   - repo: https://github.com/PyCQA/docformatter
     rev: v1.7.5
     hooks:
       - id: docformatter
         exclude: _attrdict.py
-        args: [--in-place, --pre-summary-newline, --black, --non-cap=qBittorrent]
+        args:
+          - --in-place
+          - --pre-summary-newline
+          - --black
+          - --non-cap=qBittorrent
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.291
     hooks:
       - id: ruff
         args:
-          - "--fix"
+          - --fix
 
   - repo: https://github.com/psf/black
     rev: 23.9.1
@@ -41,17 +53,19 @@ repos:
     hooks:
       - id: mypy
         files: '.*\.pyi'
-        additional_dependencies: ["types-requests", "types-six"]
+        additional_dependencies:
+          - types-requests
+          - types-six
         args:
-          - "--strict"
-          - "--disallow-any-unimported"
-          - "--disallow-any-expr"
-          - "--disallow-any-decorated"
-          - "--warn-unreachable"
-          - "--warn-unused-ignores"
-          - "--warn-redundant-casts"
-          - "--strict-optional"
-          - "--show-traceback"
+          - --strict
+          - --disallow-any-unimported
+          - --disallow-any-expr
+          - --disallow-any-decorated
+          - --warn-unreachable
+          - --warn-unused-ignores
+          - --warn-redundant-casts
+          - --strict-optional
+          - --show-traceback
 
   - repo: local
     hooks:
@@ -59,7 +73,9 @@ repos:
         name: mypy.stubtest
         language: system
         entry: stubtest
-        args: [ "qbittorrentapi", "--allowlist=tests/_resources/mypy_stubtest_allowlist.txt" ]
+        args:
+          - qbittorrentapi
+          - --allowlist=tests/_resources/mypy_stubtest_allowlist.txt
         pass_filenames: false
         types_or:
           - python

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,14 +2,13 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.11"
   jobs:
     pre_build:
       - tox -e docs-lint
@@ -20,11 +19,11 @@ sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true
 
-# Build all output formats
+# Also build the docs in to a PDF
 formats:
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
+# Declare the Python requirements required to build your docs
 python:
   install:
   - method: pip

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Features
 ------------
 * The entire qBittorrent [Web API](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)) is implemented.
 * qBittorrent version checking for an endpoint's existence/features is automatically handled.
-* All Python versions are supported.
 * If the authentication cookie expires, a new one is automatically requested in line with any API call.
 
 Installation

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -14,14 +14,12 @@ Introduction
    :target: https://pypi.org/project/qbittorrent-api/
 .. |pypi versions| image:: https://img.shields.io/pypi/pyversions/qbittorrent-api?style=flat-square
    :target: https://pypi.org/project/qbittorrent-api/
-.. |pypi implementations| image:: https://img.shields.io/pypi/implementation/qbittorrent-api?style=flat-square
-   :target: https://pypi.org/project/qbittorrent-api/
 .. |pypi downloads| image:: https://img.shields.io/pypi/dw/qbittorrent-api?color=blue&style=flat-square
    :target: https://pypi.org/project/qbittorrent-api/
 
 |github ci| |codecov| |coverity| |codacy|
 
-|pypi| |pypi versions| |pypi implementations| |pypi downloads|
+|pypi| |pypi versions| |pypi downloads|
 
 Python client implementation for qBittorrent Web API.
 
@@ -31,7 +29,6 @@ Features
 ------------
 - The entire qBittorrent `Web API <https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)>`_ is implemented.
 - qBittorrent version checking for an endpoint's existence/features is automatically handled.
-- All Python versions are supported.
 - If the authentication cookie expires, a new one is automatically requested in line with any API call.
 
 Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,13 @@ force_single_line = true
 multi_line_output = 3
 
 [tool.black]
-target-version = ['py34']
+target-version = ["py38"]
 include = '\.pyi?$'
 
 [tool.ruff]
 select = ["C40", "C9", "E", "F", "PLE", "S", "W", "YTT"]
 line-length = 121
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["C408", "S101", "S108", "S110", "S106", "S105", "C901"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,6 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Development Status :: 5 - Production/Stable
@@ -50,10 +46,7 @@ include_package_data = True
 package_dir =
     = src
 install_requires =
-    backports.functools-lru-cache; python_version < "3.3"
-    enum34; python_version < "3"
     requests >= 2.16.0
-    six
     urllib3 >= 1.24.2
     packaging
 
@@ -64,24 +57,20 @@ qbittorrentapi =
 
 [options.extras_require]
 dev =
-    black == 23.9.1; python_version >= "3.8"
-    build == 1.0.3; python_version >= "3.8"
-    coverage[toml]; python_version < "3.8"
-    coverage[toml] == 7.3.1; python_version >= "3.8"
-    furo == 2023.9.10; python_version >= "3.8"
-    mock; python_version < "3"
-    mypy == 1.5.1; python_version >= "3.8" and platform_python_implementation != "PyPy"
-    pre-commit; python_version < "3.8"
-    pre-commit == 3.4.0; python_version >= "3.8"
-    pytest; python_version < "3.8"
-    pytest == 7.4.2; python_version >= "3.8"
+    black == 23.9.1
+    build == 1.0.3
+    coverage[toml] == 7.3.1
+    furo == 2023.9.10
+    mypy == 1.5.1; platform_python_implementation != "PyPy"
+    pre-commit == 3.4.0
+    pytest == 7.4.2
     sphinx == 7.2.6; python_version >= "3.9"
-    sphinx-copybutton == 0.5.2; python_version >= "3.8"
-    sphinxcontrib-spelling == 8.0.0; python_version >= "3.8"
-    tox == 4.11.3; python_version >= "3.8"
-    twine == 4.0.2; python_version >= "3.8"
-    types-requests == 2.31.0.5; python_version > "3"
-    types-six == 1.16.21.9; python_version > "3"
+    sphinx-copybutton == 0.5.2
+    sphinxcontrib-spelling == 8.0.0
+    tox == 4.11.3
+    twine == 4.0.2
+    types-requests == 2.31.0.5
+    types-six == 1.16.21.9
 
 [options.packages.find]
 where = src

--- a/src/qbittorrentapi/_types.pyi
+++ b/src/qbittorrentapi/_types.pyi
@@ -1,4 +1,3 @@
-from typing import IO
 from typing import Any
 from typing import Iterable
 from typing import Mapping
@@ -27,4 +26,4 @@ DictMutableInputT = MutableMapping[Text, JsonValueT]
 # Type for inputs to build a List
 ListInputT = Iterable[Mapping[Text, JsonValueT]]
 # Type for `files` in requests.get()/post()
-FilesToSendT = Mapping[Text, IO[bytes] | Tuple[Text, IO[bytes]]]
+FilesToSendT = Mapping[Text, bytes | Tuple[Text, bytes]]

--- a/src/qbittorrentapi/_version_support.py
+++ b/src/qbittorrentapi/_version_support.py
@@ -1,10 +1,6 @@
+from functools import lru_cache
+
 from packaging.version import Version as _Version
-
-try:
-    from functools import lru_cache
-except ImportError:  # pragma: no cover
-    from backports.functools_lru_cache import lru_cache
-
 
 APP_VERSION_2_API_VERSION_MAP = {
     "v4.1.0": "2.0",
@@ -65,7 +61,7 @@ def v(version):
     return _Version(version)
 
 
-class Version(object):
+class Version:
     """
     Allows introspection for whether this Client supports different versions of the
     qBittorrent application and its Web API.

--- a/src/qbittorrentapi/app.py
+++ b/src/qbittorrentapi/app.py
@@ -1,8 +1,6 @@
 from json import dumps
 from logging import getLogger
 
-import six
-
 from qbittorrentapi.auth import AuthAPIMixIn
 from qbittorrentapi.decorators import alias
 from qbittorrentapi.decorators import aliased
@@ -29,9 +27,7 @@ class NetworkInterfaceList(List):
     """Response for :meth:`~AppAPIMixIn.app_network_interface_list`"""
 
     def __init__(self, list_entries, client=None):
-        super(NetworkInterfaceList, self).__init__(
-            list_entries, entry_class=NetworkInterface, client=client
-        )
+        super().__init__(list_entries, entry_class=NetworkInterface, client=client)
 
 
 class NetworkInterface(ListEntry):
@@ -42,7 +38,7 @@ class NetworkInterfaceAddressList(List):
     """Response for :meth:`~AppAPIMixIn.app_network_interface_address_list`"""
 
     def __init__(self, list_entries, client=None):
-        super(NetworkInterfaceAddressList, self).__init__(list_entries)
+        super().__init__(list_entries)
 
 
 @aliased
@@ -126,7 +122,8 @@ class Application(ClientCache):
     def network_interface_address_list(self, interface_name="", **kwargs):
         """Implements :meth:`~AppAPIMixIn.app_network_interface_list`"""
         return self._client.app_network_interface_address_list(
-            interface_name=interface_name, **kwargs
+            interface_name=interface_name,
+            **kwargs,
         )
 
 
@@ -164,10 +161,7 @@ class AppAPIMixIn(AuthAPIMixIn):
         :return: string
         """
         return self._get(
-            _name=APINames.Application,
-            _method="version",
-            response_class=six.text_type,
-            **kwargs
+            _name=APINames.Application, _method="version", response_class=str, **kwargs
         )
 
     @alias("app_webapiVersion")
@@ -181,8 +175,8 @@ class AppAPIMixIn(AuthAPIMixIn):
         return self._MOCK_WEB_API_VERSION or self._get(
             _name=APINames.Application,
             _method="webapiVersion",
-            response_class=six.text_type,
-            **kwargs
+            response_class=str,
+            **kwargs,
         )
 
     @alias("app_buildInfo")
@@ -198,7 +192,7 @@ class AppAPIMixIn(AuthAPIMixIn):
             _name=APINames.Application,
             _method="buildInfo",
             response_class=BuildInfoDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @login_required
@@ -217,7 +211,7 @@ class AppAPIMixIn(AuthAPIMixIn):
             _name=APINames.Application,
             _method="preferences",
             response_class=ApplicationPreferencesDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @alias("app_setPreferences")
@@ -231,7 +225,10 @@ class AppAPIMixIn(AuthAPIMixIn):
         """
         data = {"json": dumps(prefs, separators=(",", ":"))}
         self._post(
-            _name=APINames.Application, _method="setPreferences", data=data, **kwargs
+            _name=APINames.Application,
+            _method="setPreferences",
+            data=data,
+            **kwargs,
         )
 
     @alias("app_defaultSavePath")
@@ -245,8 +242,8 @@ class AppAPIMixIn(AuthAPIMixIn):
         return self._get(
             _name=APINames.Application,
             _method="defaultSavePath",
-            response_class=six.text_type,
-            **kwargs
+            response_class=str,
+            **kwargs,
         )
 
     @alias("app_networkInterfaceList")
@@ -262,7 +259,7 @@ class AppAPIMixIn(AuthAPIMixIn):
             _name=APINames.Application,
             _method="networkInterfaceList",
             response_class=NetworkInterfaceList,
-            **kwargs
+            **kwargs,
         )
 
     @alias("app_networkInterfaceAddressList")
@@ -281,5 +278,5 @@ class AppAPIMixIn(AuthAPIMixIn):
             _method="networkInterfaceAddressList",
             data=data,
             response_class=NetworkInterfaceAddressList,
-            **kwargs
+            **kwargs,
         )

--- a/src/qbittorrentapi/auth.py
+++ b/src/qbittorrentapi/auth.py
@@ -97,7 +97,10 @@ class AuthAPIMixIn(Request):
         self._initialize_context()
         creds = {"username": self.username, "password": self._password}
         auth_response = self._post(
-            _name=APINames.Authorization, _method="login", data=creds, **kwargs
+            _name=APINames.Authorization,
+            _method="login",
+            data=creds,
+            **kwargs,
         )
 
         if auth_response.text != "Ok.":
@@ -114,8 +117,8 @@ class AuthAPIMixIn(Request):
                 and Version.is_app_version_supported(app_version)
             ):
                 raise UnsupportedQbittorrentVersion(
-                    "This version of qBittorrent is not fully supported => App Version: %s API Version: %s"
-                    % (app_version, api_version)
+                    "This version of qBittorrent is not fully supported => "
+                    f"App Version: {app_version} API Version: {api_version}"
                 )
 
     @property

--- a/src/qbittorrentapi/auth.pyi
+++ b/src/qbittorrentapi/auth.pyi
@@ -17,7 +17,7 @@ class Authorization(ClientCache):
         self,
         username: Optional[Text] = None,
         password: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     def log_out(self, **kwargs: KwargsT) -> None: ...
 
@@ -32,7 +32,7 @@ class AuthAPIMixIn(Request):
         self,
         username: Optional[Text] = None,
         password: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     @property
     def _SID(self) -> Optional[Text]: ...

--- a/src/qbittorrentapi/client.py
+++ b/src/qbittorrentapi/client.py
@@ -112,9 +112,9 @@ class Client(
         VERBOSE_RESPONSE_LOGGING=False,
         SIMPLE_RESPONSES=False,
         DISABLE_LOGGING_DEBUG_OUTPUT=False,
-        **kwargs
+        **kwargs,
     ):
-        super(Client, self).__init__(
+        super().__init__(
             host=host,
             port=port,
             username=username,
@@ -128,5 +128,5 @@ class Client(
             VERBOSE_RESPONSE_LOGGING=VERBOSE_RESPONSE_LOGGING,
             SIMPLE_RESPONSES=SIMPLE_RESPONSES,
             DISABLE_LOGGING_DEBUG_OUTPUT=DISABLE_LOGGING_DEBUG_OUTPUT,
-            **kwargs
+            **kwargs,
         )

--- a/src/qbittorrentapi/client.pyi
+++ b/src/qbittorrentapi/client.pyi
@@ -42,5 +42,5 @@ class Client(
         VERBOSE_RESPONSE_LOGGING: Optional[bool] = False,
         SIMPLE_RESPONSES: Optional[bool] = False,
         DISABLE_LOGGING_DEBUG_OUTPUT: Optional[bool] = False,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...

--- a/src/qbittorrentapi/decorators.py
+++ b/src/qbittorrentapi/decorators.py
@@ -7,7 +7,7 @@ from qbittorrentapi.exceptions import HTTP403Error
 logger = getLogger(__name__)
 
 
-class alias(object):
+class alias:
     """
     Alias class that can be used as a decorator for making methods callable
     through other names (or "aliases").
@@ -141,9 +141,8 @@ def endpoint_introduced(version_introduced, endpoint):
             # if the endpoint doesn't exist, return None or log an error / raise an Exception
             if v(client.app_web_api_version()) < v(version_introduced):
                 error_message = (
-                    "ERROR: Endpoint '%s' is Not Implemented in this version of qBittorrent. "
-                    "This endpoint is available starting in Web API v%s."
-                    % (endpoint, version_introduced)
+                    f"ERROR: Endpoint '{endpoint}' is Not Implemented in this version of qBittorrent. "
+                    f"This endpoint is available starting in Web API v{version_introduced}."
                 )
                 check_for_raise(client=client, error_message=error_message)
                 return None
@@ -171,9 +170,8 @@ def version_removed(version_obsoleted, endpoint):
             # if the endpoint doesn't exist, return None or log an error / raise an Exception
             if v(client.app_web_api_version()) >= v(version_obsoleted):
                 error_message = (
-                    "ERROR: Endpoint '%s' is Not Implemented. "
-                    "This endpoint was removed in Web API v%s."
-                    % (endpoint, version_obsoleted)
+                    f"ERROR: Endpoint '{endpoint}' is Not Implemented. "
+                    f"This endpoint was removed in Web API v{version_obsoleted}."
                 )
                 check_for_raise(client=client, error_message=error_message)
                 return None

--- a/src/qbittorrentapi/definitions.py
+++ b/src/qbittorrentapi/definitions.py
@@ -1,11 +1,6 @@
+from collections import UserList
+from collections.abc import Mapping
 from enum import Enum
-
-try:
-    from collections import UserList
-    from collections.abc import Mapping
-except ImportError:  # pragma: no cover
-    from collections import Mapping
-    from UserList import UserList
 
 from qbittorrentapi._attrdict import AttrDict
 
@@ -166,7 +161,7 @@ class TrackerStatus(int, Enum):
         }[self]
 
 
-class ClientCache(object):
+class ClientCache:
     """
     Caches the client.
 
@@ -175,14 +170,14 @@ class ClientCache(object):
 
     def __init__(self, *args, **kwargs):
         self._client = kwargs.pop("client")
-        super(ClientCache, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class Dictionary(ClientCache, AttrDict):
     """Base definition of dictionary-like objects returned from qBittorrent."""
 
     def __init__(self, data=None, client=None):
-        super(Dictionary, self).__init__(self._normalize(data or {}), client=client)
+        super().__init__(self._normalize(data or {}), client=client)
         # allows updating properties that aren't necessarily a part of the AttrDict
         self._setattr("_allow_invalid_attributes", True)
 
@@ -199,7 +194,7 @@ class List(UserList):
 
     def __init__(self, list_entries=None, entry_class=None, client=None):
         is_safe_cast = None not in {client, entry_class}
-        super(List, self).__init__(
+        super().__init__(
             [
                 entry_class(data=entry, client=client)
                 if is_safe_cast and isinstance(entry, dict)

--- a/src/qbittorrentapi/log.py
+++ b/src/qbittorrentapi/log.py
@@ -10,9 +10,7 @@ class LogPeersList(List):
     """Response for :meth:`~LogAPIMixIn.log_peers`"""
 
     def __init__(self, list_entries, client=None):
-        super(LogPeersList, self).__init__(
-            list_entries, entry_class=LogPeer, client=client
-        )
+        super().__init__(list_entries, entry_class=LogPeer, client=client)
 
 
 class LogPeer(ListEntry):
@@ -23,9 +21,7 @@ class LogMainList(List):
     """Response to :meth:`~LogAPIMixIn.log_main`"""
 
     def __init__(self, list_entries, client=None):
-        super(LogMainList, self).__init__(
-            list_entries, entry_class=LogEntry, client=client
-        )
+        super().__init__(list_entries, entry_class=LogEntry, client=client)
 
 
 class LogEntry(ListEntry):
@@ -49,7 +45,7 @@ class Log(ClientCache):
     """
 
     def __init__(self, client):
-        super(Log, self).__init__(client=client)
+        super().__init__(client=client)
         self.main = Log._Main(client=client)
 
     def peers(self, last_known_id=None, **kwargs):
@@ -64,7 +60,7 @@ class Log(ClientCache):
             warning=None,
             critical=None,
             last_known_id=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.log_main(
                 normal=normal,
@@ -72,7 +68,7 @@ class Log(ClientCache):
                 warning=warning,
                 critical=critical,
                 last_known_id=last_known_id,
-                **kwargs
+                **kwargs,
             )
 
         def __call__(
@@ -82,7 +78,7 @@ class Log(ClientCache):
             warning=True,
             critical=True,
             last_known_id=None,
-            **kwargs
+            **kwargs,
         ):
             return self._api_call(
                 normal=normal,
@@ -90,7 +86,7 @@ class Log(ClientCache):
                 warning=warning,
                 critical=critical,
                 last_known_id=last_known_id,
-                **kwargs
+                **kwargs,
             )
 
         def info(self, last_known_id=None, **kwargs):
@@ -110,7 +106,7 @@ class Log(ClientCache):
                 normal=False,
                 warning=False,
                 last_known_id=last_known_id,
-                **kwargs
+                **kwargs,
             )
 
 
@@ -145,7 +141,7 @@ class LogAPIMixIn(AppAPIMixIn):
         warning=None,
         critical=None,
         last_known_id=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Retrieve the qBittorrent log entries. Iterate over returned object.
@@ -169,7 +165,7 @@ class LogAPIMixIn(AppAPIMixIn):
             _method="main",
             params=params,
             response_class=LogMainList,
-            **kwargs
+            **kwargs,
         )
 
     @login_required
@@ -186,5 +182,5 @@ class LogAPIMixIn(AppAPIMixIn):
             _method="peers",
             params=params,
             response_class=LogPeersList,
-            **kwargs
+            **kwargs,
         )

--- a/src/qbittorrentapi/log.pyi
+++ b/src/qbittorrentapi/log.pyi
@@ -43,7 +43,7 @@ class Log(ClientCache):
             warning: Optional[bool] = None,
             critical: Optional[bool] = None,
             last_known_id: Optional[bool] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> LogMainList: ...
         def __call__(
             self,
@@ -52,7 +52,7 @@ class Log(ClientCache):
             warning: Optional[bool] = True,
             critical: Optional[bool] = True,
             last_known_id: Optional[bool] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> LogMainList: ...
         def info(
             self,
@@ -85,7 +85,7 @@ class LogAPIMixIn(AppAPIMixIn):
         warning: Optional[bool] = None,
         critical: Optional[bool] = None,
         last_known_id: Optional[bool] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> LogMainList: ...
     def log_peers(
         self,

--- a/src/qbittorrentapi/request.pyi
+++ b/src/qbittorrentapi/request.pyi
@@ -110,7 +110,7 @@ class Request(object):
         port: Optional[Text | int] = None,
         username: Optional[Text] = None,
         password: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     def _initialize_context(self) -> None: ...
     def _initialize_lesser(
@@ -146,7 +146,7 @@ class Request(object):
         data: Optional[Mapping[Text, Any]] = None,
         files: Optional[FilesToSendT] = None,
         response_class: Optional[Type[FinalResponseT]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> FinalResponseT: ...
     def _post(
         self,
@@ -159,7 +159,7 @@ class Request(object):
         data: Optional[Mapping[Text, Any]] = None,
         files: Optional[FilesToSendT] = None,
         response_class: Optional[Type[FinalResponseT]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> FinalResponseT: ...
     def _request_manager(
         self,
@@ -175,7 +175,7 @@ class Request(object):
         data: Optional[Mapping[Text, Any]] = None,
         files: Optional[FilesToSendT] = None,
         response_class: Optional[Type[FinalResponseT]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> FinalResponseT: ...
     def _request(
         self,
@@ -189,7 +189,7 @@ class Request(object):
         data: Optional[Mapping[Text, Any]] = None,
         files: Optional[FilesToSendT] = None,
         response_class: Optional[Type[FinalResponseT]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> FinalResponseT: ...
     @staticmethod
     def _get_response_kwargs(
@@ -211,13 +211,13 @@ class Request(object):
         params: Optional[Mapping[Text, Any]] = None,
         data: Optional[Mapping[Text, Any]] = None,
         files: Optional[FilesToSendT] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> Tuple[dict[Text, Any], dict[Text, Any], FilesToSendT]: ...
     def _cast(
         self,
         response: Response,
         response_class: Type[FinalResponseT],
-        **response_kwargs: KwargsT
+        **response_kwargs: KwargsT,
     ) -> FinalResponseT: ...
     @property
     def _session(self) -> Session: ...

--- a/src/qbittorrentapi/rss.py
+++ b/src/qbittorrentapi/rss.py
@@ -38,7 +38,7 @@ class RSS(ClientCache):
     """
 
     def __init__(self, client):
-        super(RSS, self).__init__(client=client)
+        super().__init__(client=client)
         self.items = RSS._Items(client=client)
 
     @alias("addFolder")
@@ -65,7 +65,9 @@ class RSS(ClientCache):
     def move_item(self, orig_item_path=None, new_item_path=None, **kwargs):
         """Implements :meth:`~RSSAPIMixIn.rss_move_item`"""
         return self._client.rss_move_item(
-            orig_item_path=orig_item_path, new_item_path=new_item_path, **kwargs
+            orig_item_path=orig_item_path,
+            new_item_path=new_item_path,
+            **kwargs,
         )
 
     @alias("refreshItem")
@@ -77,21 +79,27 @@ class RSS(ClientCache):
     def mark_as_read(self, item_path=None, article_id=None, **kwargs):
         """Implements :meth:`~RSSAPIMixIn.rss_mark_as_read`"""
         return self._client.rss_mark_as_read(
-            item_path=item_path, article_id=article_id, **kwargs
+            item_path=item_path,
+            article_id=article_id,
+            **kwargs,
         )
 
     @alias("setRule")
     def set_rule(self, rule_name=None, rule_def=None, **kwargs):
         """Implements :meth:`~RSSAPIMixIn.rss_set_rule`"""
         return self._client.rss_set_rule(
-            rule_name=rule_name, rule_def=rule_def, **kwargs
+            rule_name=rule_name,
+            rule_def=rule_def,
+            **kwargs,
         )
 
     @alias("renameRule")
     def rename_rule(self, orig_rule_name=None, new_rule_name=None, **kwargs):
         """Implements :meth:`~RSSAPIMixIn.rss_rename_rule`"""
         return self._client.rss_rename_rule(
-            orig_rule_name=orig_rule_name, new_rule_name=new_rule_name, **kwargs
+            orig_rule_name=orig_rule_name,
+            new_rule_name=new_rule_name,
+            **kwargs,
         )
 
     @alias("removeRule")
@@ -168,7 +176,7 @@ class RSSAPIMixIn(AppAPIMixIn):
 
         :raises Conflict409Error:
 
-        :param url: URL of RSS feed (e.g https://distrowatch.com/news/torrents.xml)
+        :param url: URL of RSS feed (e.g. https://distrowatch.com/news/torrents.xml)
         :param item_path: Name and/or path for new feed (e.g. ``Folder\\Subfolder\\FeedName``)
         :return: None
         """
@@ -184,7 +192,7 @@ class RSSAPIMixIn(AppAPIMixIn):
 
         :raises Conflict409Error:
 
-        :param url: URL of RSS feed (e.g https://distrowatch.com/news/torrents.xml)
+        :param url: URL of RSS feed (e.g. https://distrowatch.com/news/torrents.xml)
         :param item_path: Name and/or path for feed (e.g. ``Folder\\Subfolder\\FeedName``)
         :return: None
         """
@@ -211,7 +219,7 @@ class RSSAPIMixIn(AppAPIMixIn):
     @login_required
     def rss_move_item(self, orig_item_path=None, new_item_path=None, **kwargs):
         """
-        Move/rename an RSS item (folder, feed, etc).
+        Move/rename an RSS item (folder, feed, etc.).
 
         :raises Conflict409Error:
 
@@ -238,7 +246,7 @@ class RSSAPIMixIn(AppAPIMixIn):
             _method="items",
             params=params,
             response_class=RSSitemsDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @endpoint_introduced("2.2", "rss/refreshItem")
@@ -325,7 +333,7 @@ class RSSAPIMixIn(AppAPIMixIn):
             _name=APINames.RSS,
             _method="rules",
             response_class=RSSRulesDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @endpoint_introduced("2.5.1", "rss/matchingArticles")
@@ -344,5 +352,5 @@ class RSSAPIMixIn(AppAPIMixIn):
             _method="matchingArticles",
             data=data,
             response_class=RSSitemsDictionary,
-            **kwargs
+            **kwargs,
         )

--- a/src/qbittorrentapi/rss.pyi
+++ b/src/qbittorrentapi/rss.pyi
@@ -24,14 +24,14 @@ class RSS(ClientCache):
         self,
         url: Optional[Text] = None,
         item_path: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     addFeed = add_feed
     def set_feed_url(
         self,
         url: Optional[Text] = None,
         item_path: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     setFeedURL = set_feed_url
     def remove_item(
@@ -44,7 +44,7 @@ class RSS(ClientCache):
         self,
         orig_item_path: Optional[Text] = None,
         new_item_path: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     moveItem = move_item
     def refresh_item(self, item_path: Optional[Text] = None) -> None: ...
@@ -53,21 +53,21 @@ class RSS(ClientCache):
         self,
         item_path: Optional[Text] = None,
         article_id: Optional[Text | int] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     markAsRead = mark_as_read
     def set_rule(
         self,
         rule_name: Optional[Text] = None,
         rule_def: Optional[Mapping[Text, JsonValueT]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     setRule = set_rule
     def rename_rule(
         self,
         orig_rule_name: Optional[Text] = None,
         new_rule_name: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     renameRule = rename_rule
     def remove_rule(
@@ -109,14 +109,14 @@ class RSSAPIMixIn(AppAPIMixIn):
         self,
         url: Optional[Text] = None,
         item_path: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     rss_addFeed = rss_add_feed
     def rss_set_feed_url(
         self,
         url: Optional[Text] = None,
         item_path: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     rss_setFeedURL = rss_set_feed_url
     def rss_remove_item(
@@ -129,7 +129,7 @@ class RSSAPIMixIn(AppAPIMixIn):
         self,
         orig_item_path: Optional[Text] = None,
         new_item_path: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     rss_moveItem = rss_move_item
     def rss_items(
@@ -147,21 +147,21 @@ class RSSAPIMixIn(AppAPIMixIn):
         self,
         item_path: Optional[Text] = None,
         article_id: Optional[Text | int] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     rss_markAsRead = rss_mark_as_read
     def rss_set_rule(
         self,
         rule_name: Optional[Text] = None,
         rule_def: Optional[Mapping[Text, JsonValueT]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     rss_setRule = rss_set_rule
     def rss_rename_rule(
         self,
         orig_rule_name: Optional[Text] = None,
         new_rule_name: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     rss_renameRule = rss_rename_rule
     def rss_remove_rule(

--- a/src/qbittorrentapi/search.py
+++ b/src/qbittorrentapi/search.py
@@ -16,7 +16,7 @@ class SearchJobDictionary(Dictionary):
 
     def __init__(self, data, client):
         self._search_job_id = data.get("id", None)
-        super(SearchJobDictionary, self).__init__(data=data, client=client)
+        super().__init__(data=data, client=client)
 
     def stop(self, **kwargs):
         """Implements :meth:`~SearchAPIMixIn.search_stop`"""
@@ -45,9 +45,7 @@ class SearchStatusesList(List):
     """Response for :meth:`~SearchAPIMixIn.search_status`"""
 
     def __init__(self, list_entries, client=None):
-        super(SearchStatusesList, self).__init__(
-            list_entries, entry_class=SearchStatus, client=client
-        )
+        super().__init__(list_entries, entry_class=SearchStatus, client=client)
 
 
 class SearchStatus(ListEntry):
@@ -58,9 +56,7 @@ class SearchCategoriesList(List):
     """Response for :meth:`~SearchAPIMixIn.search_categories`"""
 
     def __init__(self, list_entries, client=None):
-        super(SearchCategoriesList, self).__init__(
-            list_entries, entry_class=SearchCategory, client=client
-        )
+        super().__init__(list_entries, entry_class=SearchCategory, client=client)
 
 
 class SearchCategory(ListEntry):
@@ -71,9 +67,7 @@ class SearchPluginsList(List):
     """Response for :meth:`~SearchAPIMixIn.search_plugins`"""
 
     def __init__(self, list_entries, client=None):
-        super(SearchPluginsList, self).__init__(
-            list_entries, entry_class=SearchPlugin, client=client
-        )
+        super().__init__(list_entries, entry_class=SearchPlugin, client=client)
 
 
 class SearchPlugin(ListEntry):
@@ -105,7 +99,10 @@ class Search(ClientCache):
     def start(self, pattern=None, plugins=None, category=None, **kwargs):
         """Implements :meth:`~SearchAPIMixIn.search_start`"""
         return self._client.search_start(
-            pattern=pattern, plugins=plugins, category=category, **kwargs
+            pattern=pattern,
+            plugins=plugins,
+            category=category,
+            **kwargs,
         )
 
     def stop(self, search_id=None, **kwargs):
@@ -119,7 +116,10 @@ class Search(ClientCache):
     def results(self, search_id=None, limit=None, offset=None, **kwargs):
         """Implements :meth:`~SearchAPIMixIn.search_results`"""
         return self._client.search_results(
-            search_id=search_id, limit=limit, offset=offset, **kwargs
+            search_id=search_id,
+            limit=limit,
+            offset=offset,
+            **kwargs,
         )
 
     def delete(self, search_id=None, **kwargs):
@@ -149,7 +149,9 @@ class Search(ClientCache):
     def enable_plugin(self, plugins=None, enable=None, **kwargs):
         """Implements :meth:`~SearchAPIMixIn.search_enable_plugin`"""
         return self._client.search_enable_plugin(
-            plugins=plugins, enable=enable, **kwargs
+            plugins=plugins,
+            enable=enable,
+            **kwargs,
         )
 
     @alias("updatePlugins")
@@ -209,7 +211,7 @@ class SearchAPIMixIn(AppAPIMixIn):
             _method="start",
             data=data,
             response_class=SearchJobDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @endpoint_introduced("2.1.1", "search/stop")
@@ -242,7 +244,7 @@ class SearchAPIMixIn(AppAPIMixIn):
             _method="status",
             params=params,
             response_class=SearchStatusesList,
-            **kwargs
+            **kwargs,
         )
 
     @endpoint_introduced("2.1.1", "search/results")
@@ -265,7 +267,7 @@ class SearchAPIMixIn(AppAPIMixIn):
             _method="results",
             data=data,
             response_class=SearchResultsDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @endpoint_introduced("2.1.1", "search/delete")
@@ -299,7 +301,7 @@ class SearchAPIMixIn(AppAPIMixIn):
             _method="categories",
             data=data,
             response_class=SearchCategoriesList,
-            **kwargs
+            **kwargs,
         )
 
     @endpoint_introduced("2.1.1", "search/plugins")
@@ -314,7 +316,7 @@ class SearchAPIMixIn(AppAPIMixIn):
             _name=APINames.Search,
             _method="plugins",
             response_class=SearchPluginsList,
-            **kwargs
+            **kwargs,
         )
 
     @endpoint_introduced("2.1.1", "search/installPlugin")
@@ -342,7 +344,10 @@ class SearchAPIMixIn(AppAPIMixIn):
         """
         data = {"names": self._list2string(names, "|")}
         self._post(
-            _name=APINames.Search, _method="uninstallPlugin", data=data, **kwargs
+            _name=APINames.Search,
+            _method="uninstallPlugin",
+            data=data,
+            **kwargs,
         )
 
     @endpoint_introduced("2.1.1", "search/enablePlugin")

--- a/src/qbittorrentapi/search.pyi
+++ b/src/qbittorrentapi/search.pyi
@@ -23,7 +23,7 @@ class SearchJobDictionary(JsonDictionaryT):
         self,
         limit: Optional[Text | int] = None,
         offset: Optional[Text | int] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> SearchResultsDictionary: ...
     def delete(self, **kwargs: KwargsT) -> None: ...
 
@@ -61,7 +61,7 @@ class Search(ClientCache):
         pattern: Optional[Text] = None,
         plugins: Optional[Iterable[Text]] = None,
         category: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> SearchJobDictionary: ...
     def stop(
         self,
@@ -78,7 +78,7 @@ class Search(ClientCache):
         search_id: Optional[Text | int] = None,
         limit: Optional[Text | int] = None,
         offset: Optional[Text | int] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> SearchResultsDictionary: ...
     def delete(
         self,
@@ -108,7 +108,7 @@ class Search(ClientCache):
         self,
         plugins: Optional[Iterable[Text]] = None,
         enable: Optional[bool] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     enablePlugin = enable_plugin
     def update_plugins(self, **kwargs: KwargsT) -> None: ...
@@ -122,7 +122,7 @@ class SearchAPIMixIn(AppAPIMixIn):
         pattern: Optional[Text] = None,
         plugins: Optional[Iterable[Text]] = None,
         category: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> SearchJobDictionary: ...
     def search_stop(
         self,
@@ -139,7 +139,7 @@ class SearchAPIMixIn(AppAPIMixIn):
         search_id: Optional[Text | int] = None,
         limit: Optional[Text | int] = None,
         offset: Optional[Text | int] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> SearchResultsDictionary: ...
     def search_delete(
         self,
@@ -168,7 +168,7 @@ class SearchAPIMixIn(AppAPIMixIn):
         self,
         plugins: Optional[Iterable[Text]] = None,
         enable: Optional[bool] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     search_enablePlugin = search_enable_plugin
     def search_update_plugins(self, **kwargs: KwargsT) -> None: ...

--- a/src/qbittorrentapi/sync.py
+++ b/src/qbittorrentapi/sync.py
@@ -35,14 +35,14 @@ class Sync(ClientCache):
     """
 
     def __init__(self, client):
-        super(Sync, self).__init__(client=client)
+        super().__init__(client=client)
         self.maindata = self._MainData(client=client)
         self.torrent_peers = self._TorrentPeers(client=client)
         self.torrentPeers = self.torrent_peers
 
     class _MainData(ClientCache):
         def __init__(self, client):
-            super(Sync._MainData, self).__init__(client=client)
+            super().__init__(client=client)
             self._rid = 0
 
         def __call__(self, rid=None, **kwargs):
@@ -58,7 +58,7 @@ class Sync(ClientCache):
 
     class _TorrentPeers(ClientCache):
         def __init__(self, client):
-            super(Sync._TorrentPeers, self).__init__(client=client)
+            super().__init__(client=client)
             self._rid = None
 
         def __call__(self, torrent_hash=None, rid=None, **kwargs):
@@ -115,7 +115,7 @@ class SyncAPIMixIn(AppAPIMixIn):
             _method="maindata",
             data=data,
             response_class=SyncMainDataDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @alias("sync_torrentPeers")
@@ -137,5 +137,5 @@ class SyncAPIMixIn(AppAPIMixIn):
             _method="torrentPeers",
             data=data,
             response_class=SyncTorrentPeersDictionary,
-            **kwargs
+            **kwargs,
         )

--- a/src/qbittorrentapi/sync.pyi
+++ b/src/qbittorrentapi/sync.pyi
@@ -37,7 +37,7 @@ class Sync(ClientCache):
             self,
             torrent_hash: Optional[Text] = None,
             rid: Optional[Text | int] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> SyncTorrentPeersDictionary: ...
         def delta(
             self,
@@ -58,6 +58,6 @@ class SyncAPIMixIn(AppAPIMixIn):
         self,
         torrent_hash: Optional[Text] = None,
         rid: Text | int = 0,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> SyncTorrentPeersDictionary: ...
     sync_torrentPeers = sync_torrent_peers

--- a/src/qbittorrentapi/torrents.py
+++ b/src/qbittorrentapi/torrents.py
@@ -1,16 +1,9 @@
 import errno
+from collections.abc import Iterable
+from collections.abc import Mapping
 from logging import getLogger
 from os import path
 from os import strerror as os_strerror
-
-try:
-    from collections.abc import Iterable
-    from collections.abc import Mapping
-except ImportError:  # pragma: no cover
-    from collections import Iterable
-    from collections import Mapping
-
-import six
 
 from qbittorrentapi._version_support import v
 from qbittorrentapi.app import AppAPIMixIn
@@ -68,7 +61,7 @@ class TorrentDictionary(Dictionary):
         # To avoid clashing with `reannounce()`, rename to `reannounce_in`.
         if "reannounce" in data:
             data["reannounce_in"] = data.pop("reannounce")
-        super(TorrentDictionary, self).__init__(client=client, data=data)
+        super().__init__(client=client, data=data)
 
     def sync_local(self):
         """Update local cache of torrent info."""
@@ -123,14 +116,16 @@ class TorrentDictionary(Dictionary):
     def increase_priority(self, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_increase_priority`"""
         self._client.torrents_increase_priority(
-            torrent_hashes=self._torrent_hash, **kwargs
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("decreasePrio")
     def decrease_priority(self, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_decrease_priority`"""
         self._client.torrents_decrease_priority(
-            torrent_hashes=self._torrent_hash, **kwargs
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("topPrio")
@@ -142,7 +137,8 @@ class TorrentDictionary(Dictionary):
     def bottom_priority(self, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_bottom_priority`"""
         self._client.torrents_bottom_priority(
-            torrent_hashes=self._torrent_hash, **kwargs
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("setShareLimits")
@@ -151,7 +147,7 @@ class TorrentDictionary(Dictionary):
         ratio_limit=None,
         seeding_time_limit=None,
         inactive_seeding_time_limit=None,
-        **kwargs
+        **kwargs,
     ):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_set_share_limits`"""
         self._client.torrents_set_share_limits(
@@ -159,7 +155,7 @@ class TorrentDictionary(Dictionary):
             seeding_time_limit=seeding_time_limit,
             inactive_seeding_time_limit=inactive_seeding_time_limit,
             torrent_hashes=self._torrent_hash,
-            **kwargs
+            **kwargs,
         )
 
     @property
@@ -185,7 +181,9 @@ class TorrentDictionary(Dictionary):
     def set_download_limit(self, limit=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_set_download_limit`"""
         self._client.torrents_set_download_limit(
-            limit=limit, torrent_hashes=self._torrent_hash, **kwargs
+            limit=limit,
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @property
@@ -211,42 +209,54 @@ class TorrentDictionary(Dictionary):
     def set_upload_limit(self, limit=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_set_upload_limit`"""
         self._client.torrents_set_upload_limit(
-            limit=limit, torrent_hashes=self._torrent_hash, **kwargs
+            limit=limit,
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("setLocation")
     def set_location(self, location=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_set_location`"""
         self._client.torrents_set_location(
-            location=location, torrent_hashes=self._torrent_hash, **kwargs
+            location=location,
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("setSavePath")
     def set_save_path(self, save_path=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_set_save_path`"""
         self._client.torrents_set_save_path(
-            save_path=save_path, torrent_hashes=self._torrent_hash, **kwargs
+            save_path=save_path,
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("setDownloadPath")
     def set_download_path(self, download_path=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_set_download_path`"""
         self._client.torrents_set_download_path(
-            download_path=download_path, torrent_hashes=self._torrent_hash, **kwargs
+            download_path=download_path,
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("setCategory")
     def set_category(self, category=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_set_category`"""
         self._client.torrents_set_category(
-            category=category, torrent_hashes=self._torrent_hash, **kwargs
+            category=category,
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("setAutoManagement")
     def set_auto_management(self, enable=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_set_auto_management`"""
         self._client.torrents_set_auto_management(
-            enable=enable, torrent_hashes=self._torrent_hash, **kwargs
+            enable=enable,
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("toggleSequentialDownload")
@@ -261,21 +271,26 @@ class TorrentDictionary(Dictionary):
         """Implements
         :meth:`~TorrentsAPIMixIn.torrents_toggle_first_last_piece_priority`"""
         self._client.torrents_toggle_first_last_piece_priority(
-            torrent_hashes=self._torrent_hash, **kwargs
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("setForceStart")
     def set_force_start(self, enable=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_set_force_start`"""
         self._client.torrents_set_force_start(
-            enable=enable, torrent_hashes=self._torrent_hash, **kwargs
+            enable=enable,
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @alias("setSuperSeeding")
     def set_super_seeding(self, enable=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_set_super_seeding`"""
         self._client.torrents_set_super_seeding(
-            enable=enable, torrent_hashes=self._torrent_hash, **kwargs
+            enable=enable,
+            torrent_hashes=self._torrent_hash,
+            **kwargs,
         )
 
     @property
@@ -305,7 +320,12 @@ class TorrentDictionary(Dictionary):
 
     @alias("renameFile")
     def rename_file(
-        self, file_id=None, new_file_name=None, old_path=None, new_path=None, **kwargs
+        self,
+        file_id=None,
+        new_file_name=None,
+        old_path=None,
+        new_path=None,
+        **kwargs,
     ):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_rename_file`"""
         self._client.torrents_rename_file(
@@ -314,7 +334,7 @@ class TorrentDictionary(Dictionary):
             new_file_name=new_file_name,
             old_path=old_path,
             new_path=new_path,
-            **kwargs
+            **kwargs,
         )
 
     @alias("renameFolder")
@@ -324,7 +344,7 @@ class TorrentDictionary(Dictionary):
             torrent_hash=self._torrent_hash,
             old_path=old_path,
             new_path=new_path,
-            **kwargs
+            **kwargs,
         )
 
     @property
@@ -355,14 +375,16 @@ class TorrentDictionary(Dictionary):
             torrent_hash=self._torrent_hash,
             original_url=orig_url,
             new_url=new_url,
-            **kwargs
+            **kwargs,
         )
 
     @alias("removeTrackers")
     def remove_trackers(self, urls=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_trackers`"""
         self._client.torrents_remove_trackers(
-            torrent_hash=self._torrent_hash, urls=urls, **kwargs
+            torrent_hash=self._torrent_hash,
+            urls=urls,
+            **kwargs,
         )
 
     @alias("filePriority")
@@ -372,27 +394,31 @@ class TorrentDictionary(Dictionary):
             torrent_hash=self._torrent_hash,
             file_ids=file_ids,
             priority=priority,
-            **kwargs
+            **kwargs,
         )
 
     def rename(self, new_name=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_rename`"""
         self._client.torrents_rename(
             torrent_hash=self._torrent_hash, new_torrent_name=new_name, **kwargs
-        )
+        ),
 
     @alias("addTags")
     def add_tags(self, tags=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_add_tags`"""
         self._client.torrents_add_tags(
-            torrent_hashes=self._torrent_hash, tags=tags, **kwargs
+            torrent_hashes=self._torrent_hash,
+            tags=tags,
+            **kwargs,
         )
 
     @alias("removeTags")
     def remove_tags(self, tags=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_tags`"""
         self._client.torrents_remove_tags(
-            torrent_hashes=self._torrent_hash, tags=tags, **kwargs
+            torrent_hashes=self._torrent_hash,
+            tags=tags,
+            **kwargs,
         )
 
     def export(self, **kwargs):
@@ -420,9 +446,7 @@ class TorrentFilesList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_files`"""
 
     def __init__(self, list_entries, client=None):
-        super(TorrentFilesList, self).__init__(
-            list_entries, entry_class=TorrentFile, client=client
-        )
+        super().__init__(list_entries, entry_class=TorrentFile, client=client)
         # until v4.3.5, the index key wasn't returned...default it to ID for older versions.
         # when index is returned, maintain backwards compatibility and populate id with index value.
         for i, entry in enumerate(self):
@@ -437,9 +461,7 @@ class WebSeedsList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_webseeds`"""
 
     def __init__(self, list_entries, client=None):
-        super(WebSeedsList, self).__init__(
-            list_entries, entry_class=WebSeed, client=client
-        )
+        super().__init__(list_entries, entry_class=WebSeed, client=client)
 
 
 class WebSeed(ListEntry):
@@ -450,9 +472,7 @@ class TrackersList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_trackers`"""
 
     def __init__(self, list_entries, client=None):
-        super(TrackersList, self).__init__(
-            list_entries, entry_class=Tracker, client=client
-        )
+        super().__init__(list_entries, entry_class=Tracker, client=client)
 
 
 class Tracker(ListEntry):
@@ -463,9 +483,7 @@ class TorrentInfoList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_info`"""
 
     def __init__(self, list_entries, client=None):
-        super(TorrentInfoList, self).__init__(
-            list_entries, entry_class=TorrentDictionary, client=client
-        )
+        super().__init__(list_entries, entry_class=TorrentDictionary, client=client)
 
 
 class TorrentPieceInfoList(List):
@@ -473,9 +491,7 @@ class TorrentPieceInfoList(List):
     :meth:`~TorrentsAPIMixIn.torrents_piece_hashes`"""
 
     def __init__(self, list_entries, client=None):
-        super(TorrentPieceInfoList, self).__init__(
-            list_entries, entry_class=TorrentPieceData, client=client
-        )
+        super().__init__(list_entries, entry_class=TorrentPieceData, client=client)
 
 
 class TorrentPieceData(ListEntry):
@@ -486,7 +502,7 @@ class TagList(List):
     """Response to :meth:`~TorrentsAPIMixIn.torrents_tags`"""
 
     def __init__(self, list_entries, client=None):
-        super(TagList, self).__init__(list_entries, entry_class=Tag, client=client)
+        super().__init__(list_entries, entry_class=Tag, client=client)
 
 
 class Tag(ListEntry):
@@ -516,7 +532,7 @@ class Torrents(ClientCache):
     """
 
     def __init__(self, client):
-        super(Torrents, self).__init__(client=client)
+        super().__init__(client=client)
         self.info = self._Info(client=client)
         self.resume = self._ActionForAllTorrents(
             client=client, func=client.torrents_resume
@@ -633,7 +649,7 @@ class Torrents(ClientCache):
         download_path=None,
         use_download_path=None,
         stop_condition=None,
-        **kwargs
+        **kwargs,
     ):
         return self._client.torrents_add(
             urls=urls,
@@ -657,12 +673,12 @@ class Torrents(ClientCache):
             download_path=download_path,
             use_download_path=use_download_path,
             stop_condition=stop_condition,
-            **kwargs
+            **kwargs,
         )
 
     class _ActionForAllTorrents(ClientCache):
         def __init__(self, client, func):
-            super(Torrents._ActionForAllTorrents, self).__init__(client=client)
+            super().__init__(client=client)
             self.func = func
 
         def __call__(self, torrent_hashes=None, **kwargs):
@@ -682,7 +698,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter=status_filter,
@@ -693,7 +709,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def all(
@@ -705,7 +721,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="all",
@@ -716,7 +732,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def downloading(
@@ -728,7 +744,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="downloading",
@@ -739,7 +755,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def seeding(
@@ -751,7 +767,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="seeding",
@@ -762,7 +778,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def completed(
@@ -774,7 +790,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="completed",
@@ -785,7 +801,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def paused(
@@ -797,7 +813,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="paused",
@@ -808,7 +824,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def active(
@@ -820,7 +836,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="active",
@@ -831,7 +847,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def inactive(
@@ -843,7 +859,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="inactive",
@@ -854,7 +870,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def resumed(
@@ -866,7 +882,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="resumed",
@@ -877,7 +893,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def stalled(
@@ -889,7 +905,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="stalled",
@@ -900,7 +916,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def stalled_uploading(
@@ -912,7 +928,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="stalled_uploading",
@@ -923,7 +939,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def stalled_downloading(
@@ -935,7 +951,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="stalled_downloading",
@@ -946,7 +962,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def checking(
@@ -958,7 +974,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="checking",
@@ -969,7 +985,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def moving(
@@ -981,7 +997,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="moving",
@@ -992,7 +1008,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
         def errored(
@@ -1004,7 +1020,7 @@ class Torrents(ClientCache):
             offset=None,
             torrent_hashes=None,
             tag=None,
-            **kwargs
+            **kwargs,
         ):
             return self._client.torrents_info(
                 status_filter="errored",
@@ -1015,7 +1031,7 @@ class Torrents(ClientCache):
                 offset=offset,
                 torrent_hashes=torrent_hashes,
                 tag=tag,
-                **kwargs
+                **kwargs,
             )
 
 
@@ -1061,7 +1077,7 @@ class TorrentCategories(ClientCache):
         save_path=None,
         download_path=None,
         enable_download_path=None,
-        **kwargs
+        **kwargs,
     ):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_create_category`"""
         return self._client.torrents_create_category(
@@ -1069,7 +1085,7 @@ class TorrentCategories(ClientCache):
             save_path=save_path,
             download_path=download_path,
             enable_download_path=enable_download_path,
-            **kwargs
+            **kwargs,
         )
 
     @alias("editCategory")
@@ -1079,7 +1095,7 @@ class TorrentCategories(ClientCache):
         save_path=None,
         download_path=None,
         enable_download_path=None,
-        **kwargs
+        **kwargs,
     ):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_edit_category`"""
         return self._client.torrents_edit_category(
@@ -1087,7 +1103,7 @@ class TorrentCategories(ClientCache):
             save_path=save_path,
             download_path=download_path,
             enable_download_path=enable_download_path,
-            **kwargs
+            **kwargs,
         )
 
     @alias("removeCategories")
@@ -1124,14 +1140,18 @@ class TorrentTags(ClientCache):
     def add_tags(self, tags=None, torrent_hashes=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_add_tags`"""
         self._client.torrents_add_tags(
-            tags=tags, torrent_hashes=torrent_hashes, **kwargs
+            tags=tags,
+            torrent_hashes=torrent_hashes,
+            **kwargs,
         )
 
     @alias("removeTags")
     def remove_tags(self, tags=None, torrent_hashes=None, **kwargs):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_tags`"""
         self._client.torrents_remove_tags(
-            tags=tags, torrent_hashes=torrent_hashes, **kwargs
+            tags=tags,
+            torrent_hashes=torrent_hashes,
+            **kwargs,
         )
 
     @alias("createTags")
@@ -1217,7 +1237,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         download_path=None,
         use_download_path=None,
         stop_condition=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Add one or more torrents by URLs and/or torrent files.
@@ -1305,24 +1325,14 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             "stopCondition": (None, stop_condition),
         }
 
-        files_to_send, files_to_close = self._normalize_torrent_files(torrent_files)
-
-        try:
-            return self._post(
-                _name=APINames.Torrents,
-                _method="add",
-                data=data,
-                files=files_to_send,
-                response_class=six.text_type,
-                **kwargs
-            )
-        finally:
-            if files_to_close:
-                for fh in files_to_close:
-                    try:
-                        fh.close()
-                    except Exception as exp:
-                        logger.warning("Failed to close file: %r", exp)
+        return self._post(
+            _name=APINames.Torrents,
+            _method="add",
+            data=data,
+            files=self._normalize_torrent_files(torrent_files),
+            response_class=str,
+            **kwargs,
+        )
 
     @staticmethod
     def _normalize_torrent_files(user_files):
@@ -1336,12 +1346,12 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         anything...but are mostly useful as identifiers for each file.
         """
         if not user_files:
-            return None, None
+            return None
 
         prefix = "torrent__"
         # if it's string-like and not a list|set|tuple, then make it a list
         # checking for 'read' attr since a single file handle is iterable but also needs to be in a list
-        is_string_like = isinstance(user_files, (bytes, six.text_type))
+        is_string_like = isinstance(user_files, (bytes, str))
         is_file_like = hasattr(user_files, "read")
         if is_string_like or is_file_like or not isinstance(user_files, Iterable):
             user_files = [user_files]
@@ -1354,44 +1364,29 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         )
 
         files = {}
-        files_to_close = []
         for name, torrent_file in norm_files.items():
             try:
-                fh = None
-                if isinstance(torrent_file, bytes):
-                    # since strings are bytes on python 2, simple filepaths will end up here
-                    # just check if it's a file first in that case...
-                    # this does prevent providing more useful IO errors on python 2....but it's dead anyway...
-                    try:
-                        filepath = path.abspath(
-                            path.realpath(path.expanduser(torrent_file.decode()))
-                        )
-                        if path.exists(filepath):  # pragma: no branch
-                            fh = open(filepath, "rb")
-                            files_to_close.append(fh)
-                            name = path.basename(filepath)
-                    except Exception:
-                        fh = None
-                    # if bytes, assume it's a raw torrent file that was downloaded or read from disk
-                    if not fh:
-                        fh = torrent_file
-                elif hasattr(torrent_file, "read") and callable(torrent_file.read):
-                    # if hasattr('read'), assume this is a file handle from open() or similar...
-                    #  there isn't a reliable way to detect a file-like object on both python 2 & 3
-                    fh = torrent_file
+                if isinstance(torrent_file, (bytes, bytearray)):
+                    # if bytes, assume it's a torrent file that was downloaded or read from disk
+                    torrent_bytes = torrent_file
+                elif hasattr(torrent_file, "read"):
+                    # if hasattr('read'), assume this is a file handle from open() or similar
+                    torrent_bytes = torrent_file.read()
                 else:
                     # otherwise, coerce to a string and try to open it as a file
                     filepath = path.abspath(
                         path.realpath(path.expanduser(str(torrent_file)))
                     )
-                    fh = open(filepath, "rb")
-                    files_to_close.append(fh)
                     name = path.basename(filepath)
+                    with open(filepath, "rb") as file:
+                        torrent_bytes = file.read()
 
                 # if using default name, let Requests try to figure out the filename to send
                 # Requests will fall back to "name" as the dict key if fh doesn't provide a file name
-                files[name] = fh if name.startswith(prefix) else (name, fh)
-            except IOError as io_err:
+                files[name] = (
+                    torrent_bytes if name.startswith(prefix) else (name, torrent_bytes)
+                )
+            except OSError as io_err:
                 if io_err.errno == errno.ENOENT:
                     raise TorrentFileNotFoundError(
                         errno.ENOENT, os_strerror(errno.ENOENT), torrent_file
@@ -1401,7 +1396,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
                         errno.ENOENT, os_strerror(errno.EACCES), torrent_file
                     )
                 raise TorrentFileError(io_err)
-        return files, files_to_close
+        return files
 
     ##########################################################################
     # INDIVIDUAL TORRENT ENDPOINTS
@@ -1423,7 +1418,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="properties",
             data=data,
             response_class=TorrentPropertiesDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @handle_hashes
@@ -1444,7 +1439,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="trackers",
             data=data,
             response_class=TrackersList,
-            **kwargs
+            **kwargs,
         )
 
     @handle_hashes
@@ -1464,7 +1459,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="webseeds",
             data=data,
             response_class=WebSeedsList,
-            **kwargs
+            **kwargs,
         )
 
     @handle_hashes
@@ -1484,7 +1479,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="files",
             data=data,
             response_class=TorrentFilesList,
-            **kwargs
+            **kwargs,
         )
 
     @alias("torrents_pieceStates")
@@ -1505,7 +1500,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="pieceStates",
             data=data,
             response_class=TorrentPieceInfoList,
-            **kwargs
+            **kwargs,
         )
 
     @alias("torrents_pieceHashes")
@@ -1526,7 +1521,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="pieceHashes",
             data=data,
             response_class=TorrentPieceInfoList,
-            **kwargs
+            **kwargs,
         )
 
     @alias("torrents_addTrackers")
@@ -1643,7 +1638,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         new_file_name=None,
         old_path=None,
         new_path=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Rename a torrent file.
@@ -1708,7 +1703,11 @@ class TorrentsAPIMixIn(AppAPIMixIn):
     @handle_hashes
     @login_required
     def torrents_rename_folder(
-        self, torrent_hash=None, old_path=None, new_path=None, **kwargs
+        self,
+        torrent_hash=None,
+        old_path=None,
+        new_path=None,
+        **kwargs,
     ):
         """
         Rename a torrent folder.
@@ -1729,7 +1728,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
                 "newPath": new_path,
             }
             self._post(
-                _name=APINames.Torrents, _method="renameFolder", data=data, **kwargs
+                _name=APINames.Torrents,
+                _method="renameFolder",
+                data=data,
+                **kwargs,
             )
         else:
             # only get here on v4.3.2....so hack in raising exception
@@ -1759,7 +1761,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="export",
             data=data,
             response_class=bytes,
-            **kwargs
+            **kwargs,
         )
 
     ##########################################################################
@@ -1777,7 +1779,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         offset=None,
         torrent_hashes=None,
         tag=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Retrieves list of info for torrents.
@@ -1815,7 +1817,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="info",
             data=data,
             response_class=TorrentInfoList,
-            **kwargs
+            **kwargs,
         )
 
     @handle_hashes
@@ -1960,7 +1962,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="downloadLimit",
             data=data,
             response_class=TorrentLimitsDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @alias("torrents_setDownloadLimit")
@@ -1979,7 +1981,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             "limit": limit,
         }
         self._post(
-            _name=APINames.Torrents, _method="setDownloadLimit", data=data, **kwargs
+            _name=APINames.Torrents,
+            _method="setDownloadLimit",
+            data=data,
+            **kwargs,
         )
 
     @alias("torrents_setShareLimits")
@@ -1992,7 +1997,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         seeding_time_limit=None,
         inactive_seeding_time_limit=None,
         torrent_hashes=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Set share limits for one or more torrents.
@@ -2011,7 +2016,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             "inactiveSeedingTimeLimit": inactive_seeding_time_limit,
         }
         self._post(
-            _name=APINames.Torrents, _method="setShareLimits", data=data, **kwargs
+            _name=APINames.Torrents,
+            _method="setShareLimits",
+            data=data,
+            **kwargs,
         )
 
     @alias("torrents_uploadLimit")
@@ -2030,7 +2038,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="uploadLimit",
             data=data,
             response_class=TorrentLimitsDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @alias("torrents_setUploadLimit")
@@ -2049,7 +2057,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             "limit": limit,
         }
         self._post(
-            _name=APINames.Torrents, _method="setUploadLimit", data=data, **kwargs
+            _name=APINames.Torrents,
+            _method="setUploadLimit",
+            data=data,
+            **kwargs,
         )
 
     @alias("torrents_setLocation")
@@ -2114,7 +2125,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             "path": download_path,
         }
         self._post(
-            _name=APINames.Torrents, _method="setDownloadPath", data=data, **kwargs
+            _name=APINames.Torrents,
+            _method="setDownloadPath",
+            data=data,
+            **kwargs,
         )
 
     @alias("torrents_setCategory")
@@ -2152,7 +2166,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             "enable": True if enable is None else bool(enable),
         }
         self._post(
-            _name=APINames.Torrents, _method="setAutoManagement", data=data, **kwargs
+            _name=APINames.Torrents,
+            _method="setAutoManagement",
+            data=data,
+            **kwargs,
         )
 
     @alias("torrents_toggleSequentialDownload")
@@ -2170,7 +2187,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _name=APINames.Torrents,
             _method="toggleSequentialDownload",
             data=data,
-            **kwargs
+            **kwargs,
         )
 
     @alias("torrents_toggleFirstLastPiecePrio")
@@ -2188,7 +2205,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _name=APINames.Torrents,
             _method="toggleFirstLastPiecePrio",
             data=data,
-            **kwargs
+            **kwargs,
         )
 
     @alias("torrents_setForceStart")
@@ -2208,7 +2225,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             "value": True if enable is None else bool(enable),
         }
         self._post(
-            _name=APINames.Torrents, _method="setForceStart", data=data, **kwargs
+            _name=APINames.Torrents,
+            _method="setForceStart",
+            data=data,
+            **kwargs,
         )
 
     @alias("torrents_setSuperSeeding")
@@ -2227,7 +2247,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             "value": True if enable is None else bool(enable),
         }
         self._post(
-            _name=APINames.Torrents, _method="setSuperSeeding", data=data, **kwargs
+            _name=APINames.Torrents,
+            _method="setSuperSeeding",
+            data=data,
+            **kwargs,
         )
 
     @alias("torrents_addPeers")
@@ -2253,7 +2276,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _method="addPeers",
             data=data,
             response_class=TorrentsAddPeersDictionary,
-            **kwargs
+            **kwargs,
         )
 
     # TORRENT CATEGORIES ENDPOINTS
@@ -2271,7 +2294,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             _name=APINames.Torrents,
             _method="categories",
             response_class=TorrentCategoriesDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @alias("torrents_createCategory")
@@ -2282,7 +2305,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         save_path=None,
         download_path=None,
         enable_download_path=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Create a new torrent category.
@@ -2306,7 +2329,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             "downloadPathEnabled": enable_download_path,
         }
         self._post(
-            _name=APINames.Torrents, _method="createCategory", data=data, **kwargs
+            _name=APINames.Torrents,
+            _method="createCategory",
+            data=data,
+            **kwargs,
         )
 
     @endpoint_introduced("2.1.0", "torrents/editCategory")
@@ -2318,7 +2344,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         save_path=None,
         download_path=None,
         enable_download_path=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Edit an existing category.
@@ -2357,7 +2383,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         """
         data = {"categories": self._list2string(categories, "\n")}
         self._post(
-            _name=APINames.Torrents, _method="removeCategories", data=data, **kwargs
+            _name=APINames.Torrents,
+            _method="removeCategories",
+            data=data,
+            **kwargs,
         )
 
     # TORRENT TAGS ENDPOINTS
@@ -2370,7 +2399,10 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         :return: :class:`TagList`
         """
         return self._get(
-            _name=APINames.Torrents, _method="tags", response_class=TagList, **kwargs
+            _name=APINames.Torrents,
+            _method="tags",
+            response_class=TagList,
+            **kwargs,
         )
 
     @alias("torrents_addTags")

--- a/src/qbittorrentapi/torrents.pyi
+++ b/src/qbittorrentapi/torrents.pyi
@@ -7,7 +7,6 @@ from typing import Literal
 from typing import Mapping
 from typing import Optional
 from typing import Text
-from typing import Tuple
 from typing import TypeVar
 
 from qbittorrentapi._types import DictMutableInputT
@@ -78,7 +77,7 @@ class TorrentDictionary(JsonDictionaryT):
         ratio_limit: Optional[Text | int] = None,
         seeding_time_limit: Optional[Text | int] = None,
         inactive_seeding_time_limit: Optional[Text | int] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     setShareLimits = set_share_limits
     @property
@@ -169,14 +168,14 @@ class TorrentDictionary(JsonDictionaryT):
         new_file_name: Optional[Text] = None,
         old_path: Optional[Text] = None,
         new_path: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     renameFile = rename_file
     def rename_folder(
         self,
         old_path: Optional[Text] = None,
         new_path: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     renameFolder = rename_folder
     @property
@@ -197,7 +196,7 @@ class TorrentDictionary(JsonDictionaryT):
         self,
         orig_url: Optional[Text] = None,
         new_url: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     editTracker = edit_tracker
     def remove_trackers(
@@ -210,7 +209,7 @@ class TorrentDictionary(JsonDictionaryT):
         self,
         file_ids: Optional[int | Iterable[Text | int]] = None,
         priority: Optional[Text | int] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     filePriority = file_priority
     def rename(self, new_name: Optional[Text] = None, **kwargs: KwargsT) -> None: ...
@@ -355,7 +354,7 @@ class Torrents(ClientCache):
         download_path: Optional[Text] = None,
         use_download_path: Optional[bool] = None,
         stop_condition: Optional[Literal["MetadataReceived", "FilesChecked"]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> Text: ...
 
     class _ActionForAllTorrents(ClientCache):
@@ -383,7 +382,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def all(
             self,
@@ -394,7 +393,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def downloading(
             self,
@@ -405,7 +404,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def seeding(
             self,
@@ -416,7 +415,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def completed(
             self,
@@ -427,7 +426,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def paused(
             self,
@@ -438,7 +437,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def active(
             self,
@@ -449,7 +448,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def inactive(
             self,
@@ -460,7 +459,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def resumed(
             self,
@@ -471,7 +470,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def stalled(
             self,
@@ -482,7 +481,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def stalled_uploading(
             self,
@@ -493,7 +492,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def stalled_downloading(
             self,
@@ -504,7 +503,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def checking(
             self,
@@ -515,7 +514,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def moving(
             self,
@@ -526,7 +525,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
         def errored(
             self,
@@ -537,7 +536,7 @@ class Torrents(ClientCache):
             offset: Optional[Text | int] = None,
             torrent_hashes: Optional[Iterable[Text]] = None,
             tag: Optional[Text] = None,
-            **kwargs: KwargsT
+            **kwargs: KwargsT,
         ) -> TorrentInfoList: ...
 
 class TorrentCategories(ClientCache):
@@ -551,7 +550,7 @@ class TorrentCategories(ClientCache):
         save_path: Optional[Text] = None,
         download_path: Optional[Text] = None,
         enable_download_path: Optional[bool] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     createCategory = create_category
     def edit_category(
@@ -560,7 +559,7 @@ class TorrentCategories(ClientCache):
         save_path: Optional[Text] = None,
         download_path: Optional[Text] = None,
         enable_download_path: Optional[bool] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     editCategory = edit_category
     def remove_categories(
@@ -579,14 +578,14 @@ class TorrentTags(ClientCache):
         self,
         tags: Optional[Iterable[Text]] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     addTags = add_tags
     def remove_tags(
         self,
         tags: Optional[Iterable[Text]] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     removeTags = remove_tags
     def create_tags(
@@ -634,12 +633,12 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         download_path: Optional[Text] = None,
         use_download_path: Optional[bool] = None,
         stop_condition: Optional[Literal["MetadataReceived", "FilesChecked"]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> Literal["Ok.", "Fails."]: ...
     @staticmethod
     def _normalize_torrent_files(
         user_files: TorrentFilesT,
-    ) -> Tuple[FilesToSendT, list[IO[bytes]]] | Tuple[None, None]: ...
+    ) -> FilesToSendT | None: ...
     def torrents_properties(
         self,
         torrent_hash: Optional[Text] = None,
@@ -676,7 +675,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         self,
         torrent_hash: Optional[Text] = None,
         urls: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_addTrackers = torrents_add_trackers
     def torrents_edit_tracker(
@@ -684,14 +683,14 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         torrent_hash: Optional[Text] = None,
         original_url: Optional[Text] = None,
         new_url: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_editTracker = torrents_edit_tracker
     def torrents_remove_trackers(
         self,
         torrent_hash: Optional[Text] = None,
         urls: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_removeTrackers = torrents_remove_trackers
     def torrents_file_priority(
@@ -699,14 +698,14 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         torrent_hash: Optional[Text] = None,
         file_ids: Optional[int | Iterable[Text | int]] = None,
         priority: Optional[Text | int] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_filePrio = torrents_file_priority
     def torrents_rename(
         self,
         torrent_hash: Optional[Text] = None,
         new_torrent_name: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     def torrents_rename_file(
         self,
@@ -715,7 +714,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         new_file_name: Optional[Text] = None,
         old_path: Optional[Text] = None,
         new_path: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_renameFile = torrents_rename_file
     def torrents_rename_folder(
@@ -723,7 +722,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         torrent_hash: Optional[Text] = None,
         old_path: Optional[Text] = None,
         new_path: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_renameFolder = torrents_rename_folder
     def torrents_export(
@@ -741,7 +740,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         offset: Optional[Text | int] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
         tag: Optional[Text] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> TorrentInfoList: ...
     def torrents_resume(
         self,
@@ -757,7 +756,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         self,
         delete_files: Optional[bool] = False,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     def torrents_recheck(
         self,
@@ -803,7 +802,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         self,
         limit: Optional[Text | int] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_setDownloadLimit = torrents_set_download_limit
     def torrents_set_share_limits(
@@ -812,7 +811,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         seeding_time_limit: Optional[Text | int] = None,
         inactive_seeding_time_limit: Optional[Text | int] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_setShareLimits = torrents_set_share_limits
     def torrents_upload_limit(
@@ -825,42 +824,42 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         self,
         limit: Optional[Text | int] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_setUploadLimit = torrents_set_upload_limit
     def torrents_set_location(
         self,
         location: Optional[Text] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_setLocation = torrents_set_location
     def torrents_set_save_path(
         self,
         save_path: Optional[Text] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_setSavePath = torrents_set_save_path
     def torrents_set_download_path(
         self,
         download_path: Optional[Text] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_setDownloadPath = torrents_set_download_path
     def torrents_set_category(
         self,
         category: Optional[Text] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_setCategory = torrents_set_category
     def torrents_set_auto_management(
         self,
         enable: Optional[bool] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_setAutoManagement = torrents_set_auto_management
     def torrents_toggle_sequential_download(
@@ -879,21 +878,21 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         self,
         enable: Optional[bool] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_setForceStart = torrents_set_force_start
     def torrents_set_super_seeding(
         self,
         enable: Optional[bool] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_setSuperSeeding = torrents_set_super_seeding
     def torrents_add_peers(
         self,
         peers: Optional[Iterable[Text]] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> TorrentsAddPeersDictionary: ...
     torrents_addPeers = torrents_add_peers
     def torrents_categories(self, **kwargs: KwargsT) -> TorrentCategoriesDictionary: ...
@@ -903,7 +902,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         save_path: Optional[Text] = None,
         download_path: Optional[Text] = None,
         enable_download_path: Optional[bool] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_createCategory = torrents_create_category
     def torrents_edit_category(
@@ -912,7 +911,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         save_path: Optional[Text] = None,
         download_path: Optional[Text] = None,
         enable_download_path: Optional[bool] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_editCategory = torrents_edit_category
     def torrents_remove_categories(
@@ -926,14 +925,14 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         self,
         tags: Optional[Iterable[Text]] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_addTags = torrents_add_tags
     def torrents_remove_tags(
         self,
         tags: Optional[Iterable[Text]] = None,
         torrent_hashes: Optional[Iterable[Text]] = None,
-        **kwargs: KwargsT
+        **kwargs: KwargsT,
     ) -> None: ...
     torrents_removeTags = torrents_remove_tags
     def torrents_create_tags(

--- a/src/qbittorrentapi/transfer.py
+++ b/src/qbittorrentapi/transfer.py
@@ -1,5 +1,3 @@
-import six
-
 from qbittorrentapi._version_support import v
 from qbittorrentapi.app import AppAPIMixIn
 from qbittorrentapi.decorators import alias
@@ -60,7 +58,8 @@ class Transfer(ClientCache):
     def set_speed_limits_mode(self, intended_state=None, **kwargs):
         """Implements :meth:`~TransferAPIMixIn.transfer_set_speed_limits_mode`"""
         return self._client.transfer_set_speed_limits_mode(
-            intended_state=intended_state, **kwargs
+            intended_state=intended_state,
+            **kwargs,
         )
 
     @property
@@ -148,7 +147,7 @@ class TransferAPIMixIn(AppAPIMixIn):
             _name=APINames.Transfer,
             _method="info",
             response_class=TransferInfoDictionary,
-            **kwargs
+            **kwargs,
         )
 
     @alias("transfer_speedLimitsMode")
@@ -162,8 +161,8 @@ class TransferAPIMixIn(AppAPIMixIn):
         return self._get(
             _name=APINames.Transfer,
             _method="speedLimitsMode",
-            response_class=six.text_type,
-            **kwargs
+            response_class=str,
+            **kwargs,
         )
 
     @alias(
@@ -182,13 +181,17 @@ class TransferAPIMixIn(AppAPIMixIn):
         """
         if intended_state is None:
             self._post(
-                _name=APINames.Transfer, _method="toggleSpeedLimitsMode", **kwargs
+                _name=APINames.Transfer,
+                _method="toggleSpeedLimitsMode",
+                **kwargs,
             )
         elif v(self.app_web_api_version()) < v("2.8.14") and (
             (self.transfer.speed_limits_mode == "1") is not bool(intended_state)
         ):
             self._post(
-                _name=APINames.Transfer, _method="toggleSpeedLimitsMode", **kwargs
+                _name=APINames.Transfer,
+                _method="toggleSpeedLimitsMode",
+                **kwargs,
             )
         else:
             data = {"mode": 1 if intended_state else 0}
@@ -196,7 +199,7 @@ class TransferAPIMixIn(AppAPIMixIn):
                 _name=APINames.Transfer,
                 _method="setSpeedLimitsMode",
                 data=data,
-                **kwargs
+                **kwargs,
             )
 
     @alias("transfer_downloadLimit")
@@ -211,7 +214,7 @@ class TransferAPIMixIn(AppAPIMixIn):
             _name=APINames.Transfer,
             _method="downloadLimit",
             response_class=int,
-            **kwargs
+            **kwargs,
         )
 
     @alias("transfer_uploadLimit")
@@ -223,7 +226,10 @@ class TransferAPIMixIn(AppAPIMixIn):
         :return: integer
         """
         return self._get(
-            _name=APINames.Transfer, _method="uploadLimit", response_class=int, **kwargs
+            _name=APINames.Transfer,
+            _method="uploadLimit",
+            response_class=int,
+            **kwargs,
         )
 
     @alias("transfer_setDownloadLimit")
@@ -237,7 +243,10 @@ class TransferAPIMixIn(AppAPIMixIn):
         """
         data = {"limit": limit}
         self._post(
-            _name=APINames.Transfer, _method="setDownloadLimit", data=data, **kwargs
+            _name=APINames.Transfer,
+            _method="setDownloadLimit",
+            data=data,
+            **kwargs,
         )
 
     @alias("transfer_setUploadLimit")
@@ -251,7 +260,10 @@ class TransferAPIMixIn(AppAPIMixIn):
         """
         data = {"limit": limit}
         self._post(
-            _name=APINames.Transfer, _method="setUploadLimit", data=data, **kwargs
+            _name=APINames.Transfer,
+            _method="setUploadLimit",
+            data=data,
+            **kwargs,
         )
 
     @alias("transfer_banPeers")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,4 @@
 import pytest
-import six
 
 from qbittorrentapi._attrdict import AttrDict
 from qbittorrentapi.app import NetworkInterface
@@ -75,7 +74,7 @@ def test_network_interface_address_list(client):
     assert isinstance(
         client.app_network_interface_address_list(), NetworkInterfaceAddressList
     )
-    assert isinstance(client.app_network_interface_address_list()[0], six.text_type)
+    assert isinstance(client.app_network_interface_address_list()[0], str)
     assert isinstance(
         client.app.network_interface_address_list(), NetworkInterfaceAddressList
     )
@@ -83,7 +82,7 @@ def test_network_interface_address_list(client):
         client.app.network_interface_address_list(interface_name="lo"),
         NetworkInterfaceAddressList,
     )
-    assert isinstance(client.app.network_interface_address_list()[0], six.text_type)
+    assert isinstance(client.app.network_interface_address_list()[0], str)
 
 
 @pytest.mark.skipif_after_api_version("2.3")

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,4 +1,3 @@
-import sys
 from enum import Enum
 
 import pytest
@@ -200,10 +199,8 @@ def test_list_actions(client):
         ListEntry({"three": "3"}, client=client),
     ] + [ListEntry({"four": "4"}, client=client)]
 
-    # UserList doesn't have copy in 2.7
-    if sys.version_info > (3,):
-        assert list_one.copy() == [
-            ListEntry({"one": "1"}, client=client),
-            ListEntry({"two": "2"}, client=client),
-            ListEntry({"three": "3"}, client=client),
-        ]
+    assert list_one.copy() == [
+        ListEntry({"one": "1"}, client=client),
+        ListEntry({"two": "2"}, client=client),
+        ListEntry({"three": "3"}, client=client),
+    ]

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from qbittorrentapi.definitions import APINames
@@ -26,10 +24,7 @@ def test_log_main_large_id(client, main_func):
 
 @pytest.mark.parametrize("main_func", ["log_main", "log.main"])
 def test_log_main_slice(client, main_func):
-    if sys.version_info < (3,) or sys.version_info >= (3, 7):
-        assert isinstance(client.func(main_func)()[1:2], LogMainList)
-    else:
-        assert isinstance(client.func(main_func)()[1:2], list)
+    assert isinstance(client.func(main_func)()[1:2], LogMainList)
 
 
 def test_log_main_info(client_mock):
@@ -141,7 +136,4 @@ def test_log_peers(client, peers_func):
 
 @pytest.mark.parametrize("peers_func", ["log_peers", "log.peers"])
 def test_log_peers_slice(client, peers_func):
-    if sys.version_info < (3,) or sys.version_info >= (3, 7):
-        assert isinstance(client.func(peers_func)()[1:2], LogPeersList)
-    else:
-        assert isinstance(client.func(peers_func)()[1:2], list)
+    assert isinstance(client.func(peers_func)()[1:2], LogPeersList)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,16 +1,8 @@
 import logging
 import re
-import sys
 from os import environ
-
-import six
-
-try:
-    from unittest.mock import MagicMock
-    from unittest.mock import PropertyMock
-except ImportError:  # python 2
-    from mock import MagicMock
-    from mock import PropertyMock
+from unittest.mock import MagicMock
+from unittest.mock import PropertyMock
 
 import pytest
 from requests import Response
@@ -29,16 +21,20 @@ from tests.utils import mkpath
 
 
 def test_method_name(client, app_version):
-    assert app_version == client._get("app", "version", response_class=six.text_type)
+    assert app_version == client._get("app", "version", response_class=str)
     assert app_version == client._get(
-        APINames.Application, "version", response_class=six.text_type
+        APINames.Application,
+        "version",
+        response_class=str,
     )
 
 
 def test_log_in():
     client_good = Client(VERIFY_WEBUI_CERTIFICATE=False)
     client_bad = Client(
-        username="asdf", password="asdfasdf", VERIFY_WEBUI_CERTIFICATE=False
+        username="asdf",
+        password="asdfasdf",
+        VERIFY_WEBUI_CERTIFICATE=False,
     )
 
     client_good.auth_log_out()
@@ -57,7 +53,9 @@ def test_log_in():
 def test_log_in_via_auth():
     client_good = Client(VERIFY_WEBUI_CERTIFICATE=False)
     client_bad = Client(
-        username="asdf", password="asdfasdf", VERIFY_WEBUI_CERTIFICATE=False
+        username="asdf",
+        password="asdfasdf",
+        VERIFY_WEBUI_CERTIFICATE=False,
     )
 
     assert (
@@ -86,7 +84,9 @@ def test_log_in_via_auth():
 )
 def test_hostname_format(app_version, hostname):
     client = Client(
-        host=hostname, VERIFY_WEBUI_CERTIFICATE=False, REQUESTS_ARGS={"timeout": 1}
+        host=hostname,
+        VERIFY_WEBUI_CERTIFICATE=False,
+        REQUESTS_ARGS={"timeout": 1},
     )
     assert client.app.version == app_version
     # ensure the base URL is always normalized
@@ -272,7 +272,7 @@ def test_response_str(client):
     response = MagicMock(spec_set=Response)
 
     type(response).text = PropertyMock(return_value="text response")
-    assert client._cast(response, six.text_type) == "text response"
+    assert client._cast(response, str) == "text response"
 
     type(response).text = PropertyMock(return_value="text response")
     with pytest.raises(exceptions.APIError, match="Exception during response parsing."):
@@ -342,12 +342,14 @@ def test_response_unsupported(client):
 
     type(response).text = PropertyMock(return_value="123.01")
     with pytest.raises(
-        exceptions.APIError, match="No handler defined to cast response."
+        exceptions.APIError,
+        match="No handler defined to cast response.",
     ):
         client._cast(response, float)
 
     with pytest.raises(
-        exceptions.APIError, match="No handler defined to cast response."
+        exceptions.APIError,
+        match="No handler defined to cast response.",
     ):
         client._get(_name=APINames.Application, _method="version", response_class=float)
 
@@ -373,7 +375,8 @@ def test_simple_response(client):
 
 def test_request_extra_headers():
     client = Client(
-        VERIFY_WEBUI_CERTIFICATE=False, EXTRA_HEADERS={"X-MY-HEADER": "asdf"}
+        VERIFY_WEBUI_CERTIFICATE=False,
+        EXTRA_HEADERS={"X-MY-HEADER": "asdf"},
     )
     client.auth.log_in()
 
@@ -381,7 +384,9 @@ def test_request_extra_headers():
     assert r.request.headers["X-MY-HEADER"] == "asdf"
 
     r = client._get(
-        APINames.Application, "version", headers={"X-MY-HEADER-TWO": "zxcv"}
+        APINames.Application,
+        "version",
+        headers={"X-MY-HEADER-TWO": "zxcv"},
     )
     assert r.request.headers["X-MY-HEADER"] == "asdf"
     assert r.request.headers["X-MY-HEADER-TWO"] == "zxcv"
@@ -410,10 +415,6 @@ def test_request_extra_headers():
 
 @pytest.mark.skipif_before_api_version("2.2.1")
 def test_requests_timeout(api_version):
-    # timeouts are weird on python 2...just skip it...
-    if sys.version_info[0] < 3:
-        return
-
     class MyTimeoutError(Exception):
         pass
 
@@ -446,12 +447,16 @@ def test_request_extra_params(client, orig_torrent):
     """Extra params can be sent directly to qBittorrent but there aren't any real use-
     cases so force it."""
     json_response = client._post(
-        APINames.Torrents, "info", hashes=orig_torrent.hash
+        APINames.Torrents,
+        "info",
+        hashes=orig_torrent.hash,
     ).json()
     torrent = TorrentInfoList(json_response, client)[0]
     assert isinstance(torrent, TorrentDictionary)
     json_response = client._get(
-        APINames.Torrents, "info", hashes=orig_torrent.hash
+        APINames.Torrents,
+        "info",
+        hashes=orig_torrent.hash,
     ).json()
     torrent = TorrentInfoList(json_response, client)[0]
     assert isinstance(torrent, TorrentDictionary)
@@ -537,7 +542,9 @@ def test_http400(client, app_version, orig_torrent):
     if v(app_version) >= v("4.1.6"):
         with pytest.raises(exceptions.InvalidRequest400Error) as exc_info:
             client.torrents_file_priority(
-                hash=orig_torrent.hash, file_ids="asdf", priority="asdf"
+                hash=orig_torrent.hash,
+                file_ids="asdf",
+                priority="asdf",
             )
         assert exc_info.value.http_status_code == 400
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from qbittorrentapi import NotFound404Error
@@ -83,10 +81,7 @@ def test_enable_plugin(client, search_func, enable_func):
 
 @pytest.mark.skipif_before_api_version("2.1.1")
 def test_plugins_slice(client):
-    if sys.version_info < (3,) or sys.version_info >= (3, 7):
-        assert isinstance(client.search_plugins()[1:2], SearchPluginsList)
-    else:
-        assert isinstance(client.search_plugins()[1:2], list)
+    assert isinstance(client.search_plugins()[1:2], SearchPluginsList)
 
 
 @pytest.mark.skipif_after_api_version("2.1.1")
@@ -150,8 +145,7 @@ def test_install_uninstall_plugin_not_implemented(client, install_func, uninstal
 @pytest.mark.parametrize("categories_func", ["search_categories", "search.categories"])
 def test_categories(client, categories_func):
     assert isinstance(client.func(categories_func)(), SearchCategoriesList)
-    if sys.version_info < (3,) or sys.version_info >= (3, 7):
-        assert isinstance(client.func(categories_func)()[1:2], SearchCategoriesList)
+    assert isinstance(client.func(categories_func)()[1:2], SearchCategoriesList)
     check(lambda: client.func(categories_func)(), "All categories", reverse=True)
 
 
@@ -206,10 +200,7 @@ def test_search(client, start_func, status_func, results_func, stop_func, delete
 @pytest.mark.skipif_before_api_version("2.1.1")
 @pytest.mark.parametrize("status_func", ["search_status", "search.status"])
 def test_statuses_slice(client, status_func):
-    if sys.version_info < (3,) or sys.version_info >= (3, 7):
-        assert isinstance(client.func(status_func)()[1:2], SearchStatusesList)
-    else:
-        assert isinstance(client.func(status_func)()[1:2], list)
+    assert isinstance(client.func(status_func)()[1:2], SearchStatusesList)
 
 
 @pytest.mark.skipif_after_api_version("2.1.1")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,5 +1,3 @@
-from sys import version_info
-
 import pytest
 
 from qbittorrentapi import Version
@@ -28,9 +26,7 @@ def test_is_supported(app_version, api_version):
 
 @pytest.mark.skipif(IS_QBT_DEV, reason="testing devel version of qBittorrent")
 def test_latest_version():
-    # order of dictionary keys was guaranteed starting in python 3.7
-    if version_info >= (3, 7):
-        expected_latest_api_version = list(api_version_map.values())[-1]
-        expected_latest_app_version = list(api_version_map.keys())[-1]
-        assert Version.latest_supported_api_version() == expected_latest_api_version
-        assert Version.latest_supported_app_version() == expected_latest_app_version
+    expected_latest_api_version = list(api_version_map.values())[-1]
+    expected_latest_app_version = list(api_version_map.keys())[-1]
+    assert Version.latest_supported_api_version() == expected_latest_api_version
+    assert Version.latest_supported_app_version() == expected_latest_app_version

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,6 @@ from os import path
 from time import sleep
 
 import pytest
-import six
 
 from qbittorrentapi import APIConnectionError
 from qbittorrentapi import Client
@@ -122,7 +121,7 @@ def check(check_func, value, reverse=False, negate=False, any=False, check_time=
                 # print("Looking for %s in %s" % (_check_func_val, (_v,)))
                 assert _check_func_val in (_v,)
 
-    if isinstance(value, (six.string_types, int)):
+    if isinstance(value, (str, int)):
         value = (value,)
 
     check_limit = int((check_time or CHECK_TIME) / CHECK_SLEEP)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ wheel_build_env = .pkg
 extras = dev
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
-[testenv:py{,27,34,35,36,37,38,39,310,311,312}{,-ci}]
+[testenv:py{,38,39,310,311,312}{,-ci}]
 package = wheel
 wheel_build_env = .pkg
 depends: pre-commit
@@ -17,6 +17,7 @@ setenv =
     DOCKER_ARGS = {env:DOCKER_ARGS:--rm -d --name qbt-tox-testing --pull=always --publish 8080:8080 --volume {tox_root}/tests/_resources:/tmp/_resources}
     DOCKER_QBT_IMAGE_NAME = {env:DOCKER_IMAGE_NAME:ghcr.io/rmartin16/qbittorrent-nox}
     DOCKER_QBT_IMAGE_TAG = {env:DOCKER_QBT_IMAGE_TAG:master-debug}
+passenv = CI  # needed for test_shutdown()
 commands_pre = !ci: -docker stop qbt-tox-testing
 commands =
     !ci: docker run {env:DOCKER_ARGS} {env:DOCKER_QBT_IMAGE_NAME}:{env:DOCKER_QBT_IMAGE_TAG}


### PR DESCRIPTION
Only non-EOL Python will be supported going forward. This is mostly driven by the unnecessary complexity of maintaining 2.7 compatibility. When I originally created this library, Python 2 use was still prevalent...but much less so today.

Other than removing old Python support, the other backwards-incompatible change is file paths as bytes instead of strings will no longer be accepted for adding torrents.