### PR TITLE
refactor(tests): catalog torrent objects and drop the last gate twins

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -88,9 +88,11 @@ qBittorrent's own cached state already looks correct. For those, pass
 def add_webseeds():
     torrent.add_webseeds(urls=urls)
 
+
 add_webseeds()
-check(lambda: [w.url for w in torrent.webseeds], urls, reverse=True,
-      action=add_webseeds)
+check(
+    lambda: [w.url for w in torrent.webseeds], urls, reverse=True, action=add_webseeds
+)
 ```
 
 Only use `action=` for requests that are safe to send more than once.
@@ -130,9 +132,10 @@ below the version it was introduced in — through the client method *and* its
 interface spelling — and that it stops raising at that version. Writing one by
 hand adds a live request that proves something already proven.
 
-The `*_not_implemented` tests that remain cover methods on torrent objects, such
-as `torrent.set_comment()`. That surface is not in the catalog yet, so those are
-still carrying their own weight.
+That holds for all three ways an endpoint can be reached: the client method, the
+namespace interface, and the torrent objects `torrents_info()` returns. The only
+`*_not_implemented` tests left are in `test_request.py`, and they cover the gate
+mechanism itself rather than any particular endpoint.
 
 ## Gotchas that have cost real time
 

--- a/tests/api_surface.json
+++ b/tests/api_surface.json
@@ -11,6 +11,9 @@
     "interface_kind": "property",
     "namespace": "app",
     "primary": "app_build_info",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.3",
     "version_removed": ""
   },
@@ -22,6 +25,9 @@
     "interface_kind": "property",
     "namespace": "app",
     "primary": "app_cookies",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.11.3",
     "version_removed": ""
   },
@@ -37,6 +43,9 @@
     "interface_kind": "property",
     "namespace": "app",
     "primary": "app_default_save_path",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -52,6 +61,9 @@
     "interface_kind": "method",
     "namespace": "app",
     "primary": "app_delete_api_key",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.14.1",
     "version_removed": ""
   },
@@ -67,6 +79,9 @@
     "interface_kind": "method",
     "namespace": "app",
     "primary": "app_get_directory_content",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.11",
     "version_removed": ""
   },
@@ -82,6 +97,9 @@
     "interface_kind": "method",
     "namespace": "app",
     "primary": "app_get_free_space_at_path",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.15.2",
     "version_removed": ""
   },
@@ -97,6 +115,9 @@
     "interface_kind": "method",
     "namespace": "app",
     "primary": "app_network_interface_address_list",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.3",
     "version_removed": ""
   },
@@ -112,6 +133,9 @@
     "interface_kind": "property",
     "namespace": "app",
     "primary": "app_network_interface_list",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.3",
     "version_removed": ""
   },
@@ -123,6 +147,9 @@
     "interface_kind": "property",
     "namespace": "app",
     "primary": "app_preferences",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -138,6 +165,9 @@
     "interface_kind": "property",
     "namespace": "app",
     "primary": "app_process_info",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.15.1",
     "version_removed": ""
   },
@@ -153,6 +183,9 @@
     "interface_kind": "method",
     "namespace": "app",
     "primary": "app_rotate_api_key",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.14.0",
     "version_removed": ""
   },
@@ -168,6 +201,9 @@
     "interface_kind": "method",
     "namespace": "app",
     "primary": "app_send_test_email",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.10.4",
     "version_removed": ""
   },
@@ -183,6 +219,9 @@
     "interface_kind": "method",
     "namespace": "app",
     "primary": "app_set_cookies",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.11.3",
     "version_removed": ""
   },
@@ -198,6 +237,9 @@
     "interface_kind": "method",
     "namespace": "app",
     "primary": "app_set_preferences",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -209,6 +251,9 @@
     "interface_kind": "method",
     "namespace": "app",
     "primary": "app_shutdown",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -220,6 +265,9 @@
     "interface_kind": "property",
     "namespace": "app",
     "primary": "app_version",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -235,6 +283,9 @@
     "interface_kind": "property",
     "namespace": "app",
     "primary": "app_web_api_version",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -246,6 +297,9 @@
     "interface_kind": "method",
     "namespace": "auth",
     "primary": "auth_log_in",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -257,6 +311,9 @@
     "interface_kind": "method",
     "namespace": "auth",
     "primary": "auth_log_out",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -268,6 +325,9 @@
     "interface_kind": "method",
     "namespace": "clientdata",
     "primary": "clientdata_load",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.13.1",
     "version_removed": ""
   },
@@ -279,6 +339,9 @@
     "interface_kind": "method",
     "namespace": "clientdata",
     "primary": "clientdata_store",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.13.1",
     "version_removed": ""
   },
@@ -290,6 +353,9 @@
     "interface_kind": "property",
     "namespace": "log",
     "primary": "log_main",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -301,6 +367,9 @@
     "interface_kind": "method",
     "namespace": "log",
     "primary": "log_peers",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -316,6 +385,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_add_feed",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -331,6 +403,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_add_folder",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -346,6 +421,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_clone_rule",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.15.4",
     "version_removed": ""
   },
@@ -357,6 +435,9 @@
     "interface_kind": "property",
     "namespace": "rss",
     "primary": "rss_items",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -372,6 +453,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_mark_as_read",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.5.1",
     "version_removed": ""
   },
@@ -387,6 +471,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_matching_articles",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.5.1",
     "version_removed": ""
   },
@@ -402,6 +489,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_move_item",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -417,6 +507,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_refresh_item",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.2",
     "version_removed": ""
   },
@@ -432,6 +525,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_remove_item",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -447,6 +543,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_remove_rule",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -462,6 +561,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_rename_rule",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -473,6 +575,9 @@
     "interface_kind": "property",
     "namespace": "rss",
     "primary": "rss_rules",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -488,6 +593,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_set_feed_refresh_interval",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.11.5",
     "version_removed": ""
   },
@@ -503,6 +611,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_set_feed_url",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.9.1",
     "version_removed": ""
   },
@@ -518,6 +629,9 @@
     "interface_kind": "method",
     "namespace": "rss",
     "primary": "rss_set_rule",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -529,6 +643,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_categories",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": "2.6"
   },
@@ -540,6 +657,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_delete",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -555,6 +675,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_download_torrent",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.11",
     "version_removed": ""
   },
@@ -570,6 +693,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_enable_plugin",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -585,6 +711,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_install_plugin",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -596,6 +725,9 @@
     "interface_kind": "property",
     "namespace": "search",
     "primary": "search_plugins",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -607,6 +739,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_results",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -618,6 +753,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_start",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -629,6 +767,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_status",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -640,6 +781,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_stop",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -655,6 +799,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_uninstall_plugin",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -670,6 +817,9 @@
     "interface_kind": "method",
     "namespace": "search",
     "primary": "search_update_plugins",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -681,6 +831,9 @@
     "interface_kind": "property",
     "namespace": "sync",
     "primary": "sync_maindata",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -696,6 +849,9 @@
     "interface_kind": "property",
     "namespace": "sync",
     "primary": "sync_torrent_peers",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -711,6 +867,9 @@
     "interface_kind": "method",
     "namespace": "torrentcreator",
     "primary": "torrentcreator_add_task",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.10.4",
     "version_removed": ""
   },
@@ -726,6 +885,9 @@
     "interface_kind": "method",
     "namespace": "torrentcreator",
     "primary": "torrentcreator_delete_task",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.10.4",
     "version_removed": ""
   },
@@ -737,6 +899,9 @@
     "interface_kind": "method",
     "namespace": "torrentcreator",
     "primary": "torrentcreator_status",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.10.4",
     "version_removed": ""
   },
@@ -752,6 +917,9 @@
     "interface_kind": "method",
     "namespace": "torrentcreator",
     "primary": "torrentcreator_torrent_file",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.10.4",
     "version_removed": ""
   },
@@ -763,6 +931,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_add",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -778,6 +949,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_add_peers",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.3.0",
     "version_removed": ""
   },
@@ -793,6 +967,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_add_tags",
+    "torrent_method": "add_tags",
+    "torrent_method_aliases": [
+      "addTags"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.3.0",
     "version_removed": ""
   },
@@ -808,6 +987,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_add_trackers",
+    "torrent_method": "add_trackers",
+    "torrent_method_aliases": [
+      "addTrackers"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -823,6 +1007,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_add_webseeds",
+    "torrent_method": "add_webseeds",
+    "torrent_method_aliases": [
+      "addWebSeeds"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.11.3",
     "version_removed": ""
   },
@@ -838,6 +1027,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_bottom_priority",
+    "torrent_method": "bottom_priority",
+    "torrent_method_aliases": [
+      "bottomPrio"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -849,6 +1043,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_categories",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.1",
     "version_removed": ""
   },
@@ -860,6 +1057,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_count",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.9.3",
     "version_removed": ""
   },
@@ -875,6 +1075,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_create_category",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -890,6 +1093,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_create_tags",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.3.0",
     "version_removed": ""
   },
@@ -905,6 +1111,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_decrease_priority",
+    "torrent_method": "decrease_priority",
+    "torrent_method_aliases": [
+      "decreasePrio"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -916,6 +1127,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_delete",
+    "torrent_method": "delete",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -931,6 +1145,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_delete_tags",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.3.0",
     "version_removed": ""
   },
@@ -946,6 +1163,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_download_file",
+    "torrent_method": "download_file",
+    "torrent_method_aliases": [
+      "downloadFile"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.16.0",
     "version_removed": ""
   },
@@ -961,6 +1183,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_download_limit",
+    "torrent_method": "download_limit",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "property",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -976,6 +1201,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_edit_category",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.1.0",
     "version_removed": ""
   },
@@ -991,6 +1219,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_edit_tracker",
+    "torrent_method": "edit_tracker",
+    "torrent_method_aliases": [
+      "editTracker"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.2.0",
     "version_removed": ""
   },
@@ -1006,6 +1239,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_edit_webseed",
+    "torrent_method": "edit_webseed",
+    "torrent_method_aliases": [
+      "editWebSeed"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.11.3",
     "version_removed": ""
   },
@@ -1017,6 +1255,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_export",
+    "torrent_method": "export",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "method",
     "version_introduced": "2.8.14",
     "version_removed": ""
   },
@@ -1032,6 +1273,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_fetch_metadata",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.11.9",
     "version_removed": ""
   },
@@ -1047,6 +1291,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_file_priority",
+    "torrent_method": "file_priority",
+    "torrent_method_aliases": [
+      "filePriority"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1058,6 +1307,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_files",
+    "torrent_method": "files",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "property",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1073,6 +1325,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_increase_priority",
+    "torrent_method": "increase_priority",
+    "torrent_method_aliases": [
+      "increasePrio"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1084,6 +1341,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_info",
+    "torrent_method": "info",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "property",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1099,6 +1359,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_parse_metadata",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.11.9",
     "version_removed": ""
   },
@@ -1114,6 +1377,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_pause",
+    "torrent_method": "pause",
+    "torrent_method_aliases": [
+      "stop"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1129,6 +1397,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_piece_availability",
+    "torrent_method": "piece_availability",
+    "torrent_method_aliases": [
+      "pieceAvailability"
+    ],
+    "torrent_method_kind": "property",
     "version_introduced": "2.15.1",
     "version_removed": ""
   },
@@ -1144,6 +1417,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_piece_hashes",
+    "torrent_method": "piece_hashes",
+    "torrent_method_aliases": [
+      "pieceHashes"
+    ],
+    "torrent_method_kind": "property",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1159,6 +1437,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_piece_states",
+    "torrent_method": "piece_states",
+    "torrent_method_aliases": [
+      "pieceStates"
+    ],
+    "torrent_method_kind": "property",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1170,6 +1453,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_properties",
+    "torrent_method": "properties",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "property",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1181,6 +1467,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_reannounce",
+    "torrent_method": "reannounce",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "method",
     "version_introduced": "2.0.2",
     "version_removed": ""
   },
@@ -1192,6 +1481,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_recheck",
+    "torrent_method": "recheck",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1207,6 +1499,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_remove_categories",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1222,6 +1517,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_remove_tags",
+    "torrent_method": "remove_tags",
+    "torrent_method_aliases": [
+      "removeTags"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.3.0",
     "version_removed": ""
   },
@@ -1237,6 +1537,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_remove_trackers",
+    "torrent_method": "remove_trackers",
+    "torrent_method_aliases": [
+      "removeTrackers"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.2.0",
     "version_removed": ""
   },
@@ -1252,6 +1557,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_remove_webseeds",
+    "torrent_method": "remove_webseeds",
+    "torrent_method_aliases": [
+      "removeWebSeeds"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.11.3",
     "version_removed": ""
   },
@@ -1263,6 +1573,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_rename",
+    "torrent_method": "rename",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1278,6 +1591,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_rename_file",
+    "torrent_method": "rename_file",
+    "torrent_method_aliases": [
+      "renameFile"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.4.0",
     "version_removed": ""
   },
@@ -1293,6 +1611,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_rename_folder",
+    "torrent_method": "rename_folder",
+    "torrent_method_aliases": [
+      "renameFolder"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.7",
     "version_removed": ""
   },
@@ -1308,6 +1631,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_resume",
+    "torrent_method": "resume",
+    "torrent_method_aliases": [
+      "start"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1323,6 +1651,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_save_metadata",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.11.9",
     "version_removed": ""
   },
@@ -1338,6 +1669,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_auto_management",
+    "torrent_method": "set_auto_management",
+    "torrent_method_aliases": [
+      "setAutoManagement"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1353,6 +1689,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_category",
+    "torrent_method": "set_category",
+    "torrent_method_aliases": [
+      "setCategory"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1368,6 +1709,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_comment",
+    "torrent_method": "set_comment",
+    "torrent_method_aliases": [
+      "setComment"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.12.1",
     "version_removed": ""
   },
@@ -1383,6 +1729,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_download_limit",
+    "torrent_method": "set_download_limit",
+    "torrent_method_aliases": [
+      "setDownloadLimit"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1398,6 +1749,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_download_path",
+    "torrent_method": "set_download_path",
+    "torrent_method_aliases": [
+      "setDownloadPath"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.8.4",
     "version_removed": ""
   },
@@ -1413,6 +1769,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_force_start",
+    "torrent_method": "set_force_start",
+    "torrent_method_aliases": [
+      "setForceStart"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1428,6 +1789,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_location",
+    "torrent_method": "set_location",
+    "torrent_method_aliases": [
+      "setLocation"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1443,6 +1809,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_save_path",
+    "torrent_method": "set_save_path",
+    "torrent_method_aliases": [
+      "setSavePath"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.8.4",
     "version_removed": ""
   },
@@ -1458,6 +1829,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_share_limits",
+    "torrent_method": "set_share_limits",
+    "torrent_method_aliases": [
+      "setShareLimits"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.0.1",
     "version_removed": ""
   },
@@ -1473,6 +1849,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_ssl_parameters",
+    "torrent_method": "set_ssl_parameters",
+    "torrent_method_aliases": [
+      "setSSLParameters"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.10.3",
     "version_removed": ""
   },
@@ -1488,6 +1869,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_super_seeding",
+    "torrent_method": "set_super_seeding",
+    "torrent_method_aliases": [
+      "setSuperSeeding"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1503,6 +1889,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_tags",
+    "torrent_method": "set_tags",
+    "torrent_method_aliases": [
+      "setTags"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "2.11.4",
     "version_removed": ""
   },
@@ -1518,6 +1909,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_set_upload_limit",
+    "torrent_method": "set_upload_limit",
+    "torrent_method_aliases": [
+      "setUploadLimit"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1533,6 +1929,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_ssl_parameters",
+    "torrent_method": "ssl_parameters",
+    "torrent_method_aliases": [
+      "SSLParameters"
+    ],
+    "torrent_method_kind": "property",
     "version_introduced": "2.10.3",
     "version_removed": ""
   },
@@ -1544,6 +1945,9 @@
     "interface_kind": "property",
     "namespace": "torrents",
     "primary": "torrents_tags",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.3.0",
     "version_removed": ""
   },
@@ -1559,6 +1963,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_toggle_first_last_piece_priority",
+    "torrent_method": "toggle_first_last_piece_priority",
+    "torrent_method_aliases": [
+      "toggleFirstLastPiecePrio"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1574,6 +1983,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_toggle_sequential_download",
+    "torrent_method": "toggle_sequential_download",
+    "torrent_method_aliases": [
+      "toggleSequentialDownload"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1589,6 +2003,11 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_top_priority",
+    "torrent_method": "top_priority",
+    "torrent_method_aliases": [
+      "topPrio"
+    ],
+    "torrent_method_kind": "method",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1600,6 +2019,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_trackers",
+    "torrent_method": "trackers",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "property",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1615,6 +2037,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_upload_limit",
+    "torrent_method": "upload_limit",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "property",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1626,6 +2051,9 @@
     "interface_kind": "method",
     "namespace": "torrents",
     "primary": "torrents_webseeds",
+    "torrent_method": "webseeds",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "property",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1641,6 +2069,9 @@
     "interface_kind": "method",
     "namespace": "transfer",
     "primary": "transfer_ban_peers",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.3.0",
     "version_removed": ""
   },
@@ -1654,6 +2085,9 @@
     "interface_kind": "property",
     "namespace": "transfer",
     "primary": "transfer_download_limit",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1665,6 +2099,9 @@
     "interface_kind": "property",
     "namespace": "transfer",
     "primary": "transfer_info",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1680,6 +2117,9 @@
     "interface_kind": "method",
     "namespace": "transfer",
     "primary": "transfer_set_download_limit",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1695,6 +2135,9 @@
     "interface_kind": "method",
     "namespace": "transfer",
     "primary": "transfer_set_speed_limits",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.16.0",
     "version_removed": ""
   },
@@ -1714,6 +2157,9 @@
     "interface_kind": "method",
     "namespace": "transfer",
     "primary": "transfer_set_speed_limits_mode",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1729,6 +2175,9 @@
     "interface_kind": "method",
     "namespace": "transfer",
     "primary": "transfer_set_upload_limit",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1744,6 +2193,9 @@
     "interface_kind": "property",
     "namespace": "transfer",
     "primary": "transfer_speed_limits",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "2.16.0",
     "version_removed": ""
   },
@@ -1757,6 +2209,9 @@
     "interface_kind": "property",
     "namespace": "transfer",
     "primary": "transfer_speed_limits_mode",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   },
@@ -1770,6 +2225,9 @@
     "interface_kind": "property",
     "namespace": "transfer",
     "primary": "transfer_upload_limit",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
     "version_introduced": "",
     "version_removed": ""
   }

--- a/tests/catalog.py
+++ b/tests/catalog.py
@@ -25,6 +25,7 @@ from dataclasses import asdict, dataclass
 
 import qbittorrentapi
 from qbittorrentapi.definitions import APINames
+from qbittorrentapi.torrents import TorrentDictionary
 
 #: Names of the request helpers an API method calls to reach qBittorrent.
 REQUEST_HELPERS = {"_get", "_get_cast", "_post", "_post_cast", "_request_manager"}
@@ -53,6 +54,12 @@ class Endpoint:
     interface_kind: str = ""
     #: other interface spellings bound to the same object
     interface_aliases: tuple[str, ...] = ()
+    #: spelling on a torrent object, e.g. ``set_comment`` for a TorrentDictionary
+    torrent_method: str = ""
+    #: how the torrent object exposes it: ``method`` or ``property``
+    torrent_method_kind: str = ""
+    #: other torrent object spellings bound to the same object
+    torrent_method_aliases: tuple[str, ...] = ()
     #: Web API version the endpoint first appeared in, if it is gated
     version_introduced: str = ""
     #: Web API version the endpoint was removed in, if it was removed
@@ -163,6 +170,37 @@ def _interface_spelling(interfaces, namespace: str, short_name: str):
     return "", "", ()
 
 
+def _torrent_spelling(namespace: str, short_name: str):
+    """
+    Locate ``short_name`` on :class:`TorrentDictionary`.
+
+    Torrents are also operated on through the torrent objects that
+    ``torrents_info()`` returns, which bind the hash for you:
+    ``torrent.set_comment()`` rather than
+    ``client.torrents_set_comment(torrent_hash=...)``. Only per-torrent
+    endpoints appear there, so collection-level ones like ``torrents_add`` have
+    no torrent spelling.
+    """
+    if namespace != "torrents":
+        return "", "", ()
+
+    target = inspect.getattr_static(TorrentDictionary, short_name, None)
+    if target is None:
+        return "", "", ()
+
+    kind = "property" if isinstance(target, property) else "method"
+    aliases = tuple(
+        sorted(
+            name
+            for name in dir(TorrentDictionary)
+            if name != short_name
+            and not name.startswith("_")
+            and inspect.getattr_static(TorrentDictionary, name, None) is target
+        )
+    )
+    return short_name, kind, aliases
+
+
 def build_catalog() -> tuple[Endpoint, ...]:
     """Derive every API endpoint the client exposes."""
     endpoints = []
@@ -181,8 +219,12 @@ def build_catalog() -> tuple[Endpoint, ...]:
         # literal to read and api_method is left empty
 
         namespace = kwargs.get("_name", "")
+        short_name = primary[len(namespace) + 1 :]
         interface, kind, iface_aliases = _interface_spelling(
-            interfaces, namespace, primary[len(namespace) + 1 :]
+            interfaces, namespace, short_name
+        )
+        torrent_method, torrent_kind, torrent_aliases = _torrent_spelling(
+            namespace, short_name
         )
 
         endpoints.append(
@@ -194,6 +236,9 @@ def build_catalog() -> tuple[Endpoint, ...]:
                 interface=interface,
                 interface_kind=kind,
                 interface_aliases=iface_aliases,
+                torrent_method=torrent_method,
+                torrent_method_kind=torrent_kind,
+                torrent_method_aliases=torrent_aliases,
                 version_introduced=kwargs.get("version_introduced", ""),
                 version_removed=kwargs.get("version_removed", ""),
             )

--- a/tests/test_api_surface.py
+++ b/tests/test_api_surface.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from qbittorrentapi import Client
+from qbittorrentapi.torrents import TorrentDictionary
 from tests.catalog import CATALOG, as_snapshot
 
 pytestmark = pytest.mark.offline
@@ -31,6 +32,8 @@ INTRODUCED = [e for e in CATALOG if e.version_introduced]
 REMOVED = [e for e in CATALOG if e.version_removed]
 INTERFACE_ALIASED = [e for e in CATALOG if e.interface_aliases]
 INTERFACE_INTRODUCED = [e for e in INTRODUCED if e.interface]
+TORRENT_ALIASED = [e for e in CATALOG if e.torrent_method_aliases]
+TORRENT_INTRODUCED = [e for e in INTRODUCED if e.torrent_method]
 
 
 def by_primary(endpoint):
@@ -148,6 +151,61 @@ def test_interface_spelling_is_gated_before_introduction(
 
     with pytest.raises(NotImplementedError, match="available starting in"):
         reach_through_interface(offline_client, endpoint)
+
+
+def required_kwargs(func):
+    """
+    Placeholder arguments for whatever ``func`` requires.
+
+    The version gate fires before the request is built, so the values are
+    irrelevant...but a method with a required argument raises TypeError before
+    reaching the gate if it is called with none.
+    """
+    kwargs = {}
+    for name, param in inspect.signature(func).parameters.items():
+        if name == "self" or param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+            continue
+        if param.default is inspect.Parameter.empty:
+            kwargs[name] = None
+    return kwargs
+
+
+def reach_through_torrent(client, endpoint):
+    """Reach an endpoint through a torrent object, as ``torrents_info()`` returns."""
+    torrent = TorrentDictionary({"hash": "abc123"}, client=client)
+    attribute = getattr(torrent, endpoint.torrent_method)
+
+    if endpoint.torrent_method_kind == "method":
+        return attribute(**required_kwargs(attribute))
+    return attribute
+
+
+@pytest.mark.parametrize("endpoint", TORRENT_ALIASED, ids=by_primary)
+def test_torrent_method_aliases_are_the_same_object(endpoint):
+    """The torrent object's camelCase spellings are assignments too."""
+    primary = inspect.getattr_static(TorrentDictionary, endpoint.torrent_method)
+
+    for alias in endpoint.torrent_method_aliases:
+        assert inspect.getattr_static(TorrentDictionary, alias) is primary, (
+            f"torrent.{alias} is not the same object "
+            f"as torrent.{endpoint.torrent_method}"
+        )
+
+
+@pytest.mark.parametrize("endpoint", TORRENT_INTRODUCED, ids=by_primary)
+def test_torrent_method_is_gated_before_introduction(
+    offline_client, monkeypatch, endpoint
+):
+    """
+    The gate must fire on torrent objects as well.
+
+    These are a third way to reach the same endpoints, and the only thing that
+    covered them was a handful of hand-written tests.
+    """
+    pin_versions(offline_client, monkeypatch, api_version="0.0.1", app_version="v0.0.1")
+
+    with pytest.raises(NotImplementedError, match="available starting in"):
+        reach_through_torrent(offline_client, endpoint)
 
 
 @pytest.mark.parametrize("endpoint", INTRODUCED, ids=by_primary)

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -206,15 +206,6 @@ def test_set_share_limits(orig_torrent, set_share_limits_func):
         check(lambda: orig_torrent.info.max_inactive_seeding_time, 200)
 
 
-@pytest.mark.skipif_after_api_version("2.0.1")
-@pytest.mark.parametrize(
-    "set_share_limits_func", ["set_share_limits", "setShareLimits"]
-)
-def test_set_share_limits_not_implemented(orig_torrent, set_share_limits_func):
-    with pytest.raises(NotImplementedError):
-        orig_torrent.func(set_share_limits_func)(ratio_limit=5, seeding_time_limit=100)
-
-
 @pytest.mark.parametrize(
     "down_limit_func, set_down_limit_func",
     [("download_limit", "set_download_limit"), ("downloadLimit", "setDownloadLimit")],
@@ -297,13 +288,6 @@ def test_set_comment(orig_torrent, set_comment_func):
     check(lambda: orig_torrent.info.comment, "new comment")
     orig_torrent.func(set_comment_func)(comment="")
     check(lambda: orig_torrent.info.comment, "")
-
-
-@pytest.mark.parametrize("set_comment_func", ["set_comment", "setComment"])
-@pytest.mark.skipif_after_api_version("2.12.1")
-def test_set_comment_not_implemented(orig_torrent, set_comment_func):
-    with pytest.raises(NotImplementedError):
-        orig_torrent.func(set_comment_func)(comment="new comment")
 
 
 @pytest.mark.parametrize(
@@ -403,13 +387,6 @@ def test_edit_tracker(orig_torrent, edit_tracker_func):
     orig_torrent.remove_trackers(urls="127.0.1.2")
 
 
-@pytest.mark.skipif_after_api_version("2.2.0")
-@pytest.mark.parametrize("edit_tracker_func", ["edit_tracker", "editTracker"])
-def test_edit_tracker_not_implemented(orig_torrent, edit_tracker_func):
-    with pytest.raises(NotImplementedError):
-        orig_torrent.func(edit_tracker_func)()
-
-
 @pytest.mark.skipif_before_api_version("2.2.0")
 @pytest.mark.parametrize("remove_trackers_func", ["remove_trackers", "removeTrackers"])
 @pytest.mark.parametrize("trackers", ["127.0.2.2", ["127.0.2.3", "127.0.2.4"]])
@@ -429,13 +406,6 @@ def test_remove_trackers(orig_torrent, remove_trackers_func, trackers):
         reverse=True,
         negate=True,
     )
-
-
-@pytest.mark.skipif_after_api_version("2.2.0")
-@pytest.mark.parametrize("remove_trackers_func", ["remove_trackers", "removeTrackers"])
-def test_remove_trackers_not_implemented(orig_torrent, remove_trackers_func):
-    with pytest.raises(NotImplementedError):
-        orig_torrent.func(remove_trackers_func)()
 
 
 def test_webseeds(orig_torrent):
@@ -584,12 +554,6 @@ def test_reannounce(orig_torrent):
     orig_torrent.reannounce()
 
 
-@pytest.mark.skipif_after_api_version("2.0.2")
-def test_reannounce_not_implemented(orig_torrent):
-    with pytest.raises(NotImplementedError):
-        orig_torrent.reannounce()
-
-
 @pytest.mark.skipif_before_api_version("2.10")
 def test_reannounce_in(orig_torrent):
     assert "reannounce_in" in orig_torrent.info
@@ -622,13 +586,6 @@ def test_rename_file(app_version, new_torrent, rename_file_func, name):
             check(lambda: new_torrent.files[0].name, new_name)
 
         run_test_new()
-
-
-@pytest.mark.skipif_after_api_version("2.4.0")
-@pytest.mark.parametrize("rename_file_func", ["rename_file", "renameFile"])
-def test_rename_file_not_implemented(new_torrent, rename_file_func):
-    with pytest.raises(NotImplementedError):
-        new_torrent.func(rename_file_func)()
 
 
 @pytest.mark.skipif_before_api_version("2.7")
@@ -668,22 +625,9 @@ def test_rename_folder(app_version, new_torrent, rename_folder_func, name):
     test()
 
 
-@pytest.mark.skipif_after_api_version("2.4.0")
-@pytest.mark.parametrize("rename_folder_func", ["rename_folder", "renameFolder"])
-def test_rename_folder_not_implemented(new_torrent, rename_folder_func):
-    with pytest.raises(NotImplementedError):
-        new_torrent.func(rename_folder_func)()
-
-
 @pytest.mark.skipif_before_api_version("2.8.14")
 def test_export(orig_torrent):
     assert isinstance(orig_torrent.export(), bytes)
-
-
-@pytest.mark.skipif_after_api_version("2.8.14")
-def test_export_not_implemented(orig_torrent):
-    with pytest.raises(NotImplementedError):
-        orig_torrent.export()
 
 
 @pytest.mark.parametrize("piece_states_func", ["piece_states", "pieceStates"])
@@ -725,20 +669,6 @@ def test_add_remove_tags(client, orig_torrent, add_tags_func, remove_tags_func, 
         client.torrents_delete_tags(tags=tags)
 
 
-@pytest.mark.skipif_after_api_version("2.3.0")
-@pytest.mark.parametrize(
-    "add_tags_func, remove_tags_func",
-    [("add_tags", "remove_tags"), ("addTags", "removeTags")],
-)
-def test_add_remove_tags_not_implemented(
-    client, orig_torrent, add_tags_func, remove_tags_func
-):
-    with pytest.raises(NotImplementedError):
-        orig_torrent.func(add_tags_func)()
-    with pytest.raises(NotImplementedError):
-        orig_torrent.func(remove_tags_func)()
-
-
 @pytest.mark.skipif_before_api_version("2.11.4")
 @pytest.mark.parametrize("set_tags_func", ["set_tags", "setTags"])
 @pytest.mark.parametrize("tags", ["tag 1", ["tag 2", "tag 3"]])
@@ -749,10 +679,3 @@ def test_set_tags(client, orig_torrent, set_tags_func, tags):
         check(lambda: orig_torrent.info.tags, tags, reverse=True)
     finally:
         client.torrents_delete_tags(tags=tags)
-
-
-@pytest.mark.skipif_after_api_version("2.11.4")
-@pytest.mark.parametrize("set_tags_func", ["set_tags", "setTags"])
-def test_set_tags_not_implemented(client, orig_torrent, set_tags_func):
-    with pytest.raises(NotImplementedError):
-        orig_torrent.func(set_tags_func)()


### PR DESCRIPTION
**Stacked on #669** — review that first. This finishes the gate-twin work.

## The third surface

Endpoints are reachable a third way, through the torrent objects `torrents_info()`
returns:

```python
torrent.set_comment()                                  # not
client.torrents_set_comment(torrent_hash=...)          # only this
```

That surface wasn't in the catalog, which is exactly why #669 had to keep 10
`*_not_implemented` tests.

The catalog now covers it: **49 of the 62 `torrents_*` endpoints** have a torrent
spelling — 11 properties, 37 with a camelCase alias. The 13 without are
collection-level operations like `torrents_add` and `torrents_categories`, which
aren't per-torrent and so correctly have none.

Two tests parametrize over it, mirroring the client and interface surfaces: the
camelCase spellings are the same object, and the version gate fires when reached
through a torrent.

| | Before | After |
|---|---|---|
| Surface tests | 387 | **444** (0.49s) |
| Collected tests | 1,548 | 1,587 (+57 offline, −18 live) |

## The last 10 twins

Removed. Every method they exercised was confirmed to resolve to an endpoint the
new gate test covers **before** deleting anything — `NOT COVERED: []`. That check
has caught a real over-deletion three times in this series, so it isn't optional
anymore.

The only `*_not_implemented` tests left in the suite are in `test_request.py`, and
they cover the gate *mechanism* rather than any endpoint.

## One accommodation worth knowing

`add_webseeds` takes a **required** argument, so calling it bare raises `TypeError`
before the gate is ever reached — 19 of 20 passing with one baffling outlier until
I spotted it. Arguments are now derived from the signature, which is safe precisely
because the gate fires before any of them are read.

## Verification

These twins only execute against a qBittorrent old enough to lack the endpoint, so
a master run proves nothing:

```
qBittorrent v4.3.9 (Web API 2.8.2)
1413 passed, 172 skipped, 2 xfailed in 4:31
```

## Also

`tests/CLAUDE.md` updated: the "don't hand-write these" guidance now covers all
three surfaces. I also stopped reverting `ruff format`'s reformat of the snippet in
that file and just accepted it — I'd been fighting it every PR, and the reformatted
version is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)