### PR TITLE
Bump pre-commit hook for black from 23.9.1 to 23.10.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
           - --fix
 
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.10.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `black` from 23.9.1 to 23.10.0 and ran the update against the repo.