### PR TITLE
feat: add missing torrents/add and torrents/reannounce parameters

### DIFF
--- a/docs/source/spelling_wordlist
+++ b/docs/source/spelling_wordlist
@@ -23,6 +23,7 @@ namespaces
 qBittorrent
 pem
 Reannounce
+reannounce
 ResponseT
 str
 Upsert

--- a/src/qbittorrentapi/torrents.py
+++ b/src/qbittorrentapi/torrents.py
@@ -277,6 +277,8 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         ssl_dh_params: str | None = None,
         is_stopped: bool | None = None,
         forced: bool | None = None,
+        file_priorities: Iterable[int] | None = None,
+        downloader: str | None = None,
         **kwargs: APIKwargsT,
     ) -> str | TorrentsAddedMetadata:
         """
@@ -347,6 +349,11 @@ class TorrentsAPIMixIn(AppAPIMixIn):
         :param is_stopped: Adds torrent in stopped state; alias for ``is_paused`` (added
             in Web API v2.11.0)
         :param forced: add torrent in forced state (added in Web API v2.11.0)
+        :param file_priorities: priority for each file in the torrent; must contain one
+            entry per file and cannot be used when adding multiple torrents or when
+            uploading torrent files (added in Web API v2.11.9)
+        :param downloader: name of the search plugin to download the torrent with; only
+            applies when adding by URL (added in Web API v2.13.1)
         """  # noqa: E501
 
         # convert pre-v2.7 params to post-v2.7 params...or post-v2.7 to pre-v2.7
@@ -404,6 +411,8 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             "ssl_private_key": (None, ssl_private_key),
             "ssl_dh_params": (None, ssl_dh_params),
             "forced": (None, forced),
+            "filePriorities": (None, self._list2string(file_priorities, ",")),
+            "downloader": (None, downloader),
         }
 
         resp = self._post(
@@ -1149,6 +1158,7 @@ class TorrentsAPIMixIn(AppAPIMixIn):
     def torrents_reannounce(
         self,
         torrent_hashes: str | Iterable[str] | None = None,
+        urls: str | Iterable[str] | None = None,
         **kwargs: APIKwargsT,
     ) -> None:
         """
@@ -1158,8 +1168,14 @@ class TorrentsAPIMixIn(AppAPIMixIn):
 
         :param torrent_hashes: single torrent hash or list of torrent hashes.
             Or ``all`` for all torrents.
+        :param urls: single tracker URL or list of tracker URLs to reannounce to;
+            defaults to all trackers for the torrent(s)
+            (added in Web API v2.11.10)
         """
-        data = {"hashes": self._list2string(torrent_hashes, "|")}
+        data = {
+            "hashes": self._list2string(torrent_hashes, "|"),
+            "urls": self._list2string(urls, "|"),
+        }
         self._post(
             _name=APINames.Torrents,
             _method="reannounce",
@@ -2045,9 +2061,17 @@ class TorrentDictionary(ClientCache[TorrentsAPIMixIn], ListEntry):
         """Implements :meth:`~TorrentsAPIMixIn.torrents_recheck`."""
         self._client.torrents_recheck(torrent_hashes=self._torrent_hash, **kwargs)
 
-    def reannounce(self, **kwargs: APIKwargsT) -> None:
+    def reannounce(
+        self,
+        urls: str | Iterable[str] | None = None,
+        **kwargs: APIKwargsT,
+    ) -> None:
         """Implements :meth:`~TorrentsAPIMixIn.torrents_reannounce`."""
-        self._client.torrents_reannounce(torrent_hashes=self._torrent_hash, **kwargs)
+        self._client.torrents_reannounce(
+            torrent_hashes=self._torrent_hash,
+            urls=urls,
+            **kwargs,
+        )
 
     def increase_priority(self, **kwargs: APIKwargsT) -> None:
         """Implements :meth:`~TorrentsAPIMixIn.torrents_increase_priority`."""
@@ -3176,6 +3200,9 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
         ssl_private_key: str | None = None,
         ssl_dh_params: str | None = None,
         is_stopped: bool | None = None,
+        forced: bool | None = None,
+        file_priorities: Iterable[int] | None = None,
+        downloader: str | None = None,
         **kwargs: APIKwargsT,
     ) -> str | TorrentsAddedMetadata:
         """Implements :meth:`~TorrentsAPIMixIn.torrents_add`."""
@@ -3208,6 +3235,9 @@ class Torrents(ClientCache[TorrentsAPIMixIn]):
             ssl_private_key=ssl_private_key,
             ssl_dh_params=ssl_dh_params,
             is_stopped=is_stopped,
+            forced=forced,
+            file_priorities=file_priorities,
+            downloader=downloader,
             **kwargs,
         )
 

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -2,6 +2,7 @@ import errno
 import platform
 import sys
 from time import sleep
+from unittest.mock import MagicMock
 
 import pytest
 import requests
@@ -252,6 +253,25 @@ def test_add_torrent_file_fail(client, monkeypatch):
             with monkeypatch.context() as m:
                 m.setitem(__builtins__, "open", fake_open)
                 client.torrents_add(torrent_files="/etc/hosts")
+
+
+def test_add_file_priorities_and_downloader(client, monkeypatch):
+    """``filePriorities`` (v2.11.9) and ``downloader`` (v2.13.1) on torrents/add."""
+    sent = {}
+
+    def fake_post(*args, **kwargs):
+        sent.update(kwargs["data"])
+        return MagicMock(text="Ok.")
+
+    monkeypatch.setattr(client, "_post", fake_post)
+    client.torrents_add(
+        urls=TORRENT1_URL,
+        file_priorities=[0, 1, 7],
+        downloader="a-search-plugin",
+    )
+
+    assert sent["filePriorities"] == (None, "0,1,7")
+    assert sent["downloader"] == (None, "a-search-plugin")
 
 
 @pytest.mark.parametrize("keep_root_folder", [True, False, None])
@@ -1001,6 +1021,23 @@ def test_reannounce(client, orig_torrent, reannounce_func):
 def test_reannounce_not_implemented(client, reannounce_func):
     with pytest.raises(NotImplementedError):
         client.func(reannounce_func)()
+
+
+def test_reannounce_urls(client, monkeypatch):
+    """``urls`` limits the reannounce to specific trackers (Web API v2.11.10)."""
+    sent = {}
+
+    def fake_post(*args, **kwargs):
+        sent.update(kwargs["data"])
+
+    monkeypatch.setattr(client, "_post", fake_post)
+    client.torrents_reannounce(
+        torrent_hashes="hash1",
+        urls=["http://one.example/announce", "http://two.example/announce"],
+    )
+
+    assert sent["hashes"] == "hash1"
+    assert sent["urls"] == ("http://one.example/announce|http://two.example/announce")
 
 
 # priority doesn't seem to work on v4.1.0


### PR DESCRIPTION
Three parameters qBittorrent has accepted since v5.2.0 were not exposed:

| Parameter | Endpoint | Since | Purpose |
|---|---|---|---|
| `file_priorities` | `torrents/add` | Web API v2.11.9 | per-file download priority |
| `downloader` | `torrents/add` | Web API v2.13.1 | download via a named search plugin |
| `urls` | `torrents/reannounce` | Web API v2.11.10 | reannounce to specific trackers only |

qBittorrent rejects `filePriorities` when adding multiple torrents or uploading torrent files; that constraint is documented on the parameter rather than enforced client-side, consistent with how the rest of the client treats server-side validation.

### Also
`Torrents.add()` was missing the `forced` parameter that `torrents_add()` has supported since Web API v2.11.0 — same class of gap, so it is forwarded now too.

### Note
No `CHANGELOG.md` entry — left out of this and the sibling PRs so they don't all conflict on the same line.
