### PR TITLE
Bump pre-commit hook for ruff-pre-commit from v0.2.2 to v0.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           - --non-cap=qBittorrent
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.3.0
     hooks:
       - id: ruff
         args:

--- a/src/qbittorrentapi/_attrdict.py
+++ b/src/qbittorrentapi/_attrdict.py
@@ -27,6 +27,7 @@ longer be imported from collections but should use collections.abc instead.
 Since AttrDict is abandoned, I've consolidated the code here for future use.
 AttrMap and AttrDefault were removed altogether.
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `ruff-pre-commit` from v0.2.2 to v0.3.0 and ran the update against the repo.