### PR TITLE
fix: correct copy-paste docstring error in rss_move_item

### DIFF
--- a/src/qbittorrentapi/rss.py
+++ b/src/qbittorrentapi/rss.py
@@ -163,9 +163,9 @@ class RSSAPIMixIn(AppAPIMixIn):
 
         :raises Conflict409Error:
 
-        :param orig_item_path: path to item to be removed
+        :param orig_item_path: path to item to be moved
             (e.g. ``Folder\\Subfolder\\ItemName``)
-        :param new_item_path: path to item to be removed
+        :param new_item_path: new path for the item
             (e.g. ``Folder\\Subfolder\\ItemName``)
         """
         data = {"itemPath": orig_item_path, "destPath": new_item_path}


### PR DESCRIPTION
The docstring for `RSSAPIMixIn.rss_move_item` incorrectly described both `orig_item_path` and `new_item_path` as 'path to item to be removed' — a copy-paste from the `rss_remove_item` docstring just above it.

This is misleading: the method moves/renames an item, so `orig_item_path` is the source path to move and `new_item_path` is the destination path. Updated both descriptions to reflect that.

Before:
```
:param orig_item_path: path to item to be removed
:param new_item_path: path to item to be removed
```

After:
```
:param orig_item_path: path to item to be moved
:param new_item_path: new path for the item
```

— Sent via @AmSach bot