### PR TITLE
Bump pre-commit hook for isort from 5.13.0 to 5.13.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.0
+    rev: 5.13.1
     hooks:
       - id: isort
         additional_dependencies:


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `isort` from 5.13.0 to 5.13.1 and ran the update against the repo.