### PR TITLE
fix: only prefer HTTPS on certificate SSL errors during scheme detection

### DIFF
--- a/src/qbittorrentapi/request.py
+++ b/src/qbittorrentapi/request.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ssl
 from collections.abc import Iterable, Mapping
 from json import loads
 from logging import Logger, NullHandler, getLogger
@@ -57,6 +58,27 @@ ResponseT = TypeVar("ResponseT")
 
 logger: Logger = getLogger(__name__)
 getLogger("qbittorrentapi").addHandler(NullHandler())
+
+
+def _is_certificate_error(exc: BaseException) -> bool:
+    """
+    Determine whether an :class:`~requests.exceptions.SSLError` is a cert failure.
+
+    Speaking TLS to a plaintext port also raises ``SSLError``, so only a certificate
+    failure is evidence that qBittorrent is actually serving HTTPS.
+
+    :param exc: exception raised while attempting a TLS connection
+    :return: whether the exception was caused by certificate verification
+    """
+    seen = set()
+    cause: BaseException | None = exc
+    while cause is not None and id(cause) not in seen:
+        if isinstance(cause, ssl.SSLCertVerificationError):
+            return True
+        seen.add(id(cause))
+        cause = cause.__cause__ or cause.__context__
+    # older urllib3 versions can lose the original exception; fall back to the message
+    return "certificate verify failed" in str(exc).lower()
 
 
 class QbittorrentURL:
@@ -192,12 +214,21 @@ class QbittorrentURL:
                 )
                 scheme_to_use: str = urlparse(r.url).scheme
                 break
-            except requests_exceptions.SSLError:
-                # an SSLError means that qBittorrent is likely listening on HTTPS
-                # but the TLS connection is not trusted...so, if the attempt to
-                # connect on HTTP also fails, this will tell us to switch back to HTTPS
-                logger.debug("Encountered SSLError: will prefer HTTPS if HTTP fails")
-                prefer_https = True
+            except requests_exceptions.SSLError as exc:
+                # a certificate SSLError means that qBittorrent is likely listening on
+                # HTTPS but the TLS connection is not trusted...so, if the attempt to
+                # connect on HTTP also fails, this will tell us to switch back to HTTPS.
+                # speaking TLS to a plaintext port also raises SSLError, though, and
+                # that is no evidence at all that qBittorrent is serving HTTPS
+                if _is_certificate_error(exc):
+                    logger.debug(
+                        "Encountered SSLError: will prefer HTTPS if HTTP fails"
+                    )
+                    prefer_https = True
+                else:
+                    logger.debug(
+                        "Encountered non-certificate SSLError with %s", scheme.upper()
+                    )
             except requests_exceptions.RequestException:
                 logger.debug("Failed connection attempt with %s", scheme.upper())
         else:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,11 +1,14 @@
 import logging
 import re
+import ssl
 from os import environ
 from time import sleep
 from unittest.mock import MagicMock, PropertyMock
+from urllib.parse import urlparse
 
 import pytest
 from requests import Response
+from requests import exceptions as requests_exceptions
 from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE
 
 from qbittorrentapi import APINames, Client, exceptions
@@ -106,6 +109,48 @@ def test_hostname_format(app_version, hostname):
     assert client.app.version == app_version
     # ensure the base URL is always normalized
     assert re.match(r"(http|https)://localhost:8080/", client._url._base_url)
+
+
+@pytest.mark.parametrize(
+    ("ssl_error", "expected_scheme"),
+    (
+        (
+            ssl.SSLEOFError(
+                8, "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation"
+            ),
+            "http",
+        ),
+        (
+            ssl.SSLCertVerificationError(
+                1, "certificate verify failed: self signed certificate"
+            ),
+            "https",
+        ),
+    ),
+)
+def test_detect_scheme_ssl_error(monkeypatch, ssl_error, expected_scheme):
+    """Only a certificate failure means qBittorrent is serving HTTPS."""
+    client = Client(host="localhost:8080")
+
+    def request(method, url, **kwargs):
+        if urlparse(url).scheme == "http":
+            raise requests_exceptions.ConnectionError("transient connection failure")
+        raise requests_exceptions.SSLError(ssl_error)
+
+    session = MagicMock()
+    session.request = request
+    monkeypatch.setattr(type(client), "_session", PropertyMock(return_value=session))
+
+    assert (
+        client._url.detect_scheme(
+            urlparse("//localhost:8080"),
+            "http",
+            "https",
+            headers={},
+            requests_kwargs={},
+        )
+        == expected_scheme
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #642

`detect_scheme()` treated any `SSLError` from the HTTPS probe as evidence that qBittorrent is serving HTTPS, but speaking TLS to a plaintext port raises `SSLError` too (`SSLEOFError` / `WRONG_VERSION_NUMBER`). So a transient failure of the HTTP probe against an HTTP Web UI flipped the client to `https://`, and every request after that failed with a misleading untrusted-certificate error. `prefer_https` is now set only when the error was a certificate verification failure, walking the cause chain with a message fallback for older urllib3 that loses the original exception.

Regression test parametrizes both `SSLError` branches with a mocked session; the plaintext-port case fails without the fix and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
