### PR TITLE
Bump pre-commit hook for ruff-pre-commit from v0.5.7 to v0.6.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           name: coverage-data-${{ inputs.python-version }}-${{ inputs.qbittorrent-version }}
           path: ./.coverage.*
+          include-hidden-files: true
 
       - name: Send mail
         if: failure() && github.event_name != 'pull_request'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           - --non-cap=qBittorrent
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.5.7
+    rev: v0.6.3
     hooks:
       - id: ruff
         args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,12 @@ from time import sleep
 from unittest.mock import MagicMock
 
 import pytest
+
 from qbittorrentapi import APIConnectionError, Client
 from qbittorrentapi._version_support import (
     APP_VERSION_2_API_VERSION_MAP as api_version_map,
 )
 from qbittorrentapi._version_support import v
-
 from tests.utils import (
     CHECK_SLEEP,
     add_torrent,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from qbittorrentapi import APINames
 from qbittorrentapi._attrdict import AttrDict
 from qbittorrentapi.app import (
@@ -9,7 +10,6 @@ from qbittorrentapi.app import (
     NetworkInterfaceAddressList,
     NetworkInterfaceList,
 )
-
 from tests.conftest import IS_QBT_DEV
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from qbittorrentapi import APINames, Client
 from qbittorrentapi.exceptions import APIConnectionError
 

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 import pytest
+
 from qbittorrentapi._attrdict import AttrDict
 from qbittorrentapi.definitions import (
     Dictionary,

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from qbittorrentapi.definitions import APINames
 from qbittorrentapi.log import LogMainList, LogPeersList
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -4,14 +4,14 @@ from os import environ
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
+from requests import Response
+from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE
+
 from qbittorrentapi import APINames, Client, exceptions
 from qbittorrentapi._version_support import v
 from qbittorrentapi.definitions import Dictionary, List
 from qbittorrentapi.request import Request
 from qbittorrentapi.torrents import TorrentDictionary, TorrentInfoList
-from requests import Response
-from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE
-
 from tests.conftest import IS_QBT_DEV
 from tests.utils import mkpath
 

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -3,11 +3,11 @@ from contextlib import suppress
 from time import sleep
 
 import pytest
+
 from qbittorrentapi import APINames
 from qbittorrentapi._version_support import v
 from qbittorrentapi.exceptions import APIError, Conflict409Error
 from qbittorrentapi.rss import RSSitemsDictionary
-
 from tests.utils import check, retry
 
 FOLDER_ONE = "testFolderOne"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from qbittorrentapi import APINames, NotFound404Error
 from qbittorrentapi.search import (
     SearchCategoriesList,
@@ -9,7 +10,6 @@ from qbittorrentapi.search import (
     SearchResultsDictionary,
     SearchStatusesList,
 )
-
 from tests.conftest import TORRENT2_HASH, TORRENT2_URL
 from tests.utils import check, retry
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from qbittorrentapi import APINames
 from qbittorrentapi.sync import SyncMainDataDictionary, SyncTorrentPeersDictionary
 

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -4,6 +4,7 @@ from types import MethodType
 from unittest.mock import MagicMock
 
 import pytest
+
 from qbittorrentapi import (
     APINames,
     Conflict409Error,
@@ -16,7 +17,6 @@ from qbittorrentapi import (
     WebSeedsList,
 )
 from qbittorrentapi._version_support import v
-
 from tests.test_torrents import disable_queueing, enable_queueing
 from tests.utils import check, mkpath, retry
 

--- a/tests/test_torrentcreator.py
+++ b/tests/test_torrentcreator.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
+
 from qbittorrentapi import APINames
 from qbittorrentapi.exceptions import NotFound404Error
 from qbittorrentapi.torrentcreator import (
@@ -10,7 +11,6 @@ from qbittorrentapi.torrentcreator import (
     TorrentCreatorTaskStatus,
     TorrentCreatorTaskStatusList,
 )
-
 from tests.utils import check
 
 

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -5,6 +5,7 @@ from time import sleep
 
 import pytest
 import requests
+
 from qbittorrentapi import APINames
 from qbittorrentapi._version_support import v
 from qbittorrentapi.exceptions import (
@@ -27,7 +28,6 @@ from qbittorrentapi.torrents import (
     TrackersList,
     WebSeedsList,
 )
-
 from tests.conftest import (
     ROOT_FOLDER_TORRENT_FILE,
     ROOT_FOLDER_TORRENT_HASH,

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from qbittorrentapi import APINames
 from qbittorrentapi.transfer import TransferInfoDictionary
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,6 +1,6 @@
 import pytest
-from qbittorrentapi import Version
 
+from qbittorrentapi import Version
 from tests.conftest import IS_QBT_DEV, api_version_map
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@ from os import environ, path
 from time import sleep
 
 import pytest
+
 from qbittorrentapi import APIConnectionError, Client, TorrentDictionary
 from qbittorrentapi._version_support import (
     APP_VERSION_2_API_VERSION_MAP as api_version_map,


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `ruff-pre-commit` from v0.5.7 to v0.6.3 and ran the update against the repo.