### PR TITLE
Force installing py03 dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           cache-dependency-path: ${{ github.workspace }}/pyproject.toml
 
       - name: Install
-        run: pip install .[dev]
+        run: python -m pip install .[dev]
 
       - name: Lint
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,8 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip setuptools
-          python -m pip install $(ls dist/qbittorrent_api-*.whl)[dev]
+          # force installing py03 packages not explicitly compatible with the version of python
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 python -m pip install $(ls dist/qbittorrent_api-*.whl)[dev]
 
       - name: Test
         run: tox -e py-ci --installpkg dist/qbittorrent_api-*.whl


### PR DESCRIPTION
CI is failing: https://github.com/rmartin16/qbittorrent-api/actions/runs/9256970896/job/25464562657

```
Building wheels for collected packages: watchfiles
  Building wheel for watchfiles (pyproject.toml): started
  Building wheel for watchfiles (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Building wheel for watchfiles (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [51 lines of output]
      Running `maturin pep517 build-wheel -i /opt/hostedtoolcache/Python/3.13.0-beta.1/x64/bin/python --compatibility off`
      📦 Including license file "/tmp/pip-install-lzpkzp5i/watchfiles_bd404c43515e4d01a18dd5cf767447bc/LICENSE"
      🍹 Building a mixed python/rust project
      🔗 Found pyo3 bindings
      🐍 Found CPython 3.13 at /opt/hostedtoolcache/Python/3.13.0-beta.1/x64/bin/python
      📡 Using build options bindings from pyproject.toml
         Compiling target-lexicon v0.12.14
         Compiling python3-dll-a v0.2.9
         Compiling libc v0.2.154
         Compiling once_cell v1.19.0
         Compiling autocfg v1.3.0
         Compiling proc-macro2 v1.0.81
         Compiling unicode-ident v1.0.12
         Compiling cfg-if v1.0.0
         Compiling lock_api v0.4.12
         Compiling parking_lot_core v0.9.10
         Compiling crossbeam-utils v0.8.19
         Compiling pyo3-build-config v0.21.2
         Compiling memoffset v0.9.1
         Compiling scopeguard v1.2.0
         Compiling portable-atomic v1.6.0
         Compiling heck v0.4.1
         Compiling quote v1.0.36
         Compiling smallvec v1.13.2
         Compiling syn v2.0.60
         Compiling inotify-sys v0.1.5
         Compiling same-file v1.0.6
         Compiling pyo3-ffi v0.21.2
         Compiling pyo3 v0.21.2
         Compiling bitflags v1.3.2
      error: failed to run custom build command for `pyo3-ffi v0.21.2`
      
      Caused by:
        process didn't exit successfully: `/tmp/pip-install-lzpkzp5i/watchfiles_bd404c43515e4d01a18dd5cf767447bc/target/release/build/pyo3-ffi-248a2d35156f8384/build-script-build` (exit status: 1)
        --- stdout
        cargo:rerun-if-env-changed=PYO3_CROSS
        cargo:rerun-if-env-changed=PYO3_CROSS_LIB_DIR
        cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_VERSION
        cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_IMPLEMENTATION
        cargo:rerun-if-env-changed=PYO3_PRINT_CONFIG
        cargo:rerun-if-env-changed=PYO3_USE_ABI3_FORWARD_COMPATIBILITY
      
        --- stderr
        error: the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12)
        = help: please check if an updated version of PyO3 is available. Current version: 0.21.2
        = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI
      warning: build failed, waiting for other jobs to finish...
      💥 maturin failed
        Caused by: Failed to build a native library through cargo
        Caused by: Cargo build finished with "exit status: 101": `env -u CARGO PYO3_ENVIRONMENT_SIGNATURE="cpython-3.13-64bit" PYO3_PYTHON="/opt/hostedtoolcache/Python/3.13.0-beta.1/x64/bin/python" PYTHON_SYS_EXECUTABLE="/opt/hostedtoolcache/Python/3.13.0-beta.1/x64/bin/python" "cargo" "rustc" "--message-format" "json-render-diagnostics" "--manifest-path" "/tmp/pip-install-lzpkzp5i/watchfiles_bd404c4[351](https://github.com/rmartin16/qbittorrent-api/actions/runs/9256970896/job/25464562657#step:7:352)5e4d01a18dd5cf767447bc/Cargo.toml" "--release" "--lib"`
      Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/opt/hostedtoolcache/Python/3.13.0-beta.1/x64/bin/python', '--compatibility', 'off'] returned non-zero exit status 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for watchfiles
ERROR: Could not build wheels for watchfiles, which is required to install pyproject.toml-based projects
Failed to build watchfiles
```