### PR TITLE
refactor(tests): derive an endpoint catalog and test the API surface from it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ filterwarnings = [
 markers = [
     "skipif_before_api_version(api_version): skips test for current api version",
     "skipif_after_api_version(api_version): skips test for current api version",
+    "offline: test inspects the library only and never talks to qBittorrent",
 ]
 norecursedirs = "dist build .tox scripts"
 testpaths = ["tests"]

--- a/tests/api_surface.json
+++ b/tests/api_surface.json
@@ -1,0 +1,1212 @@
+[
+  {
+    "api_method": "buildInfo",
+    "client_aliases": [
+      "app_buildInfo"
+    ],
+    "namespace": "app",
+    "primary": "app_build_info",
+    "version_introduced": "2.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "cookies",
+    "client_aliases": [],
+    "namespace": "app",
+    "primary": "app_cookies",
+    "version_introduced": "2.11.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "defaultSavePath",
+    "client_aliases": [
+      "app_defaultSavePath"
+    ],
+    "namespace": "app",
+    "primary": "app_default_save_path",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "deleteAPIKey",
+    "client_aliases": [
+      "app_deleteAPIKey"
+    ],
+    "namespace": "app",
+    "primary": "app_delete_api_key",
+    "version_introduced": "2.14.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "getDirectoryContent",
+    "client_aliases": [
+      "app_getDirectoryContent"
+    ],
+    "namespace": "app",
+    "primary": "app_get_directory_content",
+    "version_introduced": "2.11",
+    "version_removed": ""
+  },
+  {
+    "api_method": "getFreeSpaceAtPath",
+    "client_aliases": [
+      "app_getFreeSpaceAtPath"
+    ],
+    "namespace": "app",
+    "primary": "app_get_free_space_at_path",
+    "version_introduced": "2.15.2",
+    "version_removed": ""
+  },
+  {
+    "api_method": "networkInterfaceAddressList",
+    "client_aliases": [
+      "app_networkInterfaceAddressList"
+    ],
+    "namespace": "app",
+    "primary": "app_network_interface_address_list",
+    "version_introduced": "2.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "networkInterfaceList",
+    "client_aliases": [
+      "app_networkInterfaceList"
+    ],
+    "namespace": "app",
+    "primary": "app_network_interface_list",
+    "version_introduced": "2.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "preferences",
+    "client_aliases": [],
+    "namespace": "app",
+    "primary": "app_preferences",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "processInfo",
+    "client_aliases": [
+      "app_processInfo"
+    ],
+    "namespace": "app",
+    "primary": "app_process_info",
+    "version_introduced": "2.15.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "rotateAPIKey",
+    "client_aliases": [
+      "app_rotateAPIKey"
+    ],
+    "namespace": "app",
+    "primary": "app_rotate_api_key",
+    "version_introduced": "2.14.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "sendTestEmail",
+    "client_aliases": [
+      "app_sendTestEmail"
+    ],
+    "namespace": "app",
+    "primary": "app_send_test_email",
+    "version_introduced": "2.10.4",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setCookies",
+    "client_aliases": [
+      "app_setCookies"
+    ],
+    "namespace": "app",
+    "primary": "app_set_cookies",
+    "version_introduced": "2.11.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setPreferences",
+    "client_aliases": [
+      "app_setPreferences"
+    ],
+    "namespace": "app",
+    "primary": "app_set_preferences",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "shutdown",
+    "client_aliases": [],
+    "namespace": "app",
+    "primary": "app_shutdown",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "version",
+    "client_aliases": [],
+    "namespace": "app",
+    "primary": "app_version",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "webapiVersion",
+    "client_aliases": [
+      "app_webapiVersion"
+    ],
+    "namespace": "app",
+    "primary": "app_web_api_version",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "login",
+    "client_aliases": [],
+    "namespace": "auth",
+    "primary": "auth_log_in",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "logout",
+    "client_aliases": [],
+    "namespace": "auth",
+    "primary": "auth_log_out",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "load",
+    "client_aliases": [],
+    "namespace": "clientdata",
+    "primary": "clientdata_load",
+    "version_introduced": "2.13.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "store",
+    "client_aliases": [],
+    "namespace": "clientdata",
+    "primary": "clientdata_store",
+    "version_introduced": "2.13.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "main",
+    "client_aliases": [],
+    "namespace": "log",
+    "primary": "log_main",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "peers",
+    "client_aliases": [],
+    "namespace": "log",
+    "primary": "log_peers",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "addFeed",
+    "client_aliases": [
+      "rss_addFeed"
+    ],
+    "namespace": "rss",
+    "primary": "rss_add_feed",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "addFolder",
+    "client_aliases": [
+      "rss_addFolder"
+    ],
+    "namespace": "rss",
+    "primary": "rss_add_folder",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "cloneRule",
+    "client_aliases": [
+      "rss_cloneRule"
+    ],
+    "namespace": "rss",
+    "primary": "rss_clone_rule",
+    "version_introduced": "2.15.4",
+    "version_removed": ""
+  },
+  {
+    "api_method": "items",
+    "client_aliases": [],
+    "namespace": "rss",
+    "primary": "rss_items",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "markAsRead",
+    "client_aliases": [
+      "rss_markAsRead"
+    ],
+    "namespace": "rss",
+    "primary": "rss_mark_as_read",
+    "version_introduced": "2.5.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "matchingArticles",
+    "client_aliases": [
+      "rss_matchingArticles"
+    ],
+    "namespace": "rss",
+    "primary": "rss_matching_articles",
+    "version_introduced": "2.5.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "moveItem",
+    "client_aliases": [
+      "rss_moveItem"
+    ],
+    "namespace": "rss",
+    "primary": "rss_move_item",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "refreshItem",
+    "client_aliases": [
+      "rss_refreshItem"
+    ],
+    "namespace": "rss",
+    "primary": "rss_refresh_item",
+    "version_introduced": "2.2",
+    "version_removed": ""
+  },
+  {
+    "api_method": "removeItem",
+    "client_aliases": [
+      "rss_removeItem"
+    ],
+    "namespace": "rss",
+    "primary": "rss_remove_item",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "removeRule",
+    "client_aliases": [
+      "rss_removeRule"
+    ],
+    "namespace": "rss",
+    "primary": "rss_remove_rule",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "renameRule",
+    "client_aliases": [
+      "rss_renameRule"
+    ],
+    "namespace": "rss",
+    "primary": "rss_rename_rule",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "rules",
+    "client_aliases": [],
+    "namespace": "rss",
+    "primary": "rss_rules",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setFeedRefreshInterval",
+    "client_aliases": [
+      "rss_setFeedRefreshInterval"
+    ],
+    "namespace": "rss",
+    "primary": "rss_set_feed_refresh_interval",
+    "version_introduced": "2.11.5",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setFeedURL",
+    "client_aliases": [
+      "rss_setFeedURL"
+    ],
+    "namespace": "rss",
+    "primary": "rss_set_feed_url",
+    "version_introduced": "2.9.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setRule",
+    "client_aliases": [
+      "rss_setRule"
+    ],
+    "namespace": "rss",
+    "primary": "rss_set_rule",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "categories",
+    "client_aliases": [],
+    "namespace": "search",
+    "primary": "search_categories",
+    "version_introduced": "2.1.1",
+    "version_removed": "2.6"
+  },
+  {
+    "api_method": "delete",
+    "client_aliases": [],
+    "namespace": "search",
+    "primary": "search_delete",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "downloadTorrent",
+    "client_aliases": [
+      "search_downloadTorrent"
+    ],
+    "namespace": "search",
+    "primary": "search_download_torrent",
+    "version_introduced": "2.11",
+    "version_removed": ""
+  },
+  {
+    "api_method": "enablePlugin",
+    "client_aliases": [
+      "search_enablePlugin"
+    ],
+    "namespace": "search",
+    "primary": "search_enable_plugin",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "installPlugin",
+    "client_aliases": [
+      "search_installPlugin"
+    ],
+    "namespace": "search",
+    "primary": "search_install_plugin",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "plugins",
+    "client_aliases": [],
+    "namespace": "search",
+    "primary": "search_plugins",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "results",
+    "client_aliases": [],
+    "namespace": "search",
+    "primary": "search_results",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "start",
+    "client_aliases": [],
+    "namespace": "search",
+    "primary": "search_start",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "status",
+    "client_aliases": [],
+    "namespace": "search",
+    "primary": "search_status",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "stop",
+    "client_aliases": [],
+    "namespace": "search",
+    "primary": "search_stop",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "uninstallPlugin",
+    "client_aliases": [
+      "search_uninstallPlugin"
+    ],
+    "namespace": "search",
+    "primary": "search_uninstall_plugin",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "updatePlugins",
+    "client_aliases": [
+      "search_updatePlugins"
+    ],
+    "namespace": "search",
+    "primary": "search_update_plugins",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "maindata",
+    "client_aliases": [],
+    "namespace": "sync",
+    "primary": "sync_maindata",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "torrentPeers",
+    "client_aliases": [
+      "sync_torrentPeers"
+    ],
+    "namespace": "sync",
+    "primary": "sync_torrent_peers",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "addTask",
+    "client_aliases": [
+      "torrentcreator_addTask"
+    ],
+    "namespace": "torrentcreator",
+    "primary": "torrentcreator_add_task",
+    "version_introduced": "2.10.4",
+    "version_removed": ""
+  },
+  {
+    "api_method": "deleteTask",
+    "client_aliases": [
+      "torrentcreator_deleteTask"
+    ],
+    "namespace": "torrentcreator",
+    "primary": "torrentcreator_delete_task",
+    "version_introduced": "2.10.4",
+    "version_removed": ""
+  },
+  {
+    "api_method": "status",
+    "client_aliases": [],
+    "namespace": "torrentcreator",
+    "primary": "torrentcreator_status",
+    "version_introduced": "2.10.4",
+    "version_removed": ""
+  },
+  {
+    "api_method": "torrentFile",
+    "client_aliases": [
+      "torrentcreator_torrentFile"
+    ],
+    "namespace": "torrentcreator",
+    "primary": "torrentcreator_torrent_file",
+    "version_introduced": "2.10.4",
+    "version_removed": ""
+  },
+  {
+    "api_method": "add",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_add",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "addPeers",
+    "client_aliases": [
+      "torrents_addPeers"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_add_peers",
+    "version_introduced": "2.3.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "addTags",
+    "client_aliases": [
+      "torrents_addTags"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_add_tags",
+    "version_introduced": "2.3.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "addTrackers",
+    "client_aliases": [
+      "torrents_addTrackers"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_add_trackers",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "addWebSeeds",
+    "client_aliases": [
+      "torrents_addWebSeeds"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_add_webseeds",
+    "version_introduced": "2.11.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "bottomPrio",
+    "client_aliases": [
+      "torrents_bottomPrio"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_bottom_priority",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "categories",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_categories",
+    "version_introduced": "2.1.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "count",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_count",
+    "version_introduced": "2.9.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "createCategory",
+    "client_aliases": [
+      "torrents_createCategory"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_create_category",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "createTags",
+    "client_aliases": [
+      "torrents_createTags"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_create_tags",
+    "version_introduced": "2.3.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "decreasePrio",
+    "client_aliases": [
+      "torrents_decreasePrio"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_decrease_priority",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "delete",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_delete",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "deleteTags",
+    "client_aliases": [
+      "torrents_deleteTags"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_delete_tags",
+    "version_introduced": "2.3.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "downloadFile",
+    "client_aliases": [
+      "torrents_downloadFile"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_download_file",
+    "version_introduced": "2.16.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "downloadLimit",
+    "client_aliases": [
+      "torrents_downloadLimit"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_download_limit",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "editCategory",
+    "client_aliases": [
+      "torrents_editCategory"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_edit_category",
+    "version_introduced": "2.1.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "editTracker",
+    "client_aliases": [
+      "torrents_editTracker"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_edit_tracker",
+    "version_introduced": "2.2.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "editWebSeed",
+    "client_aliases": [
+      "torrents_editWebSeed"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_edit_webseed",
+    "version_introduced": "2.11.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "export",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_export",
+    "version_introduced": "2.8.14",
+    "version_removed": ""
+  },
+  {
+    "api_method": "fetchMetadata",
+    "client_aliases": [
+      "torrents_fetchMetadata"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_fetch_metadata",
+    "version_introduced": "2.11.9",
+    "version_removed": ""
+  },
+  {
+    "api_method": "filePrio",
+    "client_aliases": [
+      "torrents_filePrio"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_file_priority",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "files",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_files",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "increasePrio",
+    "client_aliases": [
+      "torrents_increasePrio"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_increase_priority",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "info",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_info",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "parseMetadata",
+    "client_aliases": [
+      "torrents_parseMetadata"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_parse_metadata",
+    "version_introduced": "2.11.9",
+    "version_removed": ""
+  },
+  {
+    "api_method": "",
+    "client_aliases": [
+      "torrents_stop"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_pause",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "pieceAvailability",
+    "client_aliases": [
+      "torrents_pieceAvailability"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_piece_availability",
+    "version_introduced": "2.15.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "pieceHashes",
+    "client_aliases": [
+      "torrents_pieceHashes"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_piece_hashes",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "pieceStates",
+    "client_aliases": [
+      "torrents_pieceStates"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_piece_states",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "properties",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_properties",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "reannounce",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_reannounce",
+    "version_introduced": "2.0.2",
+    "version_removed": ""
+  },
+  {
+    "api_method": "recheck",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_recheck",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "removeCategories",
+    "client_aliases": [
+      "torrents_removeCategories"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_remove_categories",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "removeTags",
+    "client_aliases": [
+      "torrents_removeTags"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_remove_tags",
+    "version_introduced": "2.3.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "removeTrackers",
+    "client_aliases": [
+      "torrents_removeTrackers"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_remove_trackers",
+    "version_introduced": "2.2.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "removeWebSeeds",
+    "client_aliases": [
+      "torrents_removeWebSeeds"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_remove_webseeds",
+    "version_introduced": "2.11.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "rename",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_rename",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "renameFile",
+    "client_aliases": [
+      "torrents_renameFile"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_rename_file",
+    "version_introduced": "2.4.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "renameFolder",
+    "client_aliases": [
+      "torrents_renameFolder"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_rename_folder",
+    "version_introduced": "2.7",
+    "version_removed": ""
+  },
+  {
+    "api_method": "",
+    "client_aliases": [
+      "torrents_start"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_resume",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "saveMetadata",
+    "client_aliases": [
+      "torrents_saveMetadata"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_save_metadata",
+    "version_introduced": "2.11.9",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setAutoManagement",
+    "client_aliases": [
+      "torrents_setAutoManagement"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_auto_management",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setCategory",
+    "client_aliases": [
+      "torrents_setCategory"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_category",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setComment",
+    "client_aliases": [
+      "torrents_setComment"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_comment",
+    "version_introduced": "2.12.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setDownloadLimit",
+    "client_aliases": [
+      "torrents_setDownloadLimit"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_download_limit",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setDownloadPath",
+    "client_aliases": [
+      "torrents_setDownloadPath"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_download_path",
+    "version_introduced": "2.8.4",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setForceStart",
+    "client_aliases": [
+      "torrents_setForceStart"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_force_start",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setLocation",
+    "client_aliases": [
+      "torrents_setLocation"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_location",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setSavePath",
+    "client_aliases": [
+      "torrents_setSavePath"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_save_path",
+    "version_introduced": "2.8.4",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setShareLimits",
+    "client_aliases": [
+      "torrents_setShareLimits"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_share_limits",
+    "version_introduced": "2.0.1",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setSSLParameters",
+    "client_aliases": [
+      "torrents_setSSLParameters"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_ssl_parameters",
+    "version_introduced": "2.10.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setSuperSeeding",
+    "client_aliases": [
+      "torrents_setSuperSeeding"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_super_seeding",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setTags",
+    "client_aliases": [
+      "torrents_setTags"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_tags",
+    "version_introduced": "2.11.4",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setUploadLimit",
+    "client_aliases": [
+      "torrents_setUploadLimit"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_set_upload_limit",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "SSLParameters",
+    "client_aliases": [
+      "torrents_SSLParameters"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_ssl_parameters",
+    "version_introduced": "2.10.3",
+    "version_removed": ""
+  },
+  {
+    "api_method": "tags",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_tags",
+    "version_introduced": "2.3.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "toggleFirstLastPiecePrio",
+    "client_aliases": [
+      "torrents_toggleFirstLastPiecePrio"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_toggle_first_last_piece_priority",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "toggleSequentialDownload",
+    "client_aliases": [
+      "torrents_toggleSequentialDownload"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_toggle_sequential_download",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "topPrio",
+    "client_aliases": [
+      "torrents_topPrio"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_top_priority",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "trackers",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_trackers",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "uploadLimit",
+    "client_aliases": [
+      "torrents_uploadLimit"
+    ],
+    "namespace": "torrents",
+    "primary": "torrents_upload_limit",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "webseeds",
+    "client_aliases": [],
+    "namespace": "torrents",
+    "primary": "torrents_webseeds",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "banPeers",
+    "client_aliases": [
+      "transfer_banPeers"
+    ],
+    "namespace": "transfer",
+    "primary": "transfer_ban_peers",
+    "version_introduced": "2.3.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "downloadLimit",
+    "client_aliases": [
+      "transfer_downloadLimit"
+    ],
+    "namespace": "transfer",
+    "primary": "transfer_download_limit",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "info",
+    "client_aliases": [],
+    "namespace": "transfer",
+    "primary": "transfer_info",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setDownloadLimit",
+    "client_aliases": [
+      "transfer_setDownloadLimit"
+    ],
+    "namespace": "transfer",
+    "primary": "transfer_set_download_limit",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setSpeedLimits",
+    "client_aliases": [
+      "transfer_setSpeedLimits"
+    ],
+    "namespace": "transfer",
+    "primary": "transfer_set_speed_limits",
+    "version_introduced": "2.16.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "toggleSpeedLimitsMode",
+    "client_aliases": [
+      "transfer_setSpeedLimitsMode",
+      "transfer_toggleSpeedLimitsMode",
+      "transfer_toggle_speed_limits_mode"
+    ],
+    "namespace": "transfer",
+    "primary": "transfer_set_speed_limits_mode",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "setUploadLimit",
+    "client_aliases": [
+      "transfer_setUploadLimit"
+    ],
+    "namespace": "transfer",
+    "primary": "transfer_set_upload_limit",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "getSpeedLimits",
+    "client_aliases": [
+      "transfer_getSpeedLimits"
+    ],
+    "namespace": "transfer",
+    "primary": "transfer_speed_limits",
+    "version_introduced": "2.16.0",
+    "version_removed": ""
+  },
+  {
+    "api_method": "speedLimitsMode",
+    "client_aliases": [
+      "transfer_speedLimitsMode"
+    ],
+    "namespace": "transfer",
+    "primary": "transfer_speed_limits_mode",
+    "version_introduced": "",
+    "version_removed": ""
+  },
+  {
+    "api_method": "uploadLimit",
+    "client_aliases": [
+      "transfer_uploadLimit"
+    ],
+    "namespace": "transfer",
+    "primary": "transfer_upload_limit",
+    "version_introduced": "",
+    "version_removed": ""
+  }
+]

--- a/tests/catalog.py
+++ b/tests/catalog.py
@@ -1,0 +1,143 @@
+"""
+A catalog of the client's API surface, derived from the library itself.
+
+Every endpoint is reachable under several names. ``torrents_add_webseeds`` is
+also spelled ``torrents_addWebSeeds`` on the client, and ``add_webseeds`` /
+``addWebSeeds`` on the ``torrents`` interface. The camelCase spellings are plain
+assignments (``torrents_addWebSeeds = torrents_add_webseeds``), so they are the
+*same* function object rather than a second implementation.
+
+Each endpoint also declares which Web API versions it exists in, by passing
+``version_introduced`` and/or ``version_removed`` to the request helper it calls.
+
+Deriving all of that once, here, lets the surface tests parametrize over every
+endpoint instead of restating the same facts by hand for each one. Nothing in
+this module talks to qBittorrent; it only reads the library.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+
+import qbittorrentapi
+from qbittorrentapi.definitions import APINames
+
+#: Names of the request helpers an API method calls to reach qBittorrent.
+REQUEST_HELPERS = {"_get", "_get_cast", "_post", "_post_cast", "_request_manager"}
+
+#: Keyword arguments to those helpers that describe the endpoint.
+ENDPOINT_KWARGS = ("_name", "_method", "version_introduced", "version_removed")
+
+API_NAMESPACES = {namespace.value for namespace in APINames if namespace.value}
+
+
+@dataclass(frozen=True, order=True)
+class Endpoint:
+    """One qBittorrent Web API endpoint, as exposed by the client."""
+
+    #: client method name, e.g. ``torrents_add_webseeds``
+    primary: str
+    #: API namespace, e.g. ``torrents``
+    namespace: str
+    #: Web API method, e.g. ``addWebSeeds``
+    api_method: str
+    #: other client spellings bound to the same callable
+    client_aliases: tuple[str, ...] = ()
+    #: Web API version the endpoint first appeared in, if it is gated
+    version_introduced: str = ""
+    #: Web API version the endpoint was removed in, if it was removed
+    version_removed: str = ""
+
+
+def _literal(node: ast.expr) -> str | None:
+    """Value of a constant or an ``APINames.X`` attribute reference."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Attribute):
+        # e.g. APINames.Torrents -> "torrents"
+        namespace = getattr(APINames, node.attr, None)
+        return str(namespace.value) if namespace is not None else node.attr
+    return None
+
+
+def _endpoint_kwargs(func: object) -> dict[str, str]:
+    """Read the endpoint-describing kwargs out of ``func``'s request call."""
+    try:
+        source = textwrap.dedent(inspect.getsource(func))  # type: ignore[arg-type]
+    except (OSError, TypeError):  # pragma: no cover - builtins have no source
+        return {}
+
+    found: dict[str, str] = {}
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        called = node.func
+        name = called.attr if isinstance(called, ast.Attribute) else None
+        if name not in REQUEST_HELPERS:
+            continue
+        for keyword in node.keywords:
+            if keyword.arg in ENDPOINT_KWARGS:
+                value = _literal(keyword.value)
+                if value is not None:
+                    # first call wins; later ones are version-specific fallbacks
+                    found.setdefault(keyword.arg, value)
+    return found
+
+
+def _client_methods() -> dict[object, list[str]]:
+    """Client API methods grouped by the callable they are bound to."""
+    grouped: dict[object, list[str]] = defaultdict(list)
+    for name in dir(qbittorrentapi.Client):
+        if name.startswith("_") or name.split("_")[0] not in API_NAMESPACES:
+            continue
+        func = inspect.getattr_static(qbittorrentapi.Client, name)
+        if callable(func):
+            grouped[func].append(name)
+    return grouped
+
+
+def build_catalog() -> tuple[Endpoint, ...]:
+    """Derive every API endpoint the client exposes."""
+    endpoints = []
+    for func, names in _client_methods().items():
+        # the snake_case spelling is the canonical one; camelCase are aliases
+        snake_case = sorted(name for name in names if name.lower() == name)
+        primary = snake_case[0] if snake_case else sorted(names)[0]
+
+        kwargs = _endpoint_kwargs(func)
+        if not kwargs.get("_name"):
+            # not a request-issuing method, so there is no endpoint to catalog
+            continue
+        # a few endpoints choose their Web API method at runtime (torrents_stop
+        # calls "stop" or "pause" depending on the version), so there is no
+        # literal to read and api_method is left empty
+
+        endpoints.append(
+            Endpoint(
+                primary=primary,
+                namespace=kwargs.get("_name", ""),
+                api_method=kwargs.get("_method", ""),
+                client_aliases=tuple(sorted(set(names) - {primary})),
+                version_introduced=kwargs.get("version_introduced", ""),
+                version_removed=kwargs.get("version_removed", ""),
+            )
+        )
+    return tuple(sorted(endpoints))
+
+
+CATALOG = build_catalog()
+
+
+def as_snapshot() -> str:
+    """The catalog as stable, diffable JSON."""
+    import json
+
+    return json.dumps([asdict(e) for e in CATALOG], indent=2, sort_keys=True) + "\n"
+
+
+if __name__ == "__main__":
+    print(as_snapshot(), end="")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,8 +64,13 @@ ROOT_FOLDER_TORRENT_FILE = Path(RESOURCES_PATH, ROOT_FOLDER_TORRENT_FILENAME).re
 
 
 @pytest.fixture(autouse=True)
-def abort_if_qbittorrent_crashes(client):
+def abort_if_qbittorrent_crashes(request):
     """Abort tests if qbittorrent seemingly disappears during testing."""
+    if "offline" in request.keywords:
+        # the test never talks to qBittorrent, so there is nothing to watch for
+        return
+
+    client = request.getfixturevalue("client")
     # a single failed request isn't proof qBittorrent is gone; it may just be busy
     # enough to stall its event loop. since this aborts the entire test session,
     # give it a chance to respond before giving up.
@@ -81,21 +86,29 @@ def abort_if_qbittorrent_crashes(client):
 
 
 @pytest.fixture(autouse=True)
-def skip_if_not_implemented(request, api_version):
+def skip_if_not_implemented(request):
     """Skips test if `skipif_before_api_version` marker specifies min API version."""
-    if request.node.get_closest_marker("skipif_before_api_version"):
-        version = request.node.get_closest_marker("skipif_before_api_version").args[0]
-        if v(api_version) < v(version):
-            pytest.skip(f"testing {v(api_version)}; needs {version} or later")
+    # the marker is checked before the version is looked up so that tests without
+    # one never pull in the live client just to be told they are not skipped
+    marker = request.node.get_closest_marker("skipif_before_api_version")
+    if marker is None:
+        return
+
+    api_version = request.getfixturevalue("api_version")
+    if v(api_version) < v(marker.args[0]):
+        pytest.skip(f"testing {v(api_version)}; needs {marker.args[0]} or later")
 
 
 @pytest.fixture(autouse=True)
-def skip_if_implemented(request, api_version):
+def skip_if_implemented(request):
     """Skips test if `skipif_after_api_version` marker specifies max API version."""
-    if request.node.get_closest_marker("skipif_after_api_version"):
-        version = request.node.get_closest_marker("skipif_after_api_version").args[0]
-        if v(api_version) >= v(version):
-            pytest.skip(f"testing {v(api_version)}; needs before {version}")
+    marker = request.node.get_closest_marker("skipif_after_api_version")
+    if marker is None:
+        return
+
+    api_version = request.getfixturevalue("api_version")
+    if v(api_version) >= v(marker.args[0]):
+        pytest.skip(f"testing {v(api_version)}; needs before {marker.args[0]}")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_api_surface.py
+++ b/tests/test_api_surface.py
@@ -1,0 +1,151 @@
+"""
+Tests for the shape of the client's API surface, derived from the catalog.
+
+None of these talk to qBittorrent. They cover the facts that are true of the
+library itself no matter which qBittorrent is running: that every spelling of an
+endpoint reaches the same code, and that each endpoint's declared Web API
+version range is enforced.
+
+Those facts are currently also asserted per endpoint, over the network, by the
+behavior tests. Deriving them from the catalog covers every endpoint instead of
+the ones someone remembered to write a test for.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from qbittorrentapi import Client
+from tests.catalog import CATALOG, as_snapshot
+
+pytestmark = pytest.mark.offline
+
+SNAPSHOT_PATH = Path(__file__).parent / "api_surface.json"
+
+ALIASED = [e for e in CATALOG if e.client_aliases]
+INTRODUCED = [e for e in CATALOG if e.version_introduced]
+REMOVED = [e for e in CATALOG if e.version_removed]
+
+
+def by_primary(endpoint):
+    return endpoint.primary
+
+
+@pytest.fixture
+def offline_client():
+    """
+    Client that never reaches qBittorrent.
+
+    The version gate is checked before any request is sent, so these tests never
+    need a running qBittorrent...only a client whose reported Web API version can
+    be pinned.
+    """
+    return Client(
+        host="localhost:1",
+        RAISE_NOTIMPLEMENTEDERROR_FOR_UNIMPLEMENTED_API_ENDPOINTS=True,
+        VERIFY_WEBUI_CERTIFICATE=False,
+    )
+
+
+def pin_versions(client, monkeypatch, api_version, app_version):
+    """
+    Make the client believe which qBittorrent it is talking to.
+
+    Both versions are pinned because a couple of endpoints gate on the
+    application version rather than the Web API version: v4.3.2 and v4.3.3 both
+    report Web API v2.7, so ``torrents_rename_folder`` has to tell them apart by
+    application version.
+    """
+    monkeypatch.setattr(
+        client, "app_web_api_version", MagicMock(return_value=api_version)
+    )
+    monkeypatch.setattr(client, "app_version", MagicMock(return_value=app_version))
+
+
+def test_catalog_is_populated():
+    """A catalog that silently derived nothing would make every test below vacuous."""
+    assert len(CATALOG) > 100
+    assert {e.namespace for e in CATALOG} >= {"app", "torrents", "rss", "transfer"}
+    assert all(e.namespace for e in CATALOG)
+
+
+@pytest.mark.parametrize("endpoint", ALIASED, ids=by_primary)
+def test_client_aliases_are_the_same_callable(endpoint):
+    """
+    The camelCase spellings are assignments, not second implementations.
+
+    ``torrents_addWebSeeds = torrents_add_webseeds`` binds one function object to
+    two names, so asserting identity here covers what a live request through each
+    spelling would.
+    """
+    primary = getattr(Client, endpoint.primary)
+
+    for alias in endpoint.client_aliases:
+        assert getattr(Client, alias) is primary, (
+            f"{alias}() is not the same callable as {endpoint.primary}()"
+        )
+
+
+@pytest.mark.parametrize("endpoint", INTRODUCED, ids=by_primary)
+def test_endpoint_is_gated_before_it_was_introduced(
+    offline_client, monkeypatch, endpoint
+):
+    pin_versions(offline_client, monkeypatch, api_version="0.0.1", app_version="v0.0.1")
+
+    with pytest.raises(NotImplementedError, match="available starting in"):
+        getattr(offline_client, endpoint.primary)()
+
+
+@pytest.mark.parametrize("endpoint", REMOVED, ids=by_primary)
+def test_endpoint_is_gated_after_it_was_removed(offline_client, monkeypatch, endpoint):
+    pin_versions(
+        offline_client, monkeypatch, api_version="99.0.0", app_version="v99.0.0"
+    )
+
+    with pytest.raises(NotImplementedError, match="was removed in"):
+        getattr(offline_client, endpoint.primary)()
+
+
+@pytest.mark.parametrize("endpoint", INTRODUCED, ids=by_primary)
+def test_endpoint_is_not_gated_once_introduced(offline_client, monkeypatch, endpoint):
+    """A gate that always fired would pass the tests above for the wrong reason."""
+    if endpoint.version_removed:
+        pytest.skip(f"{endpoint.primary} was removed in {endpoint.version_removed}")
+
+    # the application version is pinned high so the handful of endpoints that
+    # gate on it are not held back by it here
+    pin_versions(
+        offline_client,
+        monkeypatch,
+        api_version=endpoint.version_introduced,
+        app_version="v99.0.0",
+    )
+
+    # the endpoint is supported at this version, so the request is attempted and
+    # fails to connect...which is proof the version gate let it through
+    with pytest.raises(Exception) as exc_info:
+        getattr(offline_client, endpoint.primary)()
+    assert not isinstance(exc_info.value, NotImplementedError)
+
+
+def test_catalog_matches_snapshot():
+    """
+    Guards the declared Web API versions against accidental edits.
+
+    Deriving the catalog from the source cannot, on its own, catch a version
+    constant being changed by mistake, since the expectation would move with it.
+    The snapshot is the second copy that makes such a change show up in review.
+
+    Regenerate deliberately with::
+
+        python -m tests.catalog > tests/api_surface.json
+    """
+    expected = SNAPSHOT_PATH.read_text()
+
+    assert as_snapshot() == expected, (
+        "API surface changed; if intended, regenerate with "
+        "`python -m tests.catalog > tests/api_surface.json`"
+    )


### PR DESCRIPTION
Second of the layered test changes. **Stacked on #662** — review that first.

This one only *adds*. Nothing is removed yet, so the new tests run alongside the
existing ones until they have proven themselves. Removing what they make
redundant is the next layer.

## The observation

Two facts are currently asserted per endpoint, over the network, by the behavior
tests:

- every spelling of an endpoint reaches the same code
- an endpoint declared for Web API vX raises `NotImplementedError` before it

Neither depends on which qBittorrent is running. The camelCase spellings are
plain assignments:

```python
torrents_addWebSeeds = torrents_add_webseeds
```

so they are the *same function object* — 92 of the 128 endpoints have at least
one alias, 94 alias bindings in all. Asserting that identity costs nothing; proving it with a live
request costs a round trip, times five qBittorrent versions in CI.

## What's here

**`tests/catalog.py`** derives the surface from the library itself: for each
method, the namespace and Web API method it calls, every client spelling bound to
the same callable, and the version range it declares. That is **128 endpoints, 94
alias bindings and 69 version gates**, read out of the source rather than
restated by hand.

**`tests/test_api_surface.py`** parametrizes over that catalog — covering every
endpoint rather than the ones someone remembered to write a test for.

The version gate is checked in *both* directions, since a gate that always fired
would satisfy a one-sided test for the wrong reason. Both the application and Web
API versions are pinned, because `torrents_rename_folder` gates on the former:
v4.3.2 and v4.3.3 both report Web API v2.7, so the application version is the
only way to tell them apart.

**`tests/api_surface.json`** is a checked-in snapshot. Deriving expectations from
the source cannot, on its own, catch a version constant being edited by mistake —
the expectation moves with it. The snapshot is the second copy that makes such a
change show up in review. Regenerate deliberately:

```
python -m tests.catalog > tests/api_surface.json
```

Adding an endpoint (as #659 did) will now require regenerating it. That is the
intent, not a side effect.

## conftest: lazy autouse fixtures

The autouse fixtures took `client` and `api_version` as parameters, so *every*
test pulled in a live qBittorrent even when it had no marker to act on and never
made a request. They now check for their marker first and only resolve the
fixture if they find one — which is what lets the new tests carry an `offline`
marker and stay off the network.

Caveat worth knowing: `setup_environ()` still contacts qBittorrent at conftest
import, so the suite as a whole is not yet runnable without a daemon. Deferring
that belongs to a later layer.

## Verification

```
231 tests, 230 passed, 1 skipped in 0.39s
```

The skip is the one removed endpoint in the "not gated once introduced" case.
Snapshot generation is deterministic across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
