### PR TITLE
Remove uses of `functools.wraps` for API methods

### DIFF
--- a/docs/source/apidoc/log.rst
+++ b/docs/source/apidoc/log.rst
@@ -10,6 +10,7 @@ Log
 .. autoclass:: qbittorrentapi.log.Log
     :members:
     :undoc-members:
+    :special-members: __call__
 
 .. autoclass:: qbittorrentapi.log.LogPeersList
     :members:

--- a/docs/source/apidoc/rss.rst
+++ b/docs/source/apidoc/rss.rst
@@ -10,6 +10,7 @@ RSS
 .. autoclass:: qbittorrentapi.rss.RSS
     :members:
     :undoc-members:
+    :special-members: __call__
     :exclude-members: rss, addFolder, addFeed, removeItem, moveItem, refreshItem, markAsRead, setRule, renameRule, removeRule, matchingArticles, setFeedURL
 
 .. autoclass:: qbittorrentapi.rss.RSSitemsDictionary

--- a/docs/source/apidoc/sync.rst
+++ b/docs/source/apidoc/sync.rst
@@ -10,6 +10,7 @@ Sync
 .. autoclass:: qbittorrentapi.sync.Sync
     :members:
     :undoc-members:
+    :special-members: __call__
 
 .. autoclass:: qbittorrentapi.sync.SyncMainDataDictionary
     :members:

--- a/src/qbittorrentapi/app.py
+++ b/src/qbittorrentapi/app.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from functools import wraps
 from json import dumps
 from logging import Logger, getLogger
 from typing import Any, AnyStr, Iterable, Mapping, Union
@@ -269,68 +268,68 @@ class Application(ClientCache[AppAPIMixIn]):
     """  # noqa: E501
 
     @property
-    @wraps(AppAPIMixIn.app_version)
     def version(self) -> str:
+        """Implements :meth:`~AppAPIMixIn.app_version`."""
         return self._client.app_version()
 
     @property
-    @wraps(AppAPIMixIn.app_web_api_version)
     def web_api_version(self) -> str:
+        """Implements :meth:`~AppAPIMixIn.app_web_api_version`."""
         return self._client.app_web_api_version()
 
     webapiVersion = web_api_version
 
     @property
-    @wraps(AppAPIMixIn.app_build_info)
     def build_info(self) -> BuildInfoDictionary:
+        """Implements :meth:`~AppAPIMixIn.app_build_info`."""
         return self._client.app_build_info()
 
     buildInfo = build_info
 
-    @wraps(AppAPIMixIn.app_shutdown)
     def shutdown(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~AppAPIMixIn.app_shutdown`."""
         self._client.app_shutdown(**kwargs)
 
     @property
-    @wraps(AppAPIMixIn.app_preferences)
     def preferences(self) -> ApplicationPreferencesDictionary:
+        """Implements :meth:`~AppAPIMixIn.app_preferences`."""
         return self._client.app_preferences()
 
     @preferences.setter
-    @wraps(AppAPIMixIn.app_set_preferences)
     def preferences(self, value: Mapping[str, Any]) -> None:
+        """Implements :meth:`~AppAPIMixIn.app_set_preferences`."""
         self.set_preferences(prefs=value)
 
-    @wraps(AppAPIMixIn.app_set_preferences)
     def set_preferences(
         self,
         prefs: Mapping[str, Any] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~AppAPIMixIn.app_set_preferences`."""
         self._client.app_set_preferences(prefs=prefs, **kwargs)
 
     setPreferences = set_preferences
 
     @property
-    @wraps(AppAPIMixIn.app_default_save_path)
     def default_save_path(self) -> str:
+        """Implements :meth:`~AppAPIMixIn.app_default_save_path`."""
         return self._client.app_default_save_path()
 
     defaultSavePath = default_save_path
 
     @property
-    @wraps(AppAPIMixIn.app_network_interface_list)
     def network_interface_list(self) -> NetworkInterfaceList:
+        """Implements :meth:`~AppAPIMixIn.app_network_interface_list`."""
         return self._client.app_network_interface_list()
 
     networkInterfaceList = network_interface_list
 
-    @wraps(AppAPIMixIn.app_network_interface_address_list)
     def network_interface_address_list(
         self,
         interface_name: str = "",
         **kwargs: APIKwargsT,
     ) -> NetworkInterfaceAddressList:
+        """Implements :meth:`~AppAPIMixIn.app_network_interface_address_list`."""
         return self._client.app_network_interface_address_list(
             interface_name=interface_name,
             **kwargs,
@@ -338,17 +337,17 @@ class Application(ClientCache[AppAPIMixIn]):
 
     networkInterfaceAddressList = network_interface_address_list
 
-    @wraps(AppAPIMixIn.app_send_test_email)
     def send_test_email(self) -> None:
+        """Implements :meth:`~AppAPIMixIn.app_send_test_email`."""
         self._client.app_send_test_email()
 
     sendTestEmail = send_test_email
 
-    @wraps(AppAPIMixIn.app_get_directory_content)
     def get_directory_content(
         self,
         directory_path: str | os.PathLike[AnyStr] | None = None,
     ) -> DirectoryContentList:
+        """Implements :meth:`~AppAPIMixIn.app_get_directory_content`."""
         return self._client.app_get_directory_content(directory_path=directory_path)
 
     getDirectoryContent = get_directory_content

--- a/src/qbittorrentapi/auth.py
+++ b/src/qbittorrentapi/auth.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from functools import wraps
 from logging import Logger, getLogger
 from types import TracebackType
 from typing import TYPE_CHECKING
@@ -161,23 +160,19 @@ class Authorization(ClientCache[AuthAPIMixIn]):
     """  # noqa: E501
 
     @property
-    # Starting in Python 3.11.9/3.12.4, Sphinx is erroring for wraps and property...
-    #  WARNING: Failed to get a function signature for qbittorrentapi.auth.Authorization.is_logged_in:  # noqa E501
-    #  descriptor '__call__' for 'type' objects doesn't apply to a 'property' object
-    # Removing documentation for now...hoping this is resolved in the future...
-    # @wraps(AuthAPIMixIn.is_logged_in)
     def is_logged_in(self) -> bool:
+        """Implements :meth:`~AuthAPIMixIn.is_logged_in`."""
         return self._client.is_logged_in
 
-    @wraps(AuthAPIMixIn.auth_log_in)
     def log_in(
         self,
         username: str | None = None,
         password: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~AuthAPIMixIn.auth_log_in`."""
         return self._client.auth_log_in(username=username, password=password, **kwargs)
 
-    @wraps(AuthAPIMixIn.auth_log_out)
     def log_out(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~AuthAPIMixIn.auth_log_out`."""
         return self._client.auth_log_out(**kwargs)

--- a/src/qbittorrentapi/log.py
+++ b/src/qbittorrentapi/log.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from functools import wraps
-
 from qbittorrentapi.app import AppAPIMixIn
 from qbittorrentapi.definitions import (
     APIKwargsT,
@@ -130,17 +128,17 @@ class Log(ClientCache[LogAPIMixIn]):
 
     def __init__(self, client: LogAPIMixIn):
         super().__init__(client=client)
-        self.main = Log._Main(client=client)
+        self._main = Log.Main(client=client)
 
-    @wraps(LogAPIMixIn.log_peers)
     def peers(
         self,
         last_known_id: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> LogPeersList:
+        """Implements :meth:`~LogAPIMixIn.log_peers`."""
         return self._client.log_peers(last_known_id=last_known_id, **kwargs)
 
-    class _Main(ClientCache["LogAPIMixIn"]):
+    class Main(ClientCache["LogAPIMixIn"]):
         def _api_call(
             self,
             normal: bool | None = None,
@@ -168,6 +166,7 @@ class Log(ClientCache[LogAPIMixIn]):
             last_known_id: str | int | None = None,
             **kwargs: APIKwargsT,
         ) -> LogMainList:
+            """Implements :meth:`~LogAPIMixIn.log_main`."""
             return self._api_call(
                 normal=normal,
                 info=info,
@@ -182,6 +181,7 @@ class Log(ClientCache[LogAPIMixIn]):
             last_known_id: str | int | None = None,
             **kwargs: APIKwargsT,
         ) -> LogMainList:
+            """Implements :meth:`~LogAPIMixIn.log_main`."""
             return self._api_call(last_known_id=last_known_id, **kwargs)
 
         def normal(
@@ -189,6 +189,7 @@ class Log(ClientCache[LogAPIMixIn]):
             last_known_id: str | int | None = None,
             **kwargs: APIKwargsT,
         ) -> LogMainList:
+            """Implements :meth:`~LogAPIMixIn.log_main` with ``info=False``."""
             return self._api_call(info=False, last_known_id=last_known_id, **kwargs)
 
         def warning(
@@ -196,6 +197,8 @@ class Log(ClientCache[LogAPIMixIn]):
             last_known_id: str | int | None = None,
             **kwargs: APIKwargsT,
         ) -> LogMainList:
+            """Implements :meth:`~LogAPIMixIn.log_main` with ``info=False`` and
+            ``normal=False``."""
             return self._api_call(
                 info=False,
                 normal=False,
@@ -208,6 +211,8 @@ class Log(ClientCache[LogAPIMixIn]):
             last_known_id: str | int | None = None,
             **kwargs: APIKwargsT,
         ) -> LogMainList:
+            """Implements :meth:`~LogAPIMixIn.log_main` with ``info=False``,
+            ``normal=False``, and ``warning=False``."""
             return self._api_call(
                 info=False,
                 normal=False,
@@ -215,3 +220,8 @@ class Log(ClientCache[LogAPIMixIn]):
                 last_known_id=last_known_id,
                 **kwargs,
             )
+
+    @property
+    def main(self) -> Log.Main:
+        """Implements :meth:`~LogAPIMixIn.log_main`."""
+        return self._main

--- a/src/qbittorrentapi/rss.py
+++ b/src/qbittorrentapi/rss.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from functools import wraps
 from json import dumps
 from typing import Mapping
 
@@ -329,53 +328,53 @@ class RSS(ClientCache[RSSAPIMixIn]):
 
     def __init__(self, client: RSSAPIMixIn):
         super().__init__(client=client)
-        self.items = RSS._Items(client=client)
+        self._items = RSS.Items(client=client)
 
-    @wraps(RSSAPIMixIn.rss_add_folder)
     def add_folder(
         self,
         folder_path: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~RSSAPIMixIn.rss_add_folder`."""
         return self._client.rss_add_folder(folder_path=folder_path, **kwargs)
 
     addFolder = add_folder
 
-    @wraps(RSSAPIMixIn.rss_add_feed)
     def add_feed(
         self,
         url: str | None = None,
         item_path: str = "",
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~RSSAPIMixIn.rss_add_feed`."""
         return self._client.rss_add_feed(url=url, item_path=item_path, **kwargs)
 
     addFeed = add_feed
 
-    @wraps(RSSAPIMixIn.rss_set_feed_url)
     def set_feed_url(
         self,
         url: str | None = None,
         item_path: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~RSSAPIMixIn.rss_set_feed_url`."""
         return self._client.rss_set_feed_url(url=url, item_path=item_path, **kwargs)
 
     setFeedURL = set_feed_url
 
-    @wraps(RSSAPIMixIn.rss_remove_item)
     def remove_item(self, item_path: str | None = None, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~RSSAPIMixIn.rss_remove_item`."""
         return self._client.rss_remove_item(item_path=item_path, **kwargs)
 
     removeItem = remove_item
 
-    @wraps(RSSAPIMixIn.rss_move_item)
     def move_item(
         self,
         orig_item_path: str | None = None,
         new_item_path: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~RSSAPIMixIn.rss_move_item`."""
         return self._client.rss_move_item(
             orig_item_path=orig_item_path,
             new_item_path=new_item_path,
@@ -384,19 +383,19 @@ class RSS(ClientCache[RSSAPIMixIn]):
 
     moveItem = move_item
 
-    @wraps(RSSAPIMixIn.rss_refresh_item)
     def refresh_item(self, item_path: str | None = None) -> None:
+        """Implements :meth:`~RSSAPIMixIn.rss_refresh_item`."""
         return self._client.rss_refresh_item(item_path=item_path)
 
     refreshItem = refresh_item
 
-    @wraps(RSSAPIMixIn.rss_mark_as_read)
     def mark_as_read(
         self,
         item_path: str | None = None,
         article_id: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~RSSAPIMixIn.rss_mark_as_read`."""
         return self._client.rss_mark_as_read(
             item_path=item_path,
             article_id=article_id,
@@ -405,13 +404,13 @@ class RSS(ClientCache[RSSAPIMixIn]):
 
     markAsRead = mark_as_read
 
-    @wraps(RSSAPIMixIn.rss_set_rule)
     def set_rule(
         self,
         rule_name: str | None = None,
         rule_def: Mapping[str, JsonValueT] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~RSSAPIMixIn.rss_set_rule`."""
         return self._client.rss_set_rule(
             rule_name=rule_name,
             rule_def=rule_def,
@@ -420,13 +419,13 @@ class RSS(ClientCache[RSSAPIMixIn]):
 
     setRule = set_rule
 
-    @wraps(RSSAPIMixIn.rss_rename_rule)
     def rename_rule(
         self,
         orig_rule_name: str | None = None,
         new_rule_name: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~RSSAPIMixIn.rss_rename_rule`."""
         return self._client.rss_rename_rule(
             orig_rule_name=orig_rule_name,
             new_rule_name=new_rule_name,
@@ -435,43 +434,53 @@ class RSS(ClientCache[RSSAPIMixIn]):
 
     renameRule = rename_rule
 
-    @wraps(RSSAPIMixIn.rss_remove_rule)
     def remove_rule(
         self,
         rule_name: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~RSSAPIMixIn.rss_remove_rule`."""
         return self._client.rss_remove_rule(rule_name=rule_name, **kwargs)
 
     removeRule = remove_rule
 
     @property
-    @wraps(RSSAPIMixIn.rss_rules)
     def rules(self) -> RSSRulesDictionary:
+        """Implements :meth:`~RSSAPIMixIn.rss_rules`."""
         return self._client.rss_rules()
 
-    @wraps(RSSAPIMixIn.rss_matching_articles)
     def matching_articles(
         self,
         rule_name: str | None = None,
         **kwargs: APIKwargsT,
     ) -> RSSitemsDictionary:
+        """Implements :meth:`~RSSAPIMixIn.rss_matching_articles`."""
         return self._client.rss_matching_articles(rule_name=rule_name, **kwargs)
 
     matchingArticles = matching_articles
 
-    class _Items(ClientCache[RSSAPIMixIn]):
+    class Items(ClientCache[RSSAPIMixIn]):
         def __call__(
             self,
             include_feed_data: bool | None = None,
             **kwargs: APIKwargsT,
         ) -> RSSitemsDictionary:
+            """Implements :meth:`~RSSAPIMixIn.rss_items`."""
             return self._client.rss_items(include_feed_data=include_feed_data, **kwargs)
 
         @property
         def without_data(self) -> RSSitemsDictionary:
+            """Implements :meth:`~RSSAPIMixIn.rss_items` with
+            ``include_feed_data=False``."""
             return self._client.rss_items(include_feed_data=False)
 
         @property
         def with_data(self) -> RSSitemsDictionary:
+            """Implements :meth:`~RSSAPIMixIn.rss_items` with
+            ``include_feed_data=True``."""
             return self._client.rss_items(include_feed_data=True)
+
+    @property
+    def items(self) -> RSS.Items:
+        """Implements :meth:`~RSSAPIMixIn.rss_items`."""
+        return self._items

--- a/src/qbittorrentapi/search.py
+++ b/src/qbittorrentapi/search.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from functools import wraps
 from typing import Iterable, Mapping, cast
 
 from qbittorrentapi.app import AppAPIMixIn
@@ -386,21 +385,21 @@ class SearchJobDictionary(ClientCache[SearchAPIMixIn], Dictionary[JsonValueT]):
         self._search_job_id: int | None = cast(int, data.get("id", None))
         super().__init__(data=data, client=client)
 
-    @wraps(SearchAPIMixIn.search_stop)
     def stop(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~SearchAPIMixIn.search_stop`."""
         self._client.search_stop(search_id=self._search_job_id, **kwargs)
 
-    @wraps(SearchAPIMixIn.search_status)
     def status(self, **kwargs: APIKwargsT) -> SearchStatusesList:
+        """Implements :meth:`~SearchAPIMixIn.search_status`."""
         return self._client.search_status(search_id=self._search_job_id, **kwargs)
 
-    @wraps(SearchAPIMixIn.search_results)
     def results(
         self,
         limit: str | int | None = None,
         offset: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> SearchResultsDictionary:
+        """Implements :meth:`~SearchAPIMixIn.search_results`."""
         return self._client.search_results(
             limit=limit,
             offset=offset,
@@ -408,8 +407,8 @@ class SearchJobDictionary(ClientCache[SearchAPIMixIn], Dictionary[JsonValueT]):
             **kwargs,
         )
 
-    @wraps(SearchAPIMixIn.search_delete)
     def delete(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~SearchAPIMixIn.search_delete`."""
         return self._client.search_delete(search_id=self._search_job_id, **kwargs)
 
 
@@ -434,7 +433,6 @@ class Search(ClientCache[SearchAPIMixIn]):
         >>> client.search.update_plugins()
     """  # noqa: E501
 
-    @wraps(SearchAPIMixIn.search_start)
     def start(
         self,
         pattern: str | None = None,
@@ -442,6 +440,7 @@ class Search(ClientCache[SearchAPIMixIn]):
         category: str | None = None,
         **kwargs: APIKwargsT,
     ) -> SearchJobDictionary:
+        """Implements :meth:`~SearchAPIMixIn.search_start`."""
         return self._client.search_start(
             pattern=pattern,
             plugins=plugins,
@@ -449,23 +448,22 @@ class Search(ClientCache[SearchAPIMixIn]):
             **kwargs,
         )
 
-    @wraps(SearchAPIMixIn.search_stop)
     def stop(
         self,
         search_id: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~SearchAPIMixIn.search_stop`."""
         return self._client.search_stop(search_id=search_id, **kwargs)
 
-    @wraps(SearchAPIMixIn.search_status)
     def status(
         self,
         search_id: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> SearchStatusesList:
+        """Implements :meth:`~SearchAPIMixIn.search_status`."""
         return self._client.search_status(search_id=search_id, **kwargs)
 
-    @wraps(SearchAPIMixIn.search_results)
     def results(
         self,
         search_id: str | int | None = None,
@@ -473,6 +471,7 @@ class Search(ClientCache[SearchAPIMixIn]):
         offset: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> SearchResultsDictionary:
+        """Implements :meth:`~SearchAPIMixIn.search_results`."""
         return self._client.search_results(
             search_id=search_id,
             limit=limit,
@@ -480,54 +479,54 @@ class Search(ClientCache[SearchAPIMixIn]):
             **kwargs,
         )
 
-    @wraps(SearchAPIMixIn.search_delete)
     def delete(
         self,
         search_id: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~SearchAPIMixIn.search_delete`."""
         return self._client.search_delete(search_id=search_id, **kwargs)
 
-    @wraps(SearchAPIMixIn.search_categories)
     def categories(
         self,
         plugin_name: str | None = None,
         **kwargs: APIKwargsT,
     ) -> SearchCategoriesList:
+        """Implements :meth:`~SearchAPIMixIn.search_categories`."""
         return self._client.search_categories(plugin_name=plugin_name, **kwargs)
 
     @property
-    @wraps(SearchAPIMixIn.search_plugins)
     def plugins(self) -> SearchPluginsList:
+        """Implements :meth:`~SearchAPIMixIn.search_plugins`."""
         return self._client.search_plugins()
 
-    @wraps(SearchAPIMixIn.search_install_plugin)
     def install_plugin(
         self,
         sources: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~SearchAPIMixIn.search_install_plugin`."""
         return self._client.search_install_plugin(sources=sources, **kwargs)
 
     installPlugin = install_plugin
 
-    @wraps(SearchAPIMixIn.search_uninstall_plugin)
     def uninstall_plugin(
         self,
         sources: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~SearchAPIMixIn.search_uninstall_plugin`."""
         return self._client.search_uninstall_plugin(sources=sources, **kwargs)
 
     uninstallPlugin = uninstall_plugin
 
-    @wraps(SearchAPIMixIn.search_enable_plugin)
     def enable_plugin(
         self,
         plugins: str | Iterable[str] | None = None,
         enable: bool | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~SearchAPIMixIn.search_enable_plugin`."""
         return self._client.search_enable_plugin(
             plugins=plugins,
             enable=enable,
@@ -536,19 +535,19 @@ class Search(ClientCache[SearchAPIMixIn]):
 
     enablePlugin = enable_plugin
 
-    @wraps(SearchAPIMixIn.search_update_plugins)
     def update_plugins(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~SearchAPIMixIn.search_update_plugins`."""
         return self._client.search_update_plugins(**kwargs)
 
     updatePlugins = update_plugins
 
-    @wraps(SearchAPIMixIn.search_download_torrent)
     def download_torrent(
         self,
         url: str | None = None,
         plugin: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~SearchAPIMixIn.search_download_torrent`."""
         return self._client.search_download_torrent(url=url, plugin=plugin)
 
     downloadTorrent = download_torrent

--- a/src/qbittorrentapi/torrentcreator.py
+++ b/src/qbittorrentapi/torrentcreator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import enum
 import os
 from collections.abc import Mapping
-from functools import wraps
 from typing import Any, Literal, cast
 
 from qbittorrentapi.app import AppAPIMixIn
@@ -109,14 +108,14 @@ class TorrentCreatorAPIMixIn(AppAPIMixIn):
         """
         data = {
             "sourcePath": source_path,
-            "torrentFilePath": os.fsdecode(torrent_file_path)
-            if torrent_file_path
-            else None,
+            "torrentFilePath": (
+                os.fsdecode(torrent_file_path) if torrent_file_path else None
+            ),
             "format": format,
             "private": None if is_private is None else bool(is_private),
-            "optimizeAlignment": None
-            if optimize_alignment is None
-            else bool(optimize_alignment),
+            "optimizeAlignment": (
+                None if optimize_alignment is None else bool(optimize_alignment)
+            ),
             "startSeeding": None if start_seeding is None else bool(start_seeding),
             "paddedFileSizeLimit": padded_file_size_limit,
             "pieceSize": piece_size,
@@ -222,18 +221,18 @@ class TorrentCreatorTaskDictionary(
         self.task_id: str | None = cast(str, data.get("taskID", None))
         super().__init__(data=data, client=client)
 
-    @wraps(TorrentCreatorAPIMixIn.torrentcreator_status)
     def status(self, **kwargs: APIKwargsT) -> TorrentCreatorTaskStatus:
+        """Implements :meth:`~TorrentCreatorAPIMixIn.torrentcreator_status`."""
         return self._client.torrentcreator_status(task_id=self.task_id, **kwargs)[0]
 
-    @wraps(TorrentCreatorAPIMixIn.torrentcreator_torrent_file)
     def torrent_file(self, **kwargs: APIKwargsT) -> bytes:
+        """Implements :meth:`~TorrentCreatorAPIMixIn.torrentcreator_torrent_file`."""
         return self._client.torrentcreator_torrent_file(task_id=self.task_id, **kwargs)
 
     torrentFile = torrent_file
 
-    @wraps(TorrentCreatorAPIMixIn.torrentcreator_delete_task)
     def delete(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentCreatorAPIMixIn.torrentcreator_delete_task`."""
         return self._client.torrentcreator_delete_task(task_id=self.task_id, **kwargs)
 
 
@@ -254,7 +253,6 @@ class TorrentCreator(ClientCache[TorrentCreatorAPIMixIn]):
         >>> client.torrentcreator.delete_task(task_id=task.taskID)
     """  # noqa: E501
 
-    @wraps(TorrentCreatorAPIMixIn.torrentcreator_add_task)
     def add_task(
         self,
         source_path: str | os.PathLike[Any] | None = None,
@@ -270,6 +268,7 @@ class TorrentCreator(ClientCache[TorrentCreatorAPIMixIn]):
         url_seeds: str | list[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> TorrentCreatorTaskDictionary:
+        """Implements :meth:`~TorrentCreatorAPIMixIn.torrentcreator_add_task`."""
         return self._client.torrentcreator_add_task(
             source_path=source_path,
             torrent_file_path=torrent_file_path,
@@ -287,30 +286,30 @@ class TorrentCreator(ClientCache[TorrentCreatorAPIMixIn]):
 
     addTask = add_task
 
-    @wraps(TorrentCreatorAPIMixIn.torrentcreator_status)
     def status(
         self,
         task_id: str | None = None,
         **kwargs: APIKwargsT,
     ) -> TorrentCreatorTaskStatusList:
+        """Implements :meth:`~TorrentCreatorAPIMixIn.torrentcreator_status`."""
         return self._client.torrentcreator_status(task_id=task_id, **kwargs)
 
-    @wraps(TorrentCreatorAPIMixIn.torrentcreator_torrent_file)
     def torrent_file(
         self,
         task_id: str | None = None,
         **kwargs: APIKwargsT,
     ) -> bytes:
+        """Implements :meth:`~TorrentCreatorAPIMixIn.torrentcreator_torrent_file`."""
         return self._client.torrentcreator_torrent_file(task_id=task_id, **kwargs)
 
     torrentFile = torrent_file
 
-    @wraps(TorrentCreatorAPIMixIn.torrentcreator_delete_task)
     def delete_task(
         self,
         task_id: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentCreatorAPIMixIn.torrentcreator_delete_task`."""
         self._client.torrentcreator_delete_task(task_id=task_id, **kwargs)
 
     deleteTask = delete_task

--- a/src/qbittorrentapi/torrents.py
+++ b/src/qbittorrentapi/torrents.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import errno
-from functools import wraps
 from logging import Logger, getLogger
 from os import path
 from os import strerror as os_strerror
@@ -1833,40 +1832,40 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
         return TorrentDictionary(data={}, client=self._client)
 
-    @wraps(TorrentsAPIMixIn.torrents_start)
     def start(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_start`."""
         self._client.torrents_start(torrent_hashes=self._torrent_hash, **kwargs)
 
     resume = start
 
-    @wraps(TorrentsAPIMixIn.torrents_stop)
     def stop(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_stop`."""
         self._client.torrents_stop(torrent_hashes=self._torrent_hash, **kwargs)
 
     pause = stop
 
-    @wraps(TorrentsAPIMixIn.torrents_delete)
     def delete(
         self,
         delete_files: bool | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_delete`."""
         self._client.torrents_delete(
             delete_files=delete_files,
             torrent_hashes=self._torrent_hash,
             **kwargs,
         )
 
-    @wraps(TorrentsAPIMixIn.torrents_recheck)
     def recheck(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_recheck`."""
         self._client.torrents_recheck(torrent_hashes=self._torrent_hash, **kwargs)
 
-    @wraps(TorrentsAPIMixIn.torrents_reannounce)
     def reannounce(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_reannounce`."""
         self._client.torrents_reannounce(torrent_hashes=self._torrent_hash, **kwargs)
 
-    @wraps(TorrentsAPIMixIn.torrents_increase_priority)
     def increase_priority(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_increase_priority`."""
         self._client.torrents_increase_priority(
             torrent_hashes=self._torrent_hash,
             **kwargs,
@@ -1874,8 +1873,8 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     increasePrio = increase_priority
 
-    @wraps(TorrentsAPIMixIn.torrents_decrease_priority)
     def decrease_priority(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_decrease_priority`."""
         self._client.torrents_decrease_priority(
             torrent_hashes=self._torrent_hash,
             **kwargs,
@@ -1883,14 +1882,14 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     decreasePrio = decrease_priority
 
-    @wraps(TorrentsAPIMixIn.torrents_top_priority)
     def top_priority(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_top_priority`."""
         self._client.torrents_top_priority(torrent_hashes=self._torrent_hash, **kwargs)
 
     topPrio = top_priority
 
-    @wraps(TorrentsAPIMixIn.torrents_bottom_priority)
     def bottom_priority(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_bottom_priority`."""
         self._client.torrents_bottom_priority(
             torrent_hashes=self._torrent_hash,
             **kwargs,
@@ -1898,7 +1897,6 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     bottomPrio = bottom_priority
 
-    @wraps(TorrentsAPIMixIn.torrents_set_share_limits)
     def set_share_limits(
         self,
         ratio_limit: str | int | None = None,
@@ -1906,6 +1904,7 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
         inactive_seeding_time_limit: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_share_limits`."""
         self._client.torrents_set_share_limits(
             ratio_limit=ratio_limit,
             seeding_time_limit=seeding_time_limit,
@@ -1917,8 +1916,8 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
     setShareLimits = set_share_limits
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_download_limit)
     def download_limit(self) -> int:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_download_limit`."""
         return cast(
             int,
             self._client.torrents_download_limit(torrent_hashes=self._torrent_hash).get(
@@ -1927,13 +1926,13 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
         )
 
     @download_limit.setter
-    @wraps(TorrentsAPIMixIn.torrents_set_download_limit)
     def download_limit(self, val: str | int) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_download_limit`."""
         self.set_download_limit(limit=val)
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_download_limit)
     def downloadLimit(self) -> int:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_download_limit`."""
         return cast(
             int,
             self._client.torrents_download_limit(torrent_hashes=self._torrent_hash).get(
@@ -1942,16 +1941,16 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
         )
 
     @downloadLimit.setter
-    @wraps(TorrentsAPIMixIn.torrents_set_download_limit)
     def downloadLimit(self, val: str | int) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_download_limit`."""
         self.set_download_limit(limit=val)
 
-    @wraps(TorrentsAPIMixIn.torrents_set_download_limit)
     def set_download_limit(
         self,
         limit: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_download_limit`."""
         self._client.torrents_set_download_limit(
             limit=limit,
             torrent_hashes=self._torrent_hash,
@@ -1961,8 +1960,8 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
     setDownloadLimit = set_download_limit
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_upload_limit)
     def upload_limit(self) -> int:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_upload_limit`."""
         return cast(
             int,
             self._client.torrents_upload_limit(torrent_hashes=self._torrent_hash).get(
@@ -1971,13 +1970,13 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
         )
 
     @upload_limit.setter
-    @wraps(TorrentsAPIMixIn.torrents_set_upload_limit)
     def upload_limit(self, val: str | int) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_upload_limit`."""
         self.set_upload_limit(limit=val)
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_upload_limit)
     def uploadLimit(self) -> int:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_upload_limit`."""
         return cast(
             int,
             self._client.torrents_upload_limit(torrent_hashes=self._torrent_hash).get(
@@ -1986,16 +1985,16 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
         )
 
     @uploadLimit.setter
-    @wraps(TorrentsAPIMixIn.torrents_set_upload_limit)
     def uploadLimit(self, val: str | int) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_upload_limit`."""
         self.set_upload_limit(limit=val)
 
-    @wraps(TorrentsAPIMixIn.torrents_set_upload_limit)
     def set_upload_limit(
         self,
         limit: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_upload_limit`."""
         self._client.torrents_set_upload_limit(
             limit=limit,
             torrent_hashes=self._torrent_hash,
@@ -2004,12 +2003,12 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     setUploadLimit = set_upload_limit
 
-    @wraps(TorrentsAPIMixIn.torrents_set_location)
     def set_location(
         self,
         location: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_location`."""
         self._client.torrents_set_location(
             location=location,
             torrent_hashes=self._torrent_hash,
@@ -2018,12 +2017,12 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     setLocation = set_location
 
-    @wraps(TorrentsAPIMixIn.torrents_set_save_path)
     def set_save_path(
         self,
         save_path: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_save_path`."""
         self._client.torrents_set_save_path(
             save_path=save_path,
             torrent_hashes=self._torrent_hash,
@@ -2032,12 +2031,12 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     setSavePath = set_save_path
 
-    @wraps(TorrentsAPIMixIn.torrents_set_download_path)
     def set_download_path(
         self,
         download_path: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_download_path`."""
         self._client.torrents_set_download_path(
             download_path=download_path,
             torrent_hashes=self._torrent_hash,
@@ -2046,12 +2045,12 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     setDownloadPath = set_download_path
 
-    @wraps(TorrentsAPIMixIn.torrents_set_category)
     def set_category(
         self,
         category: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_category`."""
         self._client.torrents_set_category(
             category=category,
             torrent_hashes=self._torrent_hash,
@@ -2060,12 +2059,12 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     setCategory = set_category
 
-    @wraps(TorrentsAPIMixIn.torrents_set_auto_management)
     def set_auto_management(
         self,
         enable: bool | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_auto_management`."""
         self._client.torrents_set_auto_management(
             enable=enable,
             torrent_hashes=self._torrent_hash,
@@ -2074,8 +2073,8 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     setAutoManagement = set_auto_management
 
-    @wraps(TorrentsAPIMixIn.torrents_toggle_sequential_download)
     def toggle_sequential_download(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_toggle_sequential_download`."""
         self._client.torrents_toggle_sequential_download(
             torrent_hashes=self._torrent_hash,
             **kwargs,
@@ -2083,8 +2082,9 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     toggleSequentialDownload = toggle_sequential_download
 
-    @wraps(TorrentsAPIMixIn.torrents_toggle_first_last_piece_priority)
     def toggle_first_last_piece_priority(self, **kwargs: APIKwargsT) -> None:
+        """Implements
+        :meth:`~TorrentsAPIMixIn.torrents_toggle_first_last_piece_priority`."""
         self._client.torrents_toggle_first_last_piece_priority(
             torrent_hashes=self._torrent_hash,
             **kwargs,
@@ -2092,12 +2092,12 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     toggleFirstLastPiecePrio = toggle_first_last_piece_priority
 
-    @wraps(TorrentsAPIMixIn.torrents_set_force_start)
     def set_force_start(
         self,
         enable: bool | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_force_start`."""
         self._client.torrents_set_force_start(
             enable=enable,
             torrent_hashes=self._torrent_hash,
@@ -2106,12 +2106,12 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     setForceStart = set_force_start
 
-    @wraps(TorrentsAPIMixIn.torrents_set_super_seeding)
     def set_super_seeding(
         self,
         enable: bool | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_set_super_seeding`."""
         self._client.torrents_set_super_seeding(
             enable=enable,
             torrent_hashes=self._torrent_hash,
@@ -2121,31 +2121,30 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
     setSuperSeeding = set_super_seeding
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_properties)
     def properties(self) -> TorrentPropertiesDictionary:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_properties`."""
         return self._client.torrents_properties(torrent_hash=self._torrent_hash)
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_trackers)
     def trackers(self) -> TrackersList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_trackers`."""
         return self._client.torrents_trackers(torrent_hash=self._torrent_hash)
 
     @trackers.setter
-    @wraps(TorrentsAPIMixIn.torrents_add_trackers)
     def trackers(self, val: Iterable[str]) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_add_trackers`."""
         self.add_trackers(urls=val)
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_webseeds)
     def webseeds(self) -> WebSeedsList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_webseeds`."""
         return self._client.torrents_webseeds(torrent_hash=self._torrent_hash)
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_files)
     def files(self) -> TorrentFilesList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_files`."""
         return self._client.torrents_files(torrent_hash=self._torrent_hash)
 
-    @wraps(TorrentsAPIMixIn.torrents_rename_file)
     def rename_file(
         self,
         file_id: str | int | None = None,
@@ -2154,6 +2153,7 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
         new_path: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_rename_file`."""
         self._client.torrents_rename_file(
             torrent_hash=self._torrent_hash,
             file_id=file_id,
@@ -2165,13 +2165,13 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     renameFile = rename_file
 
-    @wraps(TorrentsAPIMixIn.torrents_rename_folder)
     def rename_folder(
         self,
         old_path: str | None = None,
         new_path: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_rename_folder`."""
         self._client.torrents_rename_folder(
             torrent_hash=self._torrent_hash,
             old_path=old_path,
@@ -2182,25 +2182,25 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
     renameFolder = rename_folder
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_piece_states)
     def piece_states(self) -> TorrentPieceInfoList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_piece_states`."""
         return self._client.torrents_piece_states(torrent_hash=self._torrent_hash)
 
     pieceStates = piece_states
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_piece_hashes)
     def piece_hashes(self) -> TorrentPieceInfoList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_piece_hashes`."""
         return self._client.torrents_piece_hashes(torrent_hash=self._torrent_hash)
 
     pieceHashes = piece_hashes
 
-    @wraps(TorrentsAPIMixIn.torrents_add_trackers)
     def add_trackers(
         self,
         urls: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_add_trackers`."""
         self._client.torrents_add_trackers(
             torrent_hash=self._torrent_hash,
             urls=urls,
@@ -2209,13 +2209,13 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     addTrackers = add_trackers
 
-    @wraps(TorrentsAPIMixIn.torrents_edit_tracker)
     def edit_tracker(
         self,
         orig_url: str | None = None,
         new_url: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_edit_tracker`."""
         self._client.torrents_edit_tracker(
             torrent_hash=self._torrent_hash,
             original_url=orig_url,
@@ -2225,12 +2225,12 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     editTracker = edit_tracker
 
-    @wraps(TorrentsAPIMixIn.torrents_remove_trackers)
     def remove_trackers(
         self,
         urls: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_trackers`."""
         self._client.torrents_remove_trackers(
             torrent_hash=self._torrent_hash,
             urls=urls,
@@ -2239,13 +2239,13 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     removeTrackers = remove_trackers
 
-    @wraps(TorrentsAPIMixIn.torrents_file_priority)
     def file_priority(
         self,
         file_ids: str | int | Iterable[str | int] | None = None,
         priority: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_file_priority`."""
         self._client.torrents_file_priority(
             torrent_hash=self._torrent_hash,
             file_ids=file_ids,
@@ -2255,20 +2255,20 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     filePriority = file_priority
 
-    @wraps(TorrentsAPIMixIn.torrents_rename)
     def rename(self, new_name: str | None = None, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_rename`."""
         self._client.torrents_rename(
             torrent_hash=self._torrent_hash,
             new_torrent_name=new_name,
             **kwargs,
         )
 
-    @wraps(TorrentsAPIMixIn.torrents_add_tags)
     def add_tags(
         self,
         tags: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_add_tags`."""
         self._client.torrents_add_tags(
             torrent_hashes=self._torrent_hash,
             tags=tags,
@@ -2277,12 +2277,12 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     addTags = add_tags
 
-    @wraps(TorrentsAPIMixIn.torrents_remove_tags)
     def remove_tags(
         self,
         tags: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_tags`."""
         self._client.torrents_remove_tags(
             torrent_hashes=self._torrent_hash,
             tags=tags,
@@ -2291,8 +2291,8 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
 
     removeTags = remove_tags
 
-    @wraps(TorrentsAPIMixIn.torrents_export)
     def export(self, **kwargs: APIKwargsT) -> bytes:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_export`."""
         return self._client.torrents_export(torrent_hash=self._torrent_hash, **kwargs)
 
 
@@ -2811,7 +2811,6 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
                 **kwargs,
             )
 
-    @wraps(TorrentsAPIMixIn.torrents_add)
     def add(
         self,
         urls: str | Iterable[str] | None = None,
@@ -2847,6 +2846,7 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
         is_stopped: bool | None = None,
         **kwargs: APIKwargsT,
     ) -> str:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_add`."""
         return self._client.torrents_add(
             urls=urls,
             torrent_files=torrent_files,
@@ -2879,69 +2879,69 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
             **kwargs,
         )
 
-    @wraps(TorrentsAPIMixIn.torrents_count)
     def count(self) -> int:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_count`."""
         return self._client.torrents_count()
 
-    @wraps(TorrentsAPIMixIn.torrents_properties)
     def properties(
         self,
         torrent_hash: str | None = None,
         **kwargs: APIKwargsT,
     ) -> TorrentPropertiesDictionary:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_properties`."""
         return self._client.torrents_properties(torrent_hash=torrent_hash, **kwargs)
 
-    @wraps(TorrentsAPIMixIn.torrents_trackers)
     def trackers(
         self,
         torrent_hash: str | None = None,
         **kwargs: APIKwargsT,
     ) -> TrackersList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_trackers`."""
         return self._client.torrents_trackers(torrent_hash=torrent_hash, **kwargs)
 
-    @wraps(TorrentsAPIMixIn.torrents_webseeds)
     def webseeds(
         self,
         torrent_hash: str | None = None,
         **kwargs: APIKwargsT,
     ) -> WebSeedsList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_webseeds`."""
         return self._client.torrents_webseeds(torrent_hash=torrent_hash, **kwargs)
 
-    @wraps(TorrentsAPIMixIn.torrents_files)
     def files(
         self,
         torrent_hash: str | None = None,
         **kwargs: APIKwargsT,
     ) -> TorrentFilesList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_files`."""
         return self._client.torrents_files(torrent_hash=torrent_hash, **kwargs)
 
-    @wraps(TorrentsAPIMixIn.torrents_piece_states)
     def piece_states(
         self,
         torrent_hash: str | None = None,
         **kwargs: APIKwargsT,
     ) -> TorrentPieceInfoList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_piece_states`."""
         return self._client.torrents_piece_states(torrent_hash=torrent_hash, **kwargs)
 
     pieceStates = piece_states
 
-    @wraps(TorrentsAPIMixIn.torrents_piece_hashes)
     def piece_hashes(
         self,
         torrent_hash: str | None = None,
         **kwargs: APIKwargsT,
     ) -> TorrentPieceInfoList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_piece_hashes`."""
         return self._client.torrents_piece_hashes(torrent_hash=torrent_hash, **kwargs)
 
     pieceHashes = piece_hashes
 
-    @wraps(TorrentsAPIMixIn.torrents_add_trackers)
     def add_trackers(
         self,
         torrent_hash: str | None = None,
         urls: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_add_trackers`."""
         return self._client.torrents_add_trackers(
             torrent_hash=torrent_hash,
             urls=urls,
@@ -2950,7 +2950,6 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
 
     addTrackers = add_trackers
 
-    @wraps(TorrentsAPIMixIn.torrents_edit_tracker)
     def edit_tracker(
         self,
         torrent_hash: str | None = None,
@@ -2958,6 +2957,7 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
         new_url: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_edit_tracker`."""
         return self._client.torrents_edit_tracker(
             torrent_hash=torrent_hash,
             original_url=original_url,
@@ -2967,13 +2967,13 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
 
     editTracker = edit_tracker
 
-    @wraps(TorrentsAPIMixIn.torrents_remove_trackers)
     def remove_trackers(
         self,
         torrent_hash: str | None = None,
         urls: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_trackers`."""
         return self._client.torrents_remove_trackers(
             torrent_hash=torrent_hash,
             urls=urls,
@@ -2982,7 +2982,6 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
 
     removeTrackers = remove_trackers
 
-    @wraps(TorrentsAPIMixIn.torrents_file_priority)
     def file_priority(
         self,
         torrent_hash: str | None = None,
@@ -2990,6 +2989,7 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
         priority: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_file_priority`."""
         return self._client.torrents_file_priority(
             torrent_hash=torrent_hash,
             file_ids=file_ids,
@@ -2999,20 +2999,19 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
 
     filePrio = file_priority
 
-    @wraps(TorrentsAPIMixIn.torrents_rename)
     def rename(
         self,
         torrent_hash: str | None = None,
         new_torrent_name: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_rename`."""
         return self._client.torrents_rename(
             torrent_hash=torrent_hash,
             new_torrent_name=new_torrent_name,
             **kwargs,
         )
 
-    @wraps(TorrentsAPIMixIn.torrents_rename_file)
     def rename_file(
         self,
         torrent_hash: str | None = None,
@@ -3022,6 +3021,7 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
         new_path: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_rename_file`."""
         return self._client.torrents_rename_file(
             torrent_hash=torrent_hash,
             file_id=file_id,
@@ -3033,7 +3033,6 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
 
     renameFile = rename_file
 
-    @wraps(TorrentsAPIMixIn.torrents_rename_folder)
     def rename_folder(
         self,
         torrent_hash: str | None = None,
@@ -3041,6 +3040,7 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
         new_path: str | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_rename_folder`."""
         return self._client.torrents_rename_folder(
             torrent_hash=torrent_hash,
             old_path=old_path,
@@ -3050,12 +3050,12 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
 
     renameFolder = rename_folder
 
-    @wraps(TorrentsAPIMixIn.torrents_export)
     def export(
         self,
         torrent_hash: str | None = None,
         **kwargs: APIKwargsT,
     ) -> bytes:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_export`."""
         return self._client.torrents_export(torrent_hash=torrent_hash, **kwargs)
 
 
@@ -3080,19 +3080,18 @@ class TorrentCategories(ClientCache[TorrentsAPIMixIn]):
     """  # noqa: E501
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_categories)
     def categories(self) -> TorrentCategoriesDictionary:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_categories`."""
         return self._client.torrents_categories()
 
     @categories.setter
-    @wraps(TorrentsAPIMixIn.torrents_edit_category)
     def categories(self, val: Mapping[str, str | bool]) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_edit_category`."""
         if val.get("name", "") in self.categories:
             self.edit_category(**val)  # type: ignore[arg-type]
         else:
             self.create_category(**val)  # type: ignore[arg-type]
 
-    @wraps(TorrentsAPIMixIn.torrents_create_category)
     def create_category(
         self,
         name: str | None = None,
@@ -3101,6 +3100,7 @@ class TorrentCategories(ClientCache[TorrentsAPIMixIn]):
         enable_download_path: bool | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_create_category`."""
         return self._client.torrents_create_category(
             name=name,
             save_path=save_path,
@@ -3111,7 +3111,6 @@ class TorrentCategories(ClientCache[TorrentsAPIMixIn]):
 
     createCategory = create_category
 
-    @wraps(TorrentsAPIMixIn.torrents_edit_category)
     def edit_category(
         self,
         name: str | None = None,
@@ -3120,6 +3119,7 @@ class TorrentCategories(ClientCache[TorrentsAPIMixIn]):
         enable_download_path: bool | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_edit_category`."""
         return self._client.torrents_edit_category(
             name=name,
             save_path=save_path,
@@ -3130,12 +3130,12 @@ class TorrentCategories(ClientCache[TorrentsAPIMixIn]):
 
     editCategory = edit_category
 
-    @wraps(TorrentsAPIMixIn.torrents_remove_categories)
     def remove_categories(
         self,
         categories: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_categories`."""
         return self._client.torrents_remove_categories(categories=categories, **kwargs)
 
     removeCategories = remove_categories
@@ -3155,22 +3155,22 @@ class TorrentTags(ClientCache[TorrentsAPIMixIn]):
     """  # noqa: E501
 
     @property
-    @wraps(TorrentsAPIMixIn.torrents_tags)
     def tags(self) -> TagList:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_tags`."""
         return self._client.torrents_tags()
 
     @tags.setter
-    @wraps(TorrentsAPIMixIn.torrents_create_tags)
     def tags(self, val: Iterable[str] | None = None) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_create_tags`."""
         self._client.torrents_create_tags(tags=val)
 
-    @wraps(TorrentsAPIMixIn.torrents_add_tags)
     def add_tags(
         self,
         tags: str | Iterable[str] | None = None,
         torrent_hashes: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_add_tags`."""
         self._client.torrents_add_tags(
             tags=tags,
             torrent_hashes=torrent_hashes,
@@ -3179,13 +3179,13 @@ class TorrentTags(ClientCache[TorrentsAPIMixIn]):
 
     addTags = add_tags
 
-    @wraps(TorrentsAPIMixIn.torrents_remove_tags)
     def remove_tags(
         self,
         tags: str | Iterable[str] | None = None,
         torrent_hashes: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_remove_tags`."""
         self._client.torrents_remove_tags(
             tags=tags,
             torrent_hashes=torrent_hashes,
@@ -3194,22 +3194,22 @@ class TorrentTags(ClientCache[TorrentsAPIMixIn]):
 
     removeTags = remove_tags
 
-    @wraps(TorrentsAPIMixIn.torrents_create_tags)
     def create_tags(
         self,
         tags: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_create_tags`."""
         self._client.torrents_create_tags(tags=tags, **kwargs)
 
     createTags = create_tags
 
-    @wraps(TorrentsAPIMixIn.torrents_delete_tags)
     def delete_tags(
         self,
         tags: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TorrentsAPIMixIn.torrents_delete_tags`."""
         self._client.torrents_delete_tags(tags=tags, **kwargs)
 
     deleteTags = delete_tags

--- a/src/qbittorrentapi/transfer.py
+++ b/src/qbittorrentapi/transfer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from functools import wraps
 from typing import Iterable
 
 from qbittorrentapi._version_support import v
@@ -205,36 +204,36 @@ class Transfer(ClientCache[TransferAPIMixIn]):
     """  # noqa: E501
 
     @property
-    @wraps(TransferAPIMixIn.transfer_info)
     def info(self) -> TransferInfoDictionary:
+        """Implements :meth:`~TransferAPIMixIn.transfer_info`."""
         return self._client.transfer_info()
 
     @property
-    @wraps(TransferAPIMixIn.transfer_speed_limits_mode)
     def speed_limits_mode(self) -> str:
+        """Implements :meth:`~TransferAPIMixIn.transfer_speed_limits_mode`."""
         return self._client.transfer_speed_limits_mode()
 
     @speed_limits_mode.setter
-    @wraps(TransferAPIMixIn.transfer_set_speed_limits_mode)
     def speed_limits_mode(self, val: bool) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_speed_limits_mode`."""
         self.set_speed_limits_mode(intended_state=val)
 
     @property
-    @wraps(TransferAPIMixIn.transfer_speed_limits_mode)
     def speedLimitsMode(self) -> str:
+        """Implements :meth:`~TransferAPIMixIn.transfer_speed_limits_mode`."""
         return self._client.transfer_speed_limits_mode()
 
     @speedLimitsMode.setter
-    @wraps(TransferAPIMixIn.transfer_set_speed_limits_mode)
     def speedLimitsMode(self, val: bool) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_speed_limits_mode`."""
         self.set_speed_limits_mode(intended_state=val)
 
-    @wraps(TransferAPIMixIn.transfer_set_speed_limits_mode)
     def set_speed_limits_mode(
         self,
         intended_state: bool | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_speed_limits_mode`."""
         return self._client.transfer_set_speed_limits_mode(
             intended_state=intended_state,
             **kwargs,
@@ -245,71 +244,71 @@ class Transfer(ClientCache[TransferAPIMixIn]):
     toggle_speed_limits_mode = set_speed_limits_mode
 
     @property
-    @wraps(TransferAPIMixIn.transfer_download_limit)
     def download_limit(self) -> int:
+        """Implements :meth:`~TransferAPIMixIn.transfer_download_limit`."""
         return self._client.transfer_download_limit()
 
     @download_limit.setter
-    @wraps(TransferAPIMixIn.transfer_set_download_limit)
     def download_limit(self, val: int | str) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_download_limit`."""
         self.set_download_limit(limit=val)
 
     @property
-    @wraps(TransferAPIMixIn.transfer_download_limit)
     def downloadLimit(self) -> int:
+        """Implements :meth:`~TransferAPIMixIn.transfer_download_limit`."""
         return self._client.transfer_download_limit()
 
     @downloadLimit.setter
-    @wraps(TransferAPIMixIn.transfer_set_download_limit)
     def downloadLimit(self, val: int | str) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_download_limit`."""
         self.set_download_limit(limit=val)
 
     @property
-    @wraps(TransferAPIMixIn.transfer_upload_limit)
     def upload_limit(self) -> int:
+        """Implements :meth:`~TransferAPIMixIn.transfer_upload_limit`."""
         return self._client.transfer_upload_limit()
 
     @upload_limit.setter
-    @wraps(TransferAPIMixIn.transfer_set_upload_limit)
     def upload_limit(self, val: int | str) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_upload_limit`."""
         self.set_upload_limit(limit=val)
 
     @property
-    @wraps(TransferAPIMixIn.transfer_upload_limit)
     def uploadLimit(self) -> int:
+        """Implements :meth:`~TransferAPIMixIn.transfer_upload_limit`."""
         return self._client.transfer_upload_limit()
 
     @uploadLimit.setter
-    @wraps(TransferAPIMixIn.transfer_set_upload_limit)
     def uploadLimit(self, val: int | str) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_upload_limit`."""
         self.set_upload_limit(limit=val)
 
-    @wraps(TransferAPIMixIn.transfer_set_download_limit)
     def set_download_limit(
         self,
         limit: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_download_limit`."""
         return self._client.transfer_set_download_limit(limit=limit, **kwargs)
 
     setDownloadLimit = set_download_limit
 
-    @wraps(TransferAPIMixIn.transfer_set_upload_limit)
     def set_upload_limit(
         self,
         limit: str | int | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_set_upload_limit`."""
         return self._client.transfer_set_upload_limit(limit=limit, **kwargs)
 
     setUploadLimit = set_upload_limit
 
-    @wraps(TransferAPIMixIn.transfer_ban_peers)
     def ban_peers(
         self,
         peers: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_ban_peers`."""
         self._client.transfer_ban_peers(peers=peers, **kwargs)
 
     banPeers = ban_peers


### PR DESCRIPTION
## Changes
- This was originally implemented for the benefit of documentation so the docstrings in the MixIn classes could be replicated in the "interactive" classes in the RTD docs.
- This was leading to issues in both mypy as well as pyright and generally doesn't seem like a proper use-case for `wraps`.
- Closes #471