### PR TITLE
refactor: make mypy happy about `Torrent.is_paused`

### DIFF
--- a/src/qbittorrentapi/app.py
+++ b/src/qbittorrentapi/app.py
@@ -85,7 +85,9 @@ class AppAPIMixIn(AuthAPIMixIn):
             self._application = Application(client=self)
         return self._application
 
-    application = app
+    @property
+    def application(self) -> Application:
+        return self.app
 
     def app_version(self, **kwargs: APIKwargsT) -> str:
         """qBittorrent application version."""

--- a/src/qbittorrentapi/auth.py
+++ b/src/qbittorrentapi/auth.py
@@ -37,7 +37,9 @@ class AuthAPIMixIn(Request):
             self._authorization = Authorization(client=self)
         return self._authorization
 
-    authorization = auth
+    @property
+    def authorization(self) -> Authorization:
+        return self.auth
 
     @property
     def is_logged_in(self) -> bool:

--- a/src/qbittorrentapi/definitions.py
+++ b/src/qbittorrentapi/definitions.py
@@ -177,9 +177,9 @@ class TorrentState(str, Enum):
             TorrentState.STOPPED_DOWNLOAD,
         }
 
-    #: Alias of :any:`TorrentState.is_stopped`
     @property
-    def is_paused(self):
+    def is_paused(self) -> bool:
+        """Alias of :any:`TorrentState.is_stopped`"""
         return self.is_stopped
 
 

--- a/src/qbittorrentapi/definitions.py
+++ b/src/qbittorrentapi/definitions.py
@@ -178,7 +178,9 @@ class TorrentState(str, Enum):
         }
 
     #: Alias of :any:`TorrentState.is_stopped`
-    is_paused = is_stopped
+    @property
+    def is_paused(self):
+        return self.is_stopped
 
 
 TorrentStates = TorrentState

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,6 +27,18 @@ def test_is_logged_in():
     client.auth_log_out()
     assert client.is_logged_in is False
 
+    client.auth.log_in()
+    assert client.is_logged_in is True
+
+    client.auth.log_out()
+    assert client.is_logged_in is False
+
+    client.authorization.log_in()
+    assert client.is_logged_in is True
+
+    client.authorization.log_out()
+    assert client.is_logged_in is False
+
 
 def test_is_logged_in_bad_client():
     client = Client(


### PR DESCRIPTION
mypy doesn't think `is_paused` is a property so it raise a warning

`error: Function "is_paused" could always be true in boolean context  [truthy-function]`