### PR TITLE
bump to v2026.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 Change Log
 ==========
+### v2026.8.1 (16 aug 2026)
+- Add support for ``app/rotateAPIKey`` and ``app/deleteAPIKey`` (#658)
+- Add support for ``torrents/SSLParameters`` and ``torrents/setSSLParameters`` (#658)
+- Add support for ``torrents/fetchMetadata``, ``torrents/parseMetadata``, and ``torrents/saveMetadata`` (#658)
+- Add support for ``torrents/pieceAvailability`` (#658)
+- Add support for ``clientdata/load`` and ``clientdata/store`` (#658)
+- Add ``file_priorities`` and ``downloader`` for ``torrents/add`` (#656)
+- Add ``urls`` for ``torrents/reannounce`` (#656)
+- Fix ``is_skip_checking`` for ``torrents/add`` being ignored by qBittorrent v5.3.0 (#654)
+- Fix missing ``**kwargs`` for several endpoints (#655)
+
 ### v2026.8.0 (01 aug 2026)
 - Fix slicing returned objects (#644)
 


### PR DESCRIPTION
Changelog for the five PRs merged since v2026.8.0, ahead of cutting the release.

Covers #654, #655, #656, and #658. Version is derived by `setuptools_scm` from the git tag, so `CHANGELOG.md` is the only file that needs updating — matching the `bump to v2026.8.0` commit (1c9f4f7).

Deliberately **not** included:
- **#659** (Web API v2.16.0 endpoints) — still open, to be released separately.
- **#657** (version annotations) — docs-only with no behavior change; past releases don't list pure doc fixes.
- **#660** (retire codeql) — CI infrastructure, not user-facing.

The `is_skip_checking` fix from #654 is included and references qBittorrent v5.3.0: it is a forward-compatibility fix that is worth shipping now, independent of the v2.16.0 endpoint support still pending in #659.

Verified `python -m build` + `twine check` pass, since `CHANGELOG.md` is part of the PyPI long description.