### PR TITLE
fix: preserve list entries when slicing

### DIFF
--- a/src/qbittorrentapi/definitions.py
+++ b/src/qbittorrentapi/definitions.py
@@ -257,7 +257,9 @@ class List(UserList[ListEntryT]):
             [
                 (
                     entry_class(data=entry, **kwargs)  # type: ignore[misc]
-                    if entry_class is not None and isinstance(entry, Mapping)
+                    if entry_class is not None
+                    and isinstance(entry, Mapping)
+                    and not isinstance(entry, entry_class)
                     else entry
                 )
                 for entry in list_entries or []

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -204,3 +204,13 @@ def test_list_actions(client):
         ListEntry({"two": "2"}),
         ListEntry({"three": "3"}),
     ]
+
+
+def test_list_slice_preserves_entries():
+    """Slicing must not re-wrap (and so strip the client from) existing entries."""
+    from qbittorrentapi.torrents import TorrentInfoList
+
+    torrents = TorrentInfoList([{"hash": "abc"}], client="client sentinel")
+
+    assert torrents[0:1][0] is torrents[0]
+    assert torrents[0:1][0]._client == "client sentinel"


### PR DESCRIPTION
Closes #406

`UserList` re-invokes `__init__` with the already-constructed entries when a list is sliced (also on `copy()`/`+`). Since those entries are `Mapping`s, `List.__init__` wrapped them in `entry_class` a second time without the `client` kwarg, so the new objects had `_client = None` and `torrents[0:1][0].properties` raised `AttributeError`.

Entries that are already `entry_class` instances are now passed through unchanged, so a slice shares the original, fully-initialised objects.
