### PR TITLE
Bump pre-commit hook for ruff-pre-commit from v0.14.14 to v0.15.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   #        - --non-cap=qBittorrent
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.4
     hooks:
       - id: ruff
         args:

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -53,8 +53,9 @@ def test_state_enum(orig_torrent):
     assert orig_torrent.state_enum is not TorrentStates.UNKNOWN
     orig_torrent.resume()
     check(
-        lambda: orig_torrent.sync_local() is None
-        and orig_torrent.state_enum.is_downloading,
+        lambda: (
+            orig_torrent.sync_local() is None and orig_torrent.state_enum.is_downloading
+        ),
         True,
     )
     # simulate an unknown torrent.state
@@ -70,17 +71,21 @@ def test_state_enum(orig_torrent):
 def test_pause_resume(client, new_torrent):
     new_torrent.pause()
     check(
-        lambda: client.torrents_info(torrent_hashes=new_torrent.hash)[
-            0
-        ].state_enum.is_paused,
+        lambda: (
+            client.torrents_info(torrent_hashes=new_torrent.hash)[
+                0
+            ].state_enum.is_paused
+        ),
         True,
     )
 
     new_torrent.resume()
     check(
-        lambda: client.torrents_info(torrent_hashes=new_torrent.hash)[
-            0
-        ].state_enum.is_paused,
+        lambda: (
+            client.torrents_info(torrent_hashes=new_torrent.hash)[
+                0
+            ].state_enum.is_paused
+        ),
         False,
     )
 
@@ -90,17 +95,21 @@ def test_pause_resume(client, new_torrent):
 def test_stop_start(client, new_torrent):
     new_torrent.stop()
     check(
-        lambda: client.torrents_info(torrent_hashes=new_torrent.hash)[
-            0
-        ].state_enum.is_paused,
+        lambda: (
+            client.torrents_info(torrent_hashes=new_torrent.hash)[
+                0
+            ].state_enum.is_paused
+        ),
         True,
     )
 
     new_torrent.resume()
     check(
-        lambda: client.torrents_info(torrent_hashes=new_torrent.hash)[
-            0
-        ].state_enum.is_paused,
+        lambda: (
+            client.torrents_info(torrent_hashes=new_torrent.hash)[
+                0
+            ].state_enum.is_paused
+        ),
         False,
     )
 

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -901,17 +901,21 @@ def test_torrents_info_tag(client, new_torrent, info_func):
 def test_stop_start(client, new_torrent, stop_func, start_func):
     client.func(stop_func)(torrent_hashes=new_torrent.hash)
     check(
-        lambda: client.torrents_info(torrent_hashes=new_torrent.hash)[
-            0
-        ].state_enum.is_paused,
+        lambda: (
+            client.torrents_info(torrent_hashes=new_torrent.hash)[
+                0
+            ].state_enum.is_paused
+        ),
         True,
     )
 
     client.func(start_func)(torrent_hashes=new_torrent.hash)
     check(
-        lambda: client.torrents_info(torrent_hashes=new_torrent.hash)[
-            0
-        ].state_enum.is_paused,
+        lambda: (
+            client.torrents_info(torrent_hashes=new_torrent.hash)[
+                0
+            ].state_enum.is_paused
+        ),
         False,
     )
 


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `ruff-pre-commit` from v0.14.14 to v0.15.4 and ran the update against the repo.