### PR TITLE
Bump pre-commit hook for pre-commit-hooks from v4.5.0 to v4.6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-toml
       - id: check-yaml


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `pre-commit-hooks` from v4.5.0 to v4.6.0 and ran the update against the repo.