### PR TITLE
Bump pre-commit hook for black from 23.12.1 to 24.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
           - --fix
 
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
       - id: black
         language_version: python3

--- a/src/qbittorrentapi/client.py
+++ b/src/qbittorrentapi/client.py
@@ -53,7 +53,6 @@ class Client(
     RSSAPIMixIn,
     SearchAPIMixIn,
 ):
-
     """
     Initialize API for qBittorrent client.
 

--- a/src/qbittorrentapi/definitions.py
+++ b/src/qbittorrentapi/definitions.py
@@ -241,9 +241,11 @@ if sys.version_info < (3, 9):
         ):
             super().__init__(
                 [
-                    entry_class(data=entry, **kwargs)
-                    if entry_class is not None and isinstance(entry, Mapping)
-                    else entry
+                    (
+                        entry_class(data=entry, **kwargs)
+                        if entry_class is not None and isinstance(entry, Mapping)
+                        else entry
+                    )
                     for entry in list_entries or []
                 ]
             )
@@ -261,9 +263,11 @@ else:
         ):
             super().__init__(
                 [
-                    entry_class(data=entry, **kwargs)  # type: ignore[misc]
-                    if entry_class is not None and isinstance(entry, Mapping)
-                    else entry
+                    (
+                        entry_class(data=entry, **kwargs)  # type: ignore[misc]
+                        if entry_class is not None and isinstance(entry, Mapping)
+                        else entry
+                    )
                     for entry in list_entries or []
                 ]
             )


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `black` from 23.12.1 to 24.1.1 and ran the update against the repo.