### PR TITLE
types: add TypedDict for Tracker

### DIFF
--- a/src/qbittorrentapi/torrents.pyi
+++ b/src/qbittorrentapi/torrents.pyi
@@ -8,6 +8,7 @@ from typing import Mapping
 from typing import Optional
 from typing import Text
 from typing import TypeVar
+from typing import TypedDict
 
 from qbittorrentapi._types import DictMutableInputT
 from qbittorrentapi._types import FilesToSendT
@@ -249,7 +250,9 @@ class WebSeedsList(List[WebSeed]):
         client: Optional[TorrentsAPIMixIn] = None,
     ) -> None: ...
 
-class Tracker(ListEntry): ...
+class Tracker(TypedDict):
+    url: str
+    msg: str
 
 class TrackersList(List[Tracker]):
     def __init__(

--- a/src/qbittorrentapi/torrents.pyi
+++ b/src/qbittorrentapi/torrents.pyi
@@ -253,6 +253,7 @@ class WebSeedsList(List[WebSeed]):
 class Tracker(TypedDict):
     url: str
     msg: str
+    num_downloaded: int
 
 class TrackersList(List[Tracker]):
     def __init__(

--- a/src/qbittorrentapi/torrents.pyi
+++ b/src/qbittorrentapi/torrents.pyi
@@ -7,8 +7,8 @@ from typing import Literal
 from typing import Mapping
 from typing import Optional
 from typing import Text
-from typing import TypeVar
 from typing import TypedDict
+from typing import TypeVar
 
 from qbittorrentapi._types import DictMutableInputT
 from qbittorrentapi._types import FilesToSendT


### PR DESCRIPTION
I'n not sure if this is the right approach, but I hope to add dict field to some list item, for example, tracker.

Currently these field are typed as `int | str | bool | Sequence[JsonValueT] | Mapping[str, JsonValueT] | None`, make it hard to use.