### PR TITLE
Bump pre-commit hook for ruff-pre-commit from v0.15.20 to v0.16.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   #        - --non-cap=qBittorrent
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.16.1
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `ruff-pre-commit` from v0.15.20 to v0.16.1 and ran the update against the repo.