### PR TITLE
Bump pre-commit hook for mirrors-mypy from v1.13.0 to v1.14.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.1
     hooks:
       - id: mypy
         files: ^src/


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `mirrors-mypy` from v1.13.0 to v1.14.1 and ran the update against the repo.