### PR TITLE
Bump pre-commit hook for mirrors-mypy from v1.5.1 to v1.6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.6.0
     hooks:
       - id: mypy
         files: '.*\.pyi'


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `mirrors-mypy` from v1.5.1 to v1.6.0 and ran the update against the repo.