### PR TITLE
Bump pre-commit hook for pyupgrade from v3.13.0 to v3.14.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
           - toml
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.13.0
+    rev: v3.14.0
     hooks:
       - id: pyupgrade
         args:


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `pyupgrade` from v3.13.0 to v3.14.0 and ran the update against the repo.