### PR TITLE
refactor(tests): parametrize test_add_delete and fix dead assertions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 from contextlib import contextmanager, suppress
 from functools import partial
 from os import environ, path
+from pathlib import Path
 from sys import path as sys_path
 from time import sleep
 from unittest.mock import MagicMock
@@ -46,13 +47,11 @@ assert BASE_PATH.split("/")[-1] == "qbittorrent-api"
 ORIG_TORRENT_FILENAME = "ubuntu-22.04.1-desktop-amd64.iso.torrent"
 ORIG_TORRENT_URL = f"https://github.com/rmartin16/qbittorrent-api/raw/main/tests/_resources/{ORIG_TORRENT_FILENAME}"
 ORIG_TORRENT_HASH = "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0"
-ORIG_TORRENT = None
 
 TORRENT1_FILENAME = "kubuntu-22.04.4-desktop-amd64.iso.torrent"
 TORRENT1_URL = f"https://github.com/rmartin16/qbittorrent-api/raw/main/tests/_resources/{TORRENT1_FILENAME}"
 TORRENT1_HASH = "27a92b32757893ac9eb898e32c952636a3cc7b24"
-TORRENT1_FILE_HANDLE = open(path.join(RESOURCES_PATH, TORRENT1_FILENAME), mode="rb")  # noqa: SIM115
-TORRENT1_FILE = TORRENT1_FILE_HANDLE.read()
+TORRENT1_FILE = Path(RESOURCES_PATH, TORRENT1_FILENAME).read_bytes()
 
 TORRENT2_FILENAME = "xubuntu-22.04.4-desktop-amd64.iso.torrent"
 TORRENT2_URL = f"https://github.com/rmartin16/qbittorrent-api/raw/main/tests/_resources/{TORRENT2_FILENAME}"
@@ -60,8 +59,7 @@ TORRENT2_HASH = "c7d77fc3ecb68344b59ada11a0508dd6d08f2dfd"
 
 ROOT_FOLDER_TORRENT_FILENAME = "root_folder.torrent"
 ROOT_FOLDER_TORRENT_HASH = "a14553bd936a6d496402082454a70ea7a9521adc"
-ROOT_FOLDER_TORRENT_FILE_HANDLE = open(path.join(RESOURCES_PATH, ROOT_FOLDER_TORRENT_FILENAME), mode="rb")  # noqa: E501, SIM115
-ROOT_FOLDER_TORRENT_FILE = ROOT_FOLDER_TORRENT_FILE_HANDLE.read()
+ROOT_FOLDER_TORRENT_FILE = Path(RESOURCES_PATH, ROOT_FOLDER_TORRENT_FILENAME).read_bytes()  # noqa: E501
 # fmt: on
 
 
@@ -146,15 +144,19 @@ def client_mock(client):
         client._post_cast = client._post_cast
 
 
+@pytest.fixture(scope="session")
+def _orig_torrent(client):
+    """Torrent that remains in qBittorrent for the entirety of the session."""
+    torrent = get_torrent(client, torrent_hash=ORIG_TORRENT_HASH)
+    torrent.func = staticmethod(partial(get_func, torrent))
+    return torrent
+
+
 @pytest.fixture
-def orig_torrent(client):
-    """Torrent to remain in qBittorrent for entirety of session."""
-    global ORIG_TORRENT
-    if ORIG_TORRENT is None:
-        ORIG_TORRENT = get_torrent(client, torrent_hash=ORIG_TORRENT_HASH)
-        ORIG_TORRENT.func = staticmethod(partial(get_func, ORIG_TORRENT))
-    ORIG_TORRENT.sync_local()  # ensure torrent is up-to-date
-    return ORIG_TORRENT
+def orig_torrent(_orig_torrent):
+    """Session-long torrent, re-synced so each test sees current values."""
+    _orig_torrent.sync_local()
+    return _orig_torrent
 
 
 def wait_until_torrent_is_loaded(torrent):
@@ -260,9 +262,6 @@ def api_version(client):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    for fh in [TORRENT1_FILE_HANDLE, ROOT_FOLDER_TORRENT_FILE_HANDLE]:
-        with suppress(Exception):
-            fh.close()
     if environ.get("CI") != "true":
         client = Client()
         with suppress(Exception):

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -297,7 +297,7 @@ def test_set_comment(orig_torrent, set_comment_func):
 @pytest.mark.skipif_after_api_version("2.12.1")
 def test_set_comment_not_implemented(orig_torrent, set_comment_func):
     with pytest.raises(NotImplementedError):
-        orig_torrent.func(set_comment_func)(ratio_limit=5, seeding_time_limit=100)
+        orig_torrent.func(set_comment_func)(comment="new comment")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -1,6 +1,7 @@
 import errno
 import platform
 import sys
+from contextlib import ExitStack
 from time import sleep
 from unittest.mock import MagicMock
 
@@ -59,6 +60,36 @@ def enable_queueing(client):
         client.app.set_preferences(dict(queueing_enabled=True))
 
 
+# Each endpoint is reachable as ``client.torrents_x()`` and ``client.torrents.x()``,
+# both with a camelCase alias. These lists are shared by the tests for the endpoint
+# and its "raises NotImplementedError on older API versions" counterpart, so the two
+# can never drift apart.
+ADD_WEBSEEDS_FUNCS = [
+    "torrents_add_webseeds",
+    "torrents_addWebSeeds",
+    "torrents.add_webseeds",
+    "torrents.addWebSeeds",
+]
+EDIT_WEBSEED_FUNCS = [
+    "torrents_edit_webseed",
+    "torrents_editWebSeed",
+    "torrents.edit_webseed",
+    "torrents.editWebSeed",
+]
+REMOVE_WEBSEEDS_FUNCS = [
+    "torrents_remove_webseeds",
+    "torrents_removeWebSeeds",
+    "torrents.remove_webseeds",
+    "torrents.removeWebSeeds",
+]
+
+# webseed endpoints accept either a single URL or a list of them
+WEBSEED_URLS = [
+    "http://example/webseedone",
+    ["http://example/webseedone", "http://example/webseedtwo"],
+]
+
+
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="removeprefix not in 3.8")
 def test_methods(client):
     all_dotted_methods = {
@@ -71,31 +102,91 @@ def test_methods(client):
         assert meth.removeprefix("torrents_") in all_dotted_methods
 
 
+def download_torrent_file(url, dest=None):
+    """
+    Download a torrent file, retrying transient failures.
+
+    Returns the raw bytes when ``dest`` is None; otherwise writes the file to
+    ``dest`` and returns that path.
+    """
+    max_attempts = 3
+    for attempt in range(max_attempts):
+        try:
+            with requests.get(url, timeout=30) as r:
+                r.raise_for_status()
+                if dest is None:
+                    return r.content
+                with open(dest, "wb") as f:
+                    for chunk in r.iter_content(chunk_size=1024):
+                        f.write(chunk)
+                return dest
+        except Exception:
+            if attempt >= max_attempts - 1:
+                raise Exception(f"Download failed: {url}") from None
+
+
+def downloaded_torrent_paths(tmp_path):
+    """Both test torrents downloaded to ``tmp_path``."""
+    return [
+        download_torrent_file(TORRENT1_URL, mkpath(tmp_path, TORRENT1_FILENAME)),
+        download_torrent_file(TORRENT2_URL, mkpath(tmp_path, TORRENT2_FILENAME)),
+    ]
+
+
+def build_add_kwargs(source, single, tmp_path, stack):
+    """
+    Build the ``torrents_add()`` kwargs supplying the test torrents via ``source``.
+
+    ``stack`` is an :class:`~contextlib.ExitStack` used to close any opened files.
+    """
+    if source == "urls":
+        urls = [TORRENT1_URL, TORRENT2_URL]
+        return dict(urls=urls[0] if single else tuple(urls))
+
+    if source == "paths":
+        paths = downloaded_torrent_paths(tmp_path)
+        return dict(torrent_files=paths[0] if single else tuple(paths))
+
+    if source == "path_dict":
+        paths = downloaded_torrent_paths(tmp_path)
+        pairs = list(zip([TORRENT1_FILENAME, TORRENT2_FILENAME], paths))
+        return dict(torrent_files=dict(pairs[:1] if single else pairs))
+
+    if source == "filehandles":
+        handles = [
+            # the ExitStack closes these; ruff doesn't recognize enter_context()
+            stack.enter_context(open(torrent_path, "rb"))  # noqa: SIM115
+            for torrent_path in downloaded_torrent_paths(tmp_path)
+        ]
+        return dict(torrent_files=handles[0] if single else tuple(handles))
+
+    if source == "bytes":
+        blobs = [
+            download_torrent_file(TORRENT1_URL),
+            download_torrent_file(TORRENT2_URL),
+        ]
+        return dict(torrent_files=blobs[0] if single else tuple(blobs))
+
+    raise ValueError(f"unknown torrent source: {source}")
+
+
 # something was wrong with torrents_add on v2.0.0 (the initial version)
 @pytest.mark.skipif_before_api_version("2.0.1")
 @pytest.mark.parametrize(
     "add_func, delete_func",
     [("torrents_add", "torrents_delete"), ("torrents.add", "torrents.delete")],
 )
-def test_add_delete(client, api_version, add_func, delete_func, tmp_path):
-    def download_file(url, filename=None, return_bytes=False):
-        max_attempts = 3
-        for attempt in range(max_attempts):
-            try:
-                with requests.get(url, timeout=30) as r:
-                    r.raise_for_status()
-                    if return_bytes:
-                        return r.content
-                    with open(mkpath(tmp_path, filename), "wb") as f:
-                        for chunk in r.iter_content(chunk_size=1024):
-                            f.write(chunk)
-            except Exception if attempt < (max_attempts - 1) else ZeroDivisionError:
-                pass  # throw away errors until we hit the retry limit
-            else:
-                return
-        raise Exception(f"Download failed: {url}")
+@pytest.mark.parametrize(
+    "source", ["urls", "paths", "path_dict", "filehandles", "bytes"]
+)
+@pytest.mark.parametrize("single", [True, False], ids=["single", "multiple"])
+def test_add_delete(
+    client, api_version, add_func, delete_func, source, single, tmp_path
+):
+    expected_hashes = [TORRENT1_HASH] if single else [TORRENT1_HASH, TORRENT2_HASH]
 
-    def delete():
+    def delete_test_torrents():
+        """Delete through ``delete_func`` so both namespaces are exercised."""
         client.func(delete_func)(delete_files=True, torrent_hashes=TORRENT1_HASH)
         client.func(delete_func)(delete_files=True, torrent_hashes=TORRENT2_HASH)
         check(
@@ -105,141 +196,36 @@ def test_add_delete(client, api_version, add_func, delete_func, tmp_path):
             negate=True,
         )
 
-    def check_torrents_added(f):
-        def inner(**kwargs):
-            try:
-                f(**kwargs)
+    @retry()
+    def add_and_delete():
+        # each attempt must start from a clean slate, so the torrents are always
+        # removed again...whether the add succeeded, failed, or half-succeeded
+        try:
+            # Arrange
+            with ExitStack() as stack:
+                add_kwargs = build_add_kwargs(source, single, tmp_path, stack)
+
+                # Act
+                resp = client.func(add_func)(**add_kwargs)
+
+            # Assert
+            if source != "urls":
+                # adding by URL returns nothing worth asserting on
+                if v(api_version) >= v("2.14.0"):
+                    assert isinstance(resp, TorrentsAddedMetadata)
+                else:
+                    assert resp == "Ok."
+
+            for torrent_hash in expected_hashes:
                 check(
                     lambda: [t.hash for t in client.torrents_info()],
-                    TORRENT1_HASH,
+                    torrent_hash,
                     reverse=True,
                 )
-                if kwargs.get("single", False) is False:
-                    check(
-                        lambda: [t.hash for t in client.torrents_info()],
-                        TORRENT2_HASH,
-                        reverse=True,
-                    )
-            finally:
-                delete()
+        finally:
+            delete_test_torrents()
 
-        return inner
-
-    @retry()
-    @check_torrents_added
-    def add_by_filename(single):
-        download_file(url=TORRENT1_URL, filename=TORRENT1_FILENAME)
-        download_file(url=TORRENT2_URL, filename=TORRENT2_FILENAME)
-        files = (
-            mkpath(tmp_path, TORRENT1_FILENAME),
-            mkpath(tmp_path, TORRENT2_FILENAME),
-        )
-
-        if single:
-            resp = client.func(add_func)(torrent_files=files[0])
-            if v(api_version) >= v("2.14.0"):
-                isinstance(resp, TorrentsAddedMetadata)
-            else:
-                assert resp == "Ok."
-        else:
-            resp = client.func(add_func)(torrent_files=files)
-            if v(api_version) >= v("2.14.0"):
-                isinstance(resp, TorrentsAddedMetadata)
-            else:
-                assert resp == "Ok."
-
-    @retry()
-    @check_torrents_added
-    def add_by_filename_dict(single):
-        download_file(url=TORRENT1_URL, filename=TORRENT1_FILENAME)
-        download_file(url=TORRENT2_URL, filename=TORRENT2_FILENAME)
-
-        if single:
-            resp = client.func(add_func)(
-                torrent_files={TORRENT1_FILENAME: mkpath(tmp_path, TORRENT1_FILENAME)}
-            )
-            if v(api_version) >= v("2.14.0"):
-                isinstance(resp, TorrentsAddedMetadata)
-            else:
-                assert resp == "Ok."
-        else:
-            files = {
-                TORRENT1_FILENAME: mkpath(tmp_path, TORRENT1_FILENAME),
-                TORRENT2_FILENAME: mkpath(tmp_path, TORRENT2_FILENAME),
-            }
-            resp = client.func(add_func)(torrent_files=files)
-            if v(api_version) >= v("2.14.0"):
-                isinstance(resp, TorrentsAddedMetadata)
-            else:
-                assert resp == "Ok."
-
-    @retry()
-    @check_torrents_added
-    def add_by_filehandles(single):
-        download_file(url=TORRENT1_URL, filename=TORRENT1_FILENAME)
-        download_file(url=TORRENT2_URL, filename=TORRENT2_FILENAME)
-        files = (
-            open(mkpath(tmp_path, TORRENT1_FILENAME), "rb"),  # noqa: SIM115
-            open(mkpath(tmp_path, TORRENT2_FILENAME), "rb"),  # noqa: SIM115
-        )
-
-        if single:
-            resp = client.func(add_func)(torrent_files=files[0])
-            if v(api_version) >= v("2.14.0"):
-                isinstance(resp, TorrentsAddedMetadata)
-            else:
-                assert resp == "Ok."
-        else:
-            resp = client.func(add_func)(torrent_files=files)
-            if v(api_version) >= v("2.14.0"):
-                isinstance(resp, TorrentsAddedMetadata)
-            else:
-                assert resp == "Ok."
-
-        for file in files:
-            file.close()
-
-    @retry()
-    @check_torrents_added
-    def add_by_bytes(single):
-        files = (
-            download_file(TORRENT1_URL, return_bytes=True),
-            download_file(TORRENT2_URL, return_bytes=True),
-        )
-
-        if single:
-            resp = client.func(add_func)(torrent_files=files[0])
-            if v(api_version) >= v("2.14.0"):
-                isinstance(resp, TorrentsAddedMetadata)
-            else:
-                assert resp == "Ok."
-        else:
-            resp = client.func(add_func)(torrent_files=files)
-            if v(api_version) >= v("2.14.0"):
-                isinstance(resp, TorrentsAddedMetadata)
-            else:
-                assert resp == "Ok."
-
-    @retry()
-    @check_torrents_added
-    def add_by_url(single):
-        urls = (TORRENT1_URL, TORRENT2_URL)
-
-        if single:
-            client.func(add_func)(urls=urls[0])
-        else:
-            client.func(add_func)(urls=urls)
-
-    add_by_filename(single=False)
-    add_by_filename(single=True)
-    add_by_filename_dict(single=False)
-    add_by_filename_dict(single=True)
-    add_by_url(single=False)
-    add_by_url(single=True)
-    add_by_filehandles(single=False)
-    add_by_filehandles(single=True)
-    add_by_bytes(single=False)
-    add_by_bytes(single=True)
+    add_and_delete()
 
 
 def test_add_torrent_file_fail(client, monkeypatch):
@@ -445,22 +431,8 @@ def test_webseeds_slice(client, orig_torrent, webseeds_func):
 
 
 @pytest.mark.skipif_before_api_version("2.11.3")
-@pytest.mark.parametrize(
-    "add_webseeds_func",
-    [
-        "torrents_add_webseeds",
-        "torrents_addWebSeeds",
-        "torrents.add_webseeds",
-        "torrents.addWebSeeds",
-    ],
-)
-@pytest.mark.parametrize(
-    "webseeds",
-    [
-        "http://example/webseedone",
-        ["http://example/webseedone", "http://example/webseedtwo"],
-    ],
-)
+@pytest.mark.parametrize("add_webseeds_func", ADD_WEBSEEDS_FUNCS)
+@pytest.mark.parametrize("webseeds", WEBSEED_URLS)
 def test_add_webseeds(client, new_torrent, add_webseeds_func, webseeds):
     assert new_torrent.webseeds == WebSeedsList([])
 
@@ -478,30 +450,14 @@ def test_add_webseeds(client, new_torrent, add_webseeds_func, webseeds):
 
 
 @pytest.mark.skipif_after_api_version("2.11.3")
-@pytest.mark.parametrize(
-    "add_webseeds_func",
-    [
-        "torrents_add_webseeds",
-        "torrents_addWebSeeds",
-        "torrents.add_webseeds",
-        "torrents.addWebSeeds",
-    ],
-)
+@pytest.mark.parametrize("add_webseeds_func", ADD_WEBSEEDS_FUNCS)
 def test_add_webseeds_not_implemented(client, orig_torrent, add_webseeds_func):
     with pytest.raises(NotImplementedError):
         client.func(add_webseeds_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.11.3")
-@pytest.mark.parametrize(
-    "edit_webseed_func",
-    [
-        "torrents_edit_webseed",
-        "torrents_editWebSeed",
-        "torrents.edit_webseed",
-        "torrents.editWebSeed",
-    ],
-)
+@pytest.mark.parametrize("edit_webseed_func", EDIT_WEBSEED_FUNCS)
 def test_edit_webseeds(client, new_torrent, edit_webseed_func):
     assert new_torrent.webseeds == WebSeedsList([])
     orig_url, new_url = "http://example/asdf", "http://example/qwer"
@@ -533,37 +489,15 @@ def test_edit_webseeds(client, new_torrent, edit_webseed_func):
 
 
 @pytest.mark.skipif_after_api_version("2.11.3")
-@pytest.mark.parametrize(
-    "edit_webseed_func",
-    [
-        "torrents_edit_webseed",
-        "torrents_editWebSeed",
-        "torrents.edit_webseed",
-        "torrents.editWebSeed",
-    ],
-)
+@pytest.mark.parametrize("edit_webseed_func", EDIT_WEBSEED_FUNCS)
 def test_edit_webseed_not_implemented(client, orig_torrent, edit_webseed_func):
     with pytest.raises(NotImplementedError):
         client.func(edit_webseed_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.11.3")
-@pytest.mark.parametrize(
-    "remove_webseeds_func",
-    [
-        "torrents_remove_webseeds",
-        "torrents_removeWebSeeds",
-        "torrents.remove_webseeds",
-        "torrents.removeWebSeeds",
-    ],
-)
-@pytest.mark.parametrize(
-    "webseeds",
-    [
-        "http://example/webseedone",
-        ["http://example/webseedone", "http://example/webseedtwo"],
-    ],
-)
+@pytest.mark.parametrize("remove_webseeds_func", REMOVE_WEBSEEDS_FUNCS)
+@pytest.mark.parametrize("webseeds", WEBSEED_URLS)
 def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
     assert new_torrent.webseeds == WebSeedsList([])
     all_webseeds = [
@@ -596,15 +530,7 @@ def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
 
 
 @pytest.mark.skipif_after_api_version("2.11.3")
-@pytest.mark.parametrize(
-    "remove_webseeds_func",
-    [
-        "torrents_remove_webseeds",
-        "torrents_removeWebSeeds",
-        "torrents.remove_webseeds",
-        "torrents.removeWebSeeds",
-    ],
-)
+@pytest.mark.parametrize("remove_webseeds_func", REMOVE_WEBSEEDS_FUNCS)
 def test_remove_webseeds_not_implemented(client, orig_torrent, remove_webseeds_func):
     with pytest.raises(NotImplementedError):
         client.func(remove_webseeds_func)()


### PR DESCRIPTION
First of several layered changes restructuring the test suite. This one is
self-contained cleanup and bug fixes; the structural work builds on top of it.

## `test_add_delete`

At 165 lines it was the suite's one structural outlier — the next-largest real
test is 78. It held five nested closures, a hand-rolled `check_torrents_added`
decorator, and ten manual invocations at the bottom.

It is now parametrized into 20 independent cases over (source, single,
namespace), each following arrange-act-assert. A failure now names the exact
torrent source, mode, and namespace instead of pointing somewhere into 165
lines.

Retry and cleanup semantics are preserved exactly: each attempt still removes
both torrents in a `finally` block so a retry starts from a clean slate, and
deletion still goes through `delete_func` so both namespaces stay covered.

## Eight assertions that never asserted

Inside that test:

```python
isinstance(resp, TorrentsAddedMetadata)
```

with no `assert`, so the call was a discarded expression — eight times. They now
assert, and pass against Web API v2.16, so they were masking correct behavior
rather than a defect.

## Also here

- `test_set_comment_not_implemented` passed `ratio_limit`/`seeding_time_limit`
  to a *comment* setter, copy-pasted from `set_share_limits`.
- conftest held two torrent files open for the whole session and closed them in
  `pytest_sessionfinish` — the source of the `ResourceWarning`s. Now `read_bytes()`.
- The `ORIG_TORRENT` module global and its `global` statement are replaced by a
  session-scoped fixture.
- The 4-element webseed method-name lists were duplicated between each endpoint's
  test and its not-implemented twin; now shared constants so they cannot drift.

## Verification

Against qBittorrent `v5.3.0alpha1` (Web API 2.16):

| Scope | Result |
|---|---|
| `test_add_delete` (20 cases) | 20 passed, 8.7s |
| webseed tests | 24 passed, 12 skipped |
| `test_torrent.py` (heaviest `orig_torrent` consumer) | 93 passed, 19 skipped |

Note for reviewers: this branch does not change the pre-existing failures seen
locally against this master build (9 distinct state-mutation tests in
`test_torrents.py`, plus RSS fixture errors from a network-fetched feed). Those
are present before these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)