### PR TITLE
fix: accept and forward **kwargs on all API methods

### DIFF
--- a/src/qbittorrentapi/app.py
+++ b/src/qbittorrentapi/app.py
@@ -287,12 +287,13 @@ class AppAPIMixIn(AuthAPIMixIn):
 
     app_networkInterfaceAddressList = app_network_interface_address_list
 
-    def app_send_test_email(self) -> None:
+    def app_send_test_email(self, **kwargs: APIKwargsT) -> None:
         """Sends a test email using the configured email address."""
         self._post(
             _name=APINames.Application,
             _method="sendTestEmail",
             version_introduced="2.10.4",
+            **kwargs,
         )
 
     app_sendTestEmail = app_send_test_email
@@ -301,6 +302,7 @@ class AppAPIMixIn(AuthAPIMixIn):
         self,
         directory_path: str | os.PathLike[AnyStr] | None = None,
         with_metadata: bool | None = None,
+        **kwargs: APIKwargsT,
     ) -> DirectoryContentList:
         """
         The contents of a directory file path.
@@ -321,6 +323,7 @@ class AppAPIMixIn(AuthAPIMixIn):
             data=data,
             response_class=DirectoryContentList,
             version_introduced="2.11",
+            **kwargs,
         )
 
     app_getDirectoryContent = app_get_directory_content
@@ -441,9 +444,9 @@ class Application(ClientCache[AppAPIMixIn]):
 
     networkInterfaceAddressList = network_interface_address_list
 
-    def send_test_email(self) -> None:
+    def send_test_email(self, **kwargs: APIKwargsT) -> None:
         """Implements :meth:`~AppAPIMixIn.app_send_test_email`."""
-        self._client.app_send_test_email()
+        self._client.app_send_test_email(**kwargs)
 
     sendTestEmail = send_test_email
 
@@ -451,11 +454,13 @@ class Application(ClientCache[AppAPIMixIn]):
         self,
         directory_path: str | os.PathLike[AnyStr] | None = None,
         with_metadata: bool | None = None,
+        **kwargs: APIKwargsT,
     ) -> DirectoryContentList:
         """Implements :meth:`~AppAPIMixIn.app_get_directory_content`."""
         return self._client.app_get_directory_content(
             directory_path=directory_path,
             with_metadata=with_metadata,
+            **kwargs,
         )
 
     getDirectoryContent = get_directory_content

--- a/src/qbittorrentapi/rss.py
+++ b/src/qbittorrentapi/rss.py
@@ -113,6 +113,7 @@ class RSSAPIMixIn(AppAPIMixIn):
         self,
         item_path: str | None = None,
         refresh_interval: int | None = None,
+        **kwargs: APIKwargsT,
     ) -> None:
         """
         Update the refresh interval for the RSS feed.
@@ -128,6 +129,7 @@ class RSSAPIMixIn(AppAPIMixIn):
             _method="setFeedRefreshInterval",
             data=data,
             version_introduced="2.11.5",
+            **kwargs,
         )
 
     rss_setFeedRefreshInterval = rss_set_feed_refresh_interval
@@ -397,11 +399,13 @@ class RSS(ClientCache[RSSAPIMixIn]):
         self,
         item_path: str | None = None,
         refresh_interval: int | None = None,
+        **kwargs: APIKwargsT,
     ) -> None:
         """Implements :meth:`~RSSAPIMixIn.rss_set_feed_refresh_interval`."""
         return self._client.rss_set_feed_refresh_interval(
             item_path=item_path,
             refresh_interval=refresh_interval,
+            **kwargs,
         )
 
     setFeedRefreshInterval = set_feed_refresh_interval
@@ -427,9 +431,13 @@ class RSS(ClientCache[RSSAPIMixIn]):
 
     moveItem = move_item
 
-    def refresh_item(self, item_path: str | None = None) -> None:
+    def refresh_item(
+        self,
+        item_path: str | None = None,
+        **kwargs: APIKwargsT,
+    ) -> None:
         """Implements :meth:`~RSSAPIMixIn.rss_refresh_item`."""
-        return self._client.rss_refresh_item(item_path=item_path)
+        return self._client.rss_refresh_item(item_path=item_path, **kwargs)
 
     refreshItem = refresh_item
 

--- a/src/qbittorrentapi/search.py
+++ b/src/qbittorrentapi/search.py
@@ -549,6 +549,6 @@ class Search(ClientCache[SearchAPIMixIn]):
         **kwargs: APIKwargsT,
     ) -> None:
         """Implements :meth:`~SearchAPIMixIn.search_download_torrent`."""
-        return self._client.search_download_torrent(url=url, plugin=plugin)
+        return self._client.search_download_torrent(url=url, plugin=plugin, **kwargs)
 
     downloadTorrent = download_torrent

--- a/src/qbittorrentapi/torrents.py
+++ b/src/qbittorrentapi/torrents.py
@@ -486,13 +486,14 @@ class TorrentsAPIMixIn(AppAPIMixIn):
                 raise TorrentFileError(io_err)
         return files  # type: ignore[return-value]
 
-    def torrents_count(self) -> int:
+    def torrents_count(self, **kwargs: APIKwargsT) -> int:
         """Retrieve count of torrents."""
         return self._post_cast(
             _name=APINames.Torrents,
             _method="count",
             response_class=int,
             version_introduced="2.9.3",
+            **kwargs,
         )
 
     ##########################################################################
@@ -3211,9 +3212,9 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
             **kwargs,
         )
 
-    def count(self) -> int:
+    def count(self, **kwargs: APIKwargsT) -> int:
         """Implements :meth:`~TorrentsAPIMixIn.torrents_count`."""
-        return self._client.torrents_count()
+        return self._client.torrents_count(**kwargs)
 
     def properties(
         self,

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,9 +1,14 @@
+import ast
+import inspect
+import textwrap
 from enum import Enum
 
 import pytest
 
+import qbittorrentapi
 from qbittorrentapi._attrdict import AttrDict
 from qbittorrentapi.definitions import (
+    APINames,
     Dictionary,
     List,
     ListEntry,
@@ -205,6 +210,75 @@ def test_list_actions(client):
         ListEntry({"two": "2"}),
         ListEntry({"three": "3"}),
     ]
+
+
+def _api_method_names():
+    """Every ``<namespace>_<method>`` API method implemented on the mixins."""
+    for namespace in APINames:
+        if not namespace.value:
+            continue
+        for name in dir(qbittorrentapi.Client):
+            if not name.startswith(f"{namespace.value}_"):
+                continue
+            if callable(getattr(qbittorrentapi.Client, name)):
+                yield namespace.value, name
+
+
+_API_METHODS = list(_api_method_names())
+_API_METHOD_IDS = [name for _, name in _API_METHODS]
+
+
+def _accepts_kwargs(func):
+    try:
+        params = inspect.signature(func).parameters.values()
+    except (ValueError, TypeError):  # pragma: no cover - builtins have no signature
+        return True
+    return any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params)
+
+
+def _forwards_kwargs(func):
+    """Whether ``func`` passes its ``**kwargs`` on to a call in its body."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    func_def = tree.body[0]
+    kwarg_name = func_def.args.kwarg.arg
+    return any(
+        isinstance(node, ast.Call)
+        and any(
+            keyword.arg is None
+            and isinstance(keyword.value, ast.Name)
+            and keyword.value.id == kwarg_name
+            for keyword in node.keywords
+        )
+        for node in ast.walk(func_def)
+    )
+
+
+@pytest.mark.parametrize("namespace, name", _API_METHODS, ids=_API_METHOD_IDS)
+def test_api_methods_accept_kwargs(namespace, name):
+    """API methods must accept ``**kwargs`` to pass through to the request."""
+    meth = getattr(qbittorrentapi.Client, name)
+    assert _accepts_kwargs(meth), f"{name}() does not accept **kwargs"
+
+
+@pytest.mark.parametrize("namespace, name", _API_METHODS, ids=_API_METHOD_IDS)
+def test_interface_methods_accept_kwargs(namespace, name):
+    """Interface methods must accept ``**kwargs`` and pass them along."""
+    interface = getattr(qbittorrentapi.Client(host="localhost:1"), namespace)
+    short_name = name[len(namespace) + 1 :]
+
+    if isinstance(inspect.getattr_static(type(interface), short_name, None), property):
+        pytest.skip(f"{namespace}.{short_name} is a property")
+    meth = getattr(interface, short_name, None)
+    if meth is None or not callable(meth):
+        # e.g. torrents_create_tags is exposed via the torrent_tags interface
+        pytest.skip(f"{namespace}.{short_name} is implemented on another interface")
+
+    assert _accepts_kwargs(meth), f"{namespace}.{short_name}() does not accept **kwargs"
+
+    if inspect.ismethod(meth):
+        assert _forwards_kwargs(meth), (
+            f"{namespace}.{short_name}() accepts **kwargs but never forwards them"
+        )
 
 
 def test_list_slice_preserves_client():


### PR DESCRIPTION
A handful of endpoints never plumbed `**kwargs` through to the request, so callers could not pass `requests_args`, `requests_params`, `headers`, `SIMPLE_RESPONSES`, etc.

**Missing `**kwargs` entirely:**
- `app_send_test_email` / `Application.send_test_email`
- `app_get_directory_content` / `Application.get_directory_content`
- `rss_set_feed_refresh_interval` / `RSS.set_feed_refresh_interval`
- `torrents_count` / `Torrents.count`
- `RSS.refresh_item` — the mixin already accepted them, only the interface didn't

**Accepted `**kwargs` but discarded them:**
- `Search.download_torrent` took `**kwargs` and never passed them to `search_download_torrent()`

### Regression tests
Adds two introspection tests over every `<namespace>_<method>` API method and its interface counterpart: each must accept `**kwargs`, and interface methods must actually forward them.

The forwarding check parses the function body with `ast` rather than grepping the source — a `**kwargs` appearing only in a multi-line signature does not count as forwarding. That distinction matters: a naive source grep passes `Search.download_torrent` even though it drops them.

Verified the tests fail on `main` (18 failures, covering all 10 methods and their aliases) and pass here.

### Note
No `CHANGELOG.md` entry — left out of this and the sibling PRs so they don't all conflict on the same line.
