### PR TITLE
fix(tests): make webseed checks survive a busy qBittorrent

### DIFF
--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -565,6 +565,8 @@ def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
             lambda: webseed not in {w.url for w in new_torrent.webseeds},
             True,
             action=remove_webseeds,
+            check_time=WEBSEED_CHECK_TIME,
+            action_every=WEBSEED_ACTION_EVERY,
         )
 
 

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -18,7 +18,13 @@ from qbittorrentapi import (
 )
 from qbittorrentapi._version_support import v
 from tests.test_torrents import disable_queueing, enable_queueing
-from tests.utils import check, mkpath, retry
+from tests.utils import (
+    WEBSEED_ACTION_EVERY,
+    WEBSEED_CHECK_TIME,
+    check,
+    mkpath,
+    retry,
+)
 
 
 def test_info(orig_torrent, monkeypatch):
@@ -460,6 +466,8 @@ def test_add_webseed(new_torrent, add_webseeds_func, webseeds):
         # discards any that fail, so re-send until it takes effect. adding a
         # webseed that is already there is ignored, so this is safe to repeat.
         action=add_webseeds,
+        check_time=WEBSEED_CHECK_TIME,
+        action_every=WEBSEED_ACTION_EVERY,
     )
 
 
@@ -491,11 +499,31 @@ def test_edit_webseeds(new_torrent, edit_webseed_func):
             add_orig_url()
 
     add_orig_url()
-    check(urls, orig_url, reverse=True, action=add_orig_url)
+    check(
+        urls,
+        orig_url,
+        reverse=True,
+        action=add_orig_url,
+        check_time=WEBSEED_CHECK_TIME,
+        action_every=WEBSEED_ACTION_EVERY,
+    )
     edit_webseed()
-    check(urls, new_url, reverse=True, action=redo_edit)
+    check(
+        urls,
+        new_url,
+        reverse=True,
+        action=redo_edit,
+        check_time=WEBSEED_CHECK_TIME,
+        action_every=WEBSEED_ACTION_EVERY,
+    )
     # the original must have been replaced rather than added alongside
-    check(lambda: len(new_torrent.webseeds), 1, action=redo_edit)
+    check(
+        lambda: len(new_torrent.webseeds),
+        1,
+        action=redo_edit,
+        check_time=WEBSEED_CHECK_TIME,
+        action_every=WEBSEED_ACTION_EVERY,
+    )
 
 
 @pytest.mark.skipif_before_api_version("2.11.3")
@@ -528,6 +556,8 @@ def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
         all_webseeds,
         reverse=True,
         action=add_webseeds,
+        check_time=WEBSEED_CHECK_TIME,
+        action_every=WEBSEED_ACTION_EVERY,
     )
     remove_webseeds()
     for webseed in webseeds if isinstance(webseeds, list) else [webseeds]:

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -556,6 +556,8 @@ def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
             lambda: webseed not in {w.url for w in new_torrent.webseeds},
             True,
             action=remove_webseeds,
+            check_time=WEBSEED_CHECK_TIME,
+            action_every=WEBSEED_ACTION_EVERY,
         )
 
 

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -47,7 +47,13 @@ from tests.conftest import (
     TORRENT2_URL,
     new_torrent_standalone,
 )
-from tests.utils import check, mkpath, retry
+from tests.utils import (
+    WEBSEED_ACTION_EVERY,
+    WEBSEED_CHECK_TIME,
+    check,
+    mkpath,
+    retry,
+)
 
 
 def disable_queueing(client):
@@ -446,6 +452,8 @@ def test_add_webseeds(client, new_torrent, add_webseeds_func, webseeds):
         reverse=True,
         # see tests/test_torrent.py::test_add_webseed for why this is re-sent
         action=add_webseeds,
+        check_time=WEBSEED_CHECK_TIME,
+        action_every=WEBSEED_ACTION_EVERY,
     )
 
 
@@ -482,10 +490,30 @@ def test_edit_webseeds(client, new_torrent, edit_webseed_func):
             add_orig_url()
 
     add_orig_url()
-    check(urls, orig_url, reverse=True, action=add_orig_url)
+    check(
+        urls,
+        orig_url,
+        reverse=True,
+        action=add_orig_url,
+        check_time=WEBSEED_CHECK_TIME,
+        action_every=WEBSEED_ACTION_EVERY,
+    )
     edit_webseed()
-    check(urls, new_url, reverse=True, action=redo_edit)
-    check(lambda: len(new_torrent.webseeds), 1, action=redo_edit)
+    check(
+        urls,
+        new_url,
+        reverse=True,
+        action=redo_edit,
+        check_time=WEBSEED_CHECK_TIME,
+        action_every=WEBSEED_ACTION_EVERY,
+    )
+    check(
+        lambda: len(new_torrent.webseeds),
+        1,
+        action=redo_edit,
+        check_time=WEBSEED_CHECK_TIME,
+        action_every=WEBSEED_ACTION_EVERY,
+    )
 
 
 @pytest.mark.skipif_after_api_version("2.11.3")
@@ -519,6 +547,8 @@ def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
         all_webseeds,
         reverse=True,
         action=add_webseeds,
+        check_time=WEBSEED_CHECK_TIME,
+        action_every=WEBSEED_ACTION_EVERY,
     )
     remove_webseeds()
     for webseed in webseeds if isinstance(webseeds, list) else [webseeds]:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,6 +19,13 @@ from qbittorrentapi._version_support import (
 CHECK_TIME = 10
 # Amount of time to sleep between checks
 CHECK_SLEEP = 0.25
+# Webseed changes are handed to a qBittorrent thread pool that silently discards
+# whatever it fails to apply, and under load it can discard a great many in a row.
+# They need a much longer window than other checks, and re-sending on every retry
+# only queues more work onto the pool that is already behind, so back off between
+# attempts instead of hammering it.
+WEBSEED_CHECK_TIME = 60
+WEBSEED_ACTION_EVERY = 8
 # Errors that mean qBittorrent hasn't caught up yet, so the check should be retried.
 # LookupError and AttributeError cover values qBittorrent hasn't populated yet, e.g.
 # indexing into a list that is still empty. The last attempt raises regardless, so
@@ -113,6 +120,7 @@ def check(
     any=False,
     check_time=None,
     action=None,
+    action_every=1,
 ):
     """
     Compare the return value of an arbitrary function to expected value with retries.
@@ -131,6 +139,9 @@ def check(
         qBittorrent occasionally never applies a request (e.g. it decides its own,
         potentially stale, cached state already matches), and re-sending is the only
         way to recover. Only use for requests that are safe to send more than once.
+    :param action_every: number of retries between each ``action`` call; raise it for
+        requests qBittorrent handles on a worker thread, where re-sending on every
+        retry just queues more work onto a pool that is already behind
     """
 
     # assertions are not rewritten by pytest in this module, so each
@@ -186,7 +197,7 @@ def check(
                 if i >= check_limit - 1:
                     raise
                 sleep(CHECK_SLEEP)
-                if action is not None:
+                if action is not None and (i + 1) % action_every == 0:
                     action()
     except HTTPError:
         # every HTTP error subclasses APIConnectionError, so let anything


### PR DESCRIPTION
The webseed tests fail intermittently on qBittorrent **v5.1 and v5.2** in CI, always
the same way: a webseed add or edit is accepted, returns 200, and never takes effect.

```
AssertionError: 'http://example/asdf' not in []
```

## The compensation was feeding the problem

qBittorrent hands webseed changes to a thread pool and silently discards whatever
it fails to apply — already documented in these tests, and already compensated for
by re-sending through `check()`'s `action`.

That wasn't enough, and the reason is a little perverse: `action` fires on *every*
retry, i.e. once every 250ms. Under load the pool discards a long run of changes,
and re-sending 40 times in 10 seconds just queues more work onto a pool that is
already behind. The mitigation was contributing to the failure it was meant to fix.

So `check()` grows an `action_every`, and the webseed checks now re-send **every 2s
across a 60s window** instead of every 250ms across 10s — *fewer* attempts overall,
spread over six times as long.

This costs nothing when tests pass: a check that succeeds returns on its first look,
so only a failing check spends the longer window. Locally the full webseed set runs
in 44s, unchanged.

## Honest limitation

**This only reproduces on CI runners.** Three attempts to provoke it locally all
passed:

| Attempt | Result |
|---|---|
| Full suite vs v5.2.3 | 1319 passed, 0 failed |
| Webseed tests vs v5.2.3 | passed |
| Webseed tests vs v5.1.4 | passed |

So CI is the only place this fix can be judged, and I can't claim it verified until
the matrix says so.

## Why now

Found while investigating #665, which does **not** touch these tests but removes
enough of the tests running before them to shift the timing and make this
near-deterministic — six failures per run, twice, all on 5.1/5.2, while #664 and
#666 pass those same jobs.

The fragility is pre-existing and worth fixing on its own; #665 should rebase onto
this once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)