### PR TITLE
Bump pre-commit hook for pre-commit-hooks from v4.6.0 to v5.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-toml
       - id: check-yaml


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `pre-commit-hooks` from v4.6.0 to v5.0.0 and ran the update against the repo.