### PR TITLE
docs: correct version annotations

### DIFF
--- a/src/qbittorrentapi/rss.py
+++ b/src/qbittorrentapi/rss.py
@@ -117,7 +117,7 @@ class RSSAPIMixIn(AppAPIMixIn):
         """
         Update the refresh interval for the RSS feed.
 
-        The method was introduced with qBittorrent v5.2.0 (Web API v2.11.5).
+        This method was introduced with qBittorrent v5.2.0 (Web API v2.11.5).
 
         :param item_path: Name and/or path for feed
         :param refresh_interval: refresh interval in minutes

--- a/src/qbittorrentapi/torrents.py
+++ b/src/qbittorrentapi/torrents.py
@@ -1312,8 +1312,9 @@ class TorrentsAPIMixIn(AppAPIMixIn):
             (added in Web API v2.9.2)
         :param share_limit_action: action once share limit is reached.
             Options: Default, Stop, Remove, RemoveWithContent, EnableSuperSeeding
+            (added in Web API v2.10.4)
         :param share_limits_mode: mode once share limit is reached.
-            Options: Default, MatchAny, MatchAll
+            Options: Default, MatchAny, MatchAll (added in Web API v2.16.0)
         """
         data = {
             "hashes": self._list2string(torrent_hashes, "|"),

--- a/src/qbittorrentapi/transfer.py
+++ b/src/qbittorrentapi/transfer.py
@@ -178,7 +178,7 @@ class TransferAPIMixIn(AppAPIMixIn):
             _name=APINames.Transfer,
             _method="banPeers",
             data=data,
-            version_introduced="2.3",
+            version_introduced="2.3.0",
             **kwargs,
         )
 


### PR DESCRIPTION
Three documentation-only corrections found while auditing version annotations:

- **`transfer_ban_peers()`** passed `version_introduced="2.3"` while its docstring says v2.3.0. `packaging` treats these as equal so behavior is unchanged, but the two now agree.
- **`torrents_set_share_limits()`** documents `share_limit_action` and `share_limits_mode` without the `(added in Web API vX.Y.Z)` note every other versioned parameter carries. They arrived in v2.10.4 and v2.16.0 respectively.
- **`rss_set_feed_refresh_interval()`** started its version note with "The method was introduced" rather than "This method was introduced" used everywhere else.

No behavior change.

### Note
No `CHANGELOG.md` entry — left out of this and the sibling PRs so they don't all conflict on the same line.
