### PR TITLE
Bump pre-commit hook for isort from 5.13.1 to 5.13.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.1
+    rev: 5.13.2
     hooks:
       - id: isort
         additional_dependencies:


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `isort` from 5.13.1 to 5.13.2 and ran the update against the repo.