### PR TITLE
refactor(tests): finish the eventually() migration and delete check()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from qbittorrentapi._version_support import v
 from tests.utils import (
     CHECK_SLEEP,
     add_torrent,
-    check,
+    eventually,
     get_func,
     get_torrent,
     mkpath,
@@ -180,12 +180,15 @@ def wait_until_torrent_is_loaded(torrent):
     without any indication to the caller...for instance, adding a webseed is done in
     a worker thread that silently swallows any exception it encounters.
     """
-    check(
-        lambda: torrent.info.state,
-        ("checkingResumeData", "checkingDL", "checkingUP", "allocating", "metaDL"),
-        negate=True,
-        check_time=30,
-    )
+    for attempt in eventually(timeout=30):
+        with attempt:
+            assert torrent.info.state not in (
+                "checkingResumeData",
+                "checkingDL",
+                "checkingUP",
+                "allocating",
+                "metaDL",
+            )
 
 
 @contextmanager
@@ -229,12 +232,9 @@ def new_torrent_standalone(client, torrent_hash=TORRENT1_HASH, tmp_path=None, **
     @retry()
     def delete_test_torrent(client_, torrent_hash_):
         client_.torrents_delete(torrent_hashes=torrent_hash_, delete_files=True)
-        check(
-            lambda: [t.hash for t in client_.torrents_info()],
-            torrent_hash_,
-            reverse=True,
-            negate=True,
-        )
+        for attempt in eventually():
+            with attempt:
+                assert torrent_hash_ not in [t.hash for t in client_.torrents_info()]
 
     try:
         try:

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -8,7 +8,7 @@ from qbittorrentapi import APINames
 from qbittorrentapi._version_support import v
 from qbittorrentapi.exceptions import APIError, Conflict409Error
 from qbittorrentapi.rss import RSSitemsDictionary
-from tests.utils import check, retry
+from tests.utils import eventually, retry
 
 FOLDER_ONE = "testFolderOne"
 FOLDER_TWO = "testFolderTwo"
@@ -26,7 +26,9 @@ RSS_URL = (
 def delete_feed(client, name):
     with suppress(Conflict409Error):
         client.rss_remove_item(item_path=name)
-        check(lambda: client.rss_items(), name, reverse=True, negate=True)
+        for attempt in eventually():
+            with attempt:
+                assert name not in client.rss_items()
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -40,7 +42,9 @@ def rss_feed(client, api_version):
                 delete_feed(client, ITEM_ONE)
                 delete_feed(client, RSS_NAME)
                 client.rss.add_feed(url=RSS_URL, item_path=ITEM_ONE)
-                check(lambda: client.rss_items(), ITEM_ONE, reverse=True)
+                for attempt in eventually():
+                    with attempt:
+                        assert ITEM_ONE in client.rss_items()
                 # wait until feed is refreshed
                 for j in range(20):
                     if client.rss.items.with_data[ITEM_ONE]["articles"]:
@@ -75,11 +79,11 @@ def test_rss_refresh_item(client, rss_feed, refresh_item_func):
 
     client.func(refresh_item_func)(item_path=rss_feed)
 
-    check(
-        lambda: [e.message for e in client.log.main(last_known_id=last_log_id)],
-        f"RSS feed at '{RSS_URL}' updated. Added 0 new articles.",
-        reverse=True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert f"RSS feed at '{RSS_URL}' updated. Added 0 new articles." in [
+                e.message for e in client.log.main(last_known_id=last_log_id)
+            ]
 
 
 # inconsistent behavior with endpoint for API version 2.2
@@ -88,29 +92,25 @@ def test_rss_refresh_item(client, rss_feed, refresh_item_func):
 @pytest.mark.skipif_before_api_version("2.2")
 @pytest.mark.parametrize("items_func", ["rss_items", "rss.items"])
 def test_rss_items(client, rss_feed, items_func):
-    check(lambda: client.func(items_func)(), rss_feed, reverse=True)
-    check(
-        lambda: client.func(items_func)(include_feed_data=True),
-        rss_feed,
-        reverse=True,
-    )
-    check(
-        lambda: client.func(items_func)(include_feed_data=True)[rss_feed],
-        "articles",
-        reverse=True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert rss_feed in client.func(items_func)()
+    for attempt in eventually():
+        with attempt:
+            assert rss_feed in client.func(items_func)(include_feed_data=True)
+    for attempt in eventually():
+        with attempt:
+            assert (
+                "articles" in client.func(items_func)(include_feed_data=True)[rss_feed]
+            )
 
     if "." in items_func:
-        check(
-            lambda: client.func(items_func).without_data,
-            rss_feed,
-            reverse=True,
-        )
-        check(
-            lambda: client.func(items_func).with_data[rss_feed],
-            "articles",
-            reverse=True,
-        )
+        for attempt in eventually():
+            with attempt:
+                assert rss_feed in client.func(items_func).without_data
+        for attempt in eventually():
+            with attempt:
+                assert "articles" in client.func(items_func).with_data[rss_feed]
 
 
 # disabling as failures are too common...
@@ -161,7 +161,9 @@ def test_rss_set_refresh_interval(client, rss_feed, set_refresh_interval_func):
 @pytest.mark.parametrize("remove_item_func", ["rss_remove_item", "rss.remove_item"])
 def test_rss_remove_feed(client, rss_feed, remove_item_func):
     client.func(remove_item_func)(item_path=rss_feed)
-    check(lambda: client.rss_items(), rss_feed, reverse=True, negate=True)
+    for attempt in eventually():
+        with attempt:
+            assert rss_feed not in client.rss_items()
 
 
 @pytest.mark.parametrize(
@@ -177,9 +179,13 @@ def test_rss_add_remove_folder(client, add_folder_func, remove_item_func):
     name = "test_isos"
 
     client.func(add_folder_func)(folder_path=name)
-    check(lambda: client.rss_items(), name, reverse=True)
+    for attempt in eventually():
+        with attempt:
+            assert name in client.rss_items()
     client.func(remove_item_func)(item_path=name)
-    check(lambda: client.rss_items(), name, reverse=True, negate=True)
+    for attempt in eventually():
+        with attempt:
+            assert name not in client.rss_items()
 
 
 @pytest.mark.skipif_before_api_version("2.2")
@@ -188,7 +194,9 @@ def test_rss_move(client, rss_feed, move_func):
     new_name = "new_loc"
     try:
         client.func(move_func)(orig_item_path=rss_feed, new_item_path=new_name)
-        check(lambda: client.rss_items(), new_name, reverse=True)
+        for attempt in eventually():
+            with attempt:
+                assert new_name in client.rss_items()
     finally:
         with suppress(APIError):
             client.rss_remove_item(item_path=new_name)
@@ -199,11 +207,9 @@ def test_rss_move(client, rss_feed, move_func):
 def test_rss_mark_as_read(client, rss_feed, mark_read_func):
     item_id = client.rss.items.with_data[rss_feed]["articles"][0]["id"]
     client.func(mark_read_func)(item_path=rss_feed, article_id=item_id)
-    check(
-        lambda: client.rss.items.with_data[rss_feed]["articles"][0],
-        "isRead",
-        reverse=True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert "isRead" in client.rss.items.with_data[rss_feed]["articles"][0]
 
 
 @pytest.mark.skipif_before_api_version("2.2")
@@ -258,9 +264,13 @@ def test_rss_rules(
     def check_for_rule(name):
         try:
             client.func(rules_func)()
-            check(lambda: client.func(rules_func)(), name, reverse=True)
+            for attempt in eventually():
+                with attempt:
+                    assert name in client.func(rules_func)()
         except TypeError:
-            check(lambda: client.func(rules_func), name, reverse=True)
+            for attempt in eventually():
+                with attempt:
+                    assert name in client.func(rules_func)
 
     rule_name = ITEM_ONE + "Rule"
     rule_name_new = rule_name + "New"
@@ -284,10 +294,14 @@ def test_rss_rules(
     finally:
         client.func(remove_rule_func)(rule_name=rule_name)
         client.func(remove_rule_func)(rule_name=rule_name_new)
-        check(lambda: client.rss_rules(), rule_name, reverse=True, negate=True)
+        for attempt in eventually():
+            with attempt:
+                assert rule_name not in client.rss_rules()
         client.func(remove_item_func)(item_path=ITEM_ONE)
         assert ITEM_TWO not in client.rss_items()
-        check(lambda: client.rss_items(), ITEM_TWO, reverse=True, negate=True)
+        for attempt in eventually():
+            with attempt:
+                assert ITEM_TWO not in client.rss_items()
 
 
 @pytest.mark.skipif_before_api_version("2.15.4")
@@ -299,9 +313,13 @@ def test_rss_clone_rule(client, clone_rule_func):
     try:
         client.rss_set_rule(rule_name=rule_name, rule_def=rule_def)
         client.func(clone_rule_func)(orig_rule_name=rule_name, new_rule_name=clone_name)
-        check(lambda: client.rss_rules(), clone_name, reverse=True)
+        for attempt in eventually():
+            with attempt:
+                assert clone_name in client.rss_rules()
         # the clone is a copy; the original is left in place
-        check(lambda: client.rss_rules(), rule_name, reverse=True)
+        for attempt in eventually():
+            with attempt:
+                assert rule_name in client.rss_rules()
     finally:
         client.rss_remove_rule(rule_name=rule_name)
         client.rss_remove_rule(rule_name=clone_name)

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -19,9 +19,9 @@ from qbittorrentapi import (
 from qbittorrentapi._version_support import v
 from tests.test_torrents import disable_queueing, enable_queueing
 from tests.utils import (
-    WEBSEED_ACTION_EVERY,
-    WEBSEED_CHECK_TIME,
-    check,
+    WEBSEED_RESEND_EVERY,
+    WEBSEED_TIMEOUT,
+    eventually,
     mkpath,
     retry,
 )
@@ -58,66 +58,68 @@ def test_state_enum(orig_torrent):
     assert orig_torrent.state_enum in TorrentStates
     assert orig_torrent.state_enum is not TorrentStates.UNKNOWN
     orig_torrent.resume()
-    check(
-        lambda: (
-            orig_torrent.sync_local() is None and orig_torrent.state_enum.is_downloading
-        ),
-        True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                orig_torrent.sync_local() is None
+                and orig_torrent.state_enum.is_downloading
+            )
     # simulate an unknown torrent.state
     orig_torrent.state = "gibberish"
     assert orig_torrent.state_enum is TorrentStates.UNKNOWN
     # restore torrent state
     orig_torrent.sync_local()
-    check(lambda: orig_torrent.state_enum.is_downloading, True)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.state_enum.is_downloading is True
 
 
 # test fails on 4.1.0 release
 @pytest.mark.skipif_before_api_version("2.0.1")
 def test_pause_resume(client, new_torrent):
     new_torrent.pause()
-    check(
-        lambda: (
-            client.torrents_info(torrent_hashes=new_torrent.hash)[
-                0
-            ].state_enum.is_paused
-        ),
-        True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                client.torrents_info(torrent_hashes=new_torrent.hash)[
+                    0
+                ].state_enum.is_paused
+                is True
+            )
 
     new_torrent.resume()
-    check(
-        lambda: (
-            client.torrents_info(torrent_hashes=new_torrent.hash)[
-                0
-            ].state_enum.is_paused
-        ),
-        False,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                client.torrents_info(torrent_hashes=new_torrent.hash)[
+                    0
+                ].state_enum.is_paused
+                is False
+            )
 
 
 # test fails on 4.1.0 release
 @pytest.mark.skipif_before_api_version("2.0.1")
 def test_stop_start(client, new_torrent):
     new_torrent.stop()
-    check(
-        lambda: (
-            client.torrents_info(torrent_hashes=new_torrent.hash)[
-                0
-            ].state_enum.is_paused
-        ),
-        True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                client.torrents_info(torrent_hashes=new_torrent.hash)[
+                    0
+                ].state_enum.is_paused
+                is True
+            )
 
     new_torrent.resume()
-    check(
-        lambda: (
-            client.torrents_info(torrent_hashes=new_torrent.hash)[
-                0
-            ].state_enum.is_paused
-        ),
-        False,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                client.torrents_info(torrent_hashes=new_torrent.hash)[
+                    0
+                ].state_enum.is_paused
+                is False
+            )
 
 
 @pytest.mark.parametrize("delete", [True, False, None, 0, 1])
@@ -131,12 +133,9 @@ def test_delete(client_mock, new_torrent, delete):
             "deleteFiles": bool(delete),
         },
     )
-    check(
-        lambda: [t.hash for t in client_mock.torrents_info()],
-        new_torrent.hash,
-        reverse=True,
-        negate=True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert new_torrent.hash not in [t.hash for t in client_mock.torrents_info()]
 
 
 @pytest.mark.parametrize(
@@ -166,22 +165,30 @@ def test_priority(
     current_priority = new_torrent.info.priority
     new_torrent.func(inc_prio_func)()
     sleep(0.25)
-    check(lambda: new_torrent.info.priority < current_priority, True)
+    for attempt in eventually():
+        with attempt:
+            assert new_torrent.info.priority < current_priority
 
     current_priority = new_torrent.info.priority
     new_torrent.func(dec_prio_func)()
     sleep(0.25)
-    check(lambda: new_torrent.info.priority > current_priority, True)
+    for attempt in eventually():
+        with attempt:
+            assert new_torrent.info.priority > current_priority
 
     current_priority = new_torrent.info.priority
     new_torrent.func(top_prio_func)()
     sleep(0.25)
-    check(lambda: new_torrent.info.priority < current_priority, True)
+    for attempt in eventually():
+        with attempt:
+            assert new_torrent.info.priority < current_priority
 
     current_priority = new_torrent.info.priority
     new_torrent.func(bottom_prio_func)()
     sleep(0.25)
-    check(lambda: new_torrent.info.priority > current_priority, True)
+    for attempt in eventually():
+        with attempt:
+            assert new_torrent.info.priority > current_priority
 
 
 @pytest.mark.skipif_before_api_version("2.0.1")
@@ -196,14 +203,24 @@ def test_set_share_limits(orig_torrent, set_share_limits_func):
         share_limit_action="Stop",
         share_limits_mode="MatchAny",
     )
-    check(lambda: orig_torrent.info.max_ratio, 5)
-    check(lambda: orig_torrent.info.max_seeding_time, 100)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.max_ratio == 5
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.max_seeding_time == 100
     if "share_limit_action" in orig_torrent.info:
-        check(lambda: orig_torrent.info.share_limit_action, "Stop")
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.share_limit_action == "Stop"
     if "share_limits_mode" in orig_torrent.info:
-        check(lambda: orig_torrent.info.share_limits_mode, "MatchAny")
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.share_limits_mode == "MatchAny"
     if "max_inactive_seeding_time" in orig_torrent.info:
-        check(lambda: orig_torrent.info.max_inactive_seeding_time, 200)
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.max_inactive_seeding_time == 200
 
 
 @pytest.mark.parametrize(
@@ -212,12 +229,20 @@ def test_set_share_limits(orig_torrent, set_share_limits_func):
 )
 def test_download_limit(orig_torrent, down_limit_func, set_down_limit_func):
     setattr(orig_torrent, down_limit_func, 2048)
-    check(lambda: orig_torrent.func(down_limit_func), 2048)
-    check(lambda: orig_torrent.info.dl_limit, 2048)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.func(down_limit_func) == 2048
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.dl_limit == 2048
 
     orig_torrent.func(set_down_limit_func)(4096)
-    check(lambda: orig_torrent.func(down_limit_func), 4096)
-    check(lambda: orig_torrent.info.dl_limit, 4096)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.func(down_limit_func) == 4096
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.dl_limit == 4096
 
 
 @pytest.mark.parametrize(
@@ -226,12 +251,20 @@ def test_download_limit(orig_torrent, down_limit_func, set_down_limit_func):
 )
 def test_upload_limit(orig_torrent, up_limit_func, set_up_limit_func):
     setattr(orig_torrent, up_limit_func, 2048)
-    check(lambda: orig_torrent.func(up_limit_func), 2048)
-    check(lambda: orig_torrent.info.up_limit, 2048)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.func(up_limit_func) == 2048
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.up_limit == 2048
 
     orig_torrent.func(set_up_limit_func)(4096)
-    check(lambda: orig_torrent.func(up_limit_func), 4096)
-    check(lambda: orig_torrent.info.up_limit, 4096)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.func(up_limit_func) == 4096
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.up_limit == 4096
 
 
 @pytest.mark.skipif_before_api_version("2.0.2")
@@ -240,7 +273,9 @@ def test_set_location(new_torrent, set_loc_func, tmp_path):
     sleep(0.5)
     loc = mkpath(tmp_path, "3")
     new_torrent.func(set_loc_func)(loc)
-    check(lambda: mkpath(new_torrent.info.save_path), mkpath(loc))
+    for attempt in eventually():
+        with attempt:
+            assert mkpath(new_torrent.info.save_path) == mkpath(loc)
 
 
 @pytest.mark.skipif_before_api_version("2.8.4")
@@ -249,7 +284,9 @@ def test_set_save_path(new_torrent, set_save_path_func, tmp_path):
     loc = mkpath(tmp_path, "savepath3")
     new_torrent.func(set_save_path_func)(loc)
     # qBittorrent may return trailing separators depending on version....
-    check(lambda: mkpath(new_torrent.info.save_path), mkpath(loc))
+    for attempt in eventually():
+        with attempt:
+            assert mkpath(new_torrent.info.save_path) == mkpath(loc)
 
 
 @pytest.mark.skipif_before_api_version("2.8.4")
@@ -258,7 +295,9 @@ def test_set_download_path(new_torrent, set_down_path_func, tmp_path):
     loc = mkpath(tmp_path, "downloadpath3")
     new_torrent.func(set_down_path_func)(loc)
     # qBittorrent may return trailing separators depending on version....
-    check(lambda: mkpath(new_torrent.info.download_path), mkpath(loc))
+    for attempt in eventually():
+        with attempt:
+            assert mkpath(new_torrent.info.download_path) == mkpath(loc)
 
 
 @pytest.mark.parametrize("set_cat_func", ["set_category", "setCategory"])
@@ -266,7 +305,9 @@ def test_set_download_path(new_torrent, set_down_path_func, tmp_path):
 def test_set_category(client, orig_torrent, set_cat_func, category):
     client.torrents_create_category(category=category)
     orig_torrent.func(set_cat_func)(category=category)
-    check(lambda: orig_torrent.info.category.replace("+", " "), category, reverse=True)
+    for attempt in eventually():
+        with attempt:
+            assert category in orig_torrent.info.category.replace("+", " ")
     client.torrents_remove_categories(categories=category)
 
 
@@ -276,18 +317,26 @@ def test_set_category(client, orig_torrent, set_cat_func, category):
 def test_set_auto_management(orig_torrent, set_auto_mgmt_func):
     current_setting = orig_torrent.auto_tmm
     orig_torrent.func(set_auto_mgmt_func)(enable=(not current_setting))
-    check(lambda: orig_torrent.info.auto_tmm, not current_setting)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.auto_tmm == (not current_setting)
     orig_torrent.func(set_auto_mgmt_func)(enable=current_setting)
-    check(lambda: orig_torrent.info.auto_tmm, current_setting)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.auto_tmm == current_setting
 
 
 @pytest.mark.parametrize("set_comment_func", ["set_comment", "setComment"])
 @pytest.mark.skipif_before_api_version("2.12.1")
 def test_set_comment(orig_torrent, set_comment_func):
     orig_torrent.func(set_comment_func)(comment="new comment")
-    check(lambda: orig_torrent.info.comment, "new comment")
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.comment == "new comment"
     orig_torrent.func(set_comment_func)(comment="")
-    check(lambda: orig_torrent.info.comment, "")
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.comment == ""
 
 
 @pytest.mark.parametrize(
@@ -296,9 +345,13 @@ def test_set_comment(orig_torrent, set_comment_func):
 def test_toggle_sequential_download(orig_torrent, toggle_seq_down_func):
     current_setting = orig_torrent.seq_dl
     orig_torrent.func(toggle_seq_down_func)()
-    check(lambda: orig_torrent.info.seq_dl, not current_setting)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.seq_dl == (not current_setting)
     orig_torrent.func(toggle_seq_down_func)()
-    check(lambda: orig_torrent.info.seq_dl, current_setting)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.seq_dl == current_setting
 
 
 @pytest.mark.skipif_before_api_version("2.0.2")
@@ -309,7 +362,9 @@ def test_toggle_sequential_download(orig_torrent, toggle_seq_down_func):
 def test_toggle_first_last_piece_priority(orig_torrent, toggle_piece_prio_func):
     current_setting = orig_torrent.f_l_piece_prio
     orig_torrent.func(toggle_piece_prio_func)()
-    check(lambda: orig_torrent.info.f_l_piece_prio, not current_setting)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.f_l_piece_prio == (not current_setting)
 
 
 @pytest.mark.parametrize("set_force_start_func", ["set_force_start", "setForceStart"])
@@ -319,19 +374,17 @@ def test_set_force_start(orig_torrent, set_force_start_func):
 
     try:
         set_force_start(enable=(not current_setting))
-        check(
-            lambda: orig_torrent.info.force_start,
-            not current_setting,
-            action=lambda: set_force_start(enable=(not current_setting)),
-        )
+        for attempt in eventually(
+            resend=lambda: set_force_start(enable=(not current_setting))
+        ):
+            with attempt:
+                assert orig_torrent.info.force_start == (not current_setting)
     finally:
         # leave the torrent as it was found for the tests that follow
         set_force_start(enable=current_setting)
-    check(
-        lambda: orig_torrent.info.force_start,
-        current_setting,
-        action=lambda: set_force_start(enable=current_setting),
-    )
+    for attempt in eventually(resend=lambda: set_force_start(enable=current_setting)):
+        with attempt:
+            assert orig_torrent.info.force_start == current_setting
 
 
 @pytest.mark.parametrize(
@@ -361,7 +414,9 @@ def test_trackers(orig_torrent, trackers):
     assert "num_peers" in orig_torrent.trackers[-1]
 
     orig_torrent.trackers = trackers
-    check(lambda: (t.url for t in orig_torrent.trackers), trackers, reverse=True)
+    for attempt in eventually():
+        with attempt:
+            assert trackers in (t.url for t in orig_torrent.trackers)
 
 
 @pytest.mark.parametrize("add_trackers_func", ["add_trackers", "addTrackers"])
@@ -369,7 +424,9 @@ def test_trackers(orig_torrent, trackers):
 def test_add_tracker(new_torrent, add_trackers_func, trackers):
     new_torrent.func(add_trackers_func)(urls=trackers)
     sleep(0.1)  # try to stop crashing qbittorrent
-    check(lambda: (t.url for t in new_torrent.trackers), trackers, reverse=True)
+    for attempt in eventually():
+        with attempt:
+            assert trackers in (t.url for t in new_torrent.trackers)
 
 
 @pytest.mark.skipif_before_api_version("2.2.0")
@@ -377,13 +434,12 @@ def test_add_tracker(new_torrent, add_trackers_func, trackers):
 def test_edit_tracker(orig_torrent, edit_tracker_func):
     orig_torrent.add_trackers(urls="127.0.1.1")
     orig_torrent.func(edit_tracker_func)(orig_url="127.0.1.1", new_url="127.0.1.2")
-    check(
-        lambda: (t.url for t in orig_torrent.trackers),
-        "127.0.1.1",
-        reverse=True,
-        negate=True,
-    )
-    check(lambda: (t.url for t in orig_torrent.trackers), "127.0.1.2", reverse=True)
+    for attempt in eventually():
+        with attempt:
+            assert "127.0.1.1" not in (t.url for t in orig_torrent.trackers)
+    for attempt in eventually():
+        with attempt:
+            assert "127.0.1.2" in (t.url for t in orig_torrent.trackers)
     orig_torrent.remove_trackers(urls="127.0.1.2")
 
 
@@ -391,21 +447,17 @@ def test_edit_tracker(orig_torrent, edit_tracker_func):
 @pytest.mark.parametrize("remove_trackers_func", ["remove_trackers", "removeTrackers"])
 @pytest.mark.parametrize("trackers", ["127.0.2.2", ["127.0.2.3", "127.0.2.4"]])
 def test_remove_trackers(orig_torrent, remove_trackers_func, trackers):
-    check(
-        lambda: (t.url for t in orig_torrent.trackers),
-        trackers,
-        reverse=True,
-        negate=True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert trackers not in (t.url for t in orig_torrent.trackers)
     orig_torrent.add_trackers(urls=trackers)
-    check(lambda: (t.url for t in orig_torrent.trackers), trackers, reverse=True)
+    for attempt in eventually():
+        with attempt:
+            assert trackers in (t.url for t in orig_torrent.trackers)
     orig_torrent.func(remove_trackers_func)(urls=trackers)
-    check(
-        lambda: (t.url for t in orig_torrent.trackers),
-        trackers,
-        reverse=True,
-        negate=True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert trackers not in (t.url for t in orig_torrent.trackers)
 
 
 def test_webseeds(orig_torrent):
@@ -428,17 +480,13 @@ def test_add_webseed(new_torrent, add_webseeds_func, webseeds):
         new_torrent.func(add_webseeds_func)(urls=webseeds)
 
     add_webseeds()
-    check(
-        lambda: sorted([w.url for w in new_torrent.webseeds]),
-        (webseeds if isinstance(webseeds, list) else [webseeds]),
-        reverse=True,
-        # qBittorrent applies webseed changes on a thread pool and silently
-        # discards any that fail, so re-send until it takes effect. adding a
-        # webseed that is already there is ignored, so this is safe to repeat.
-        action=add_webseeds,
-        check_time=WEBSEED_CHECK_TIME,
-        action_every=WEBSEED_ACTION_EVERY,
-    )
+    for attempt in eventually(
+        timeout=WEBSEED_TIMEOUT, resend=add_webseeds, resend_every=WEBSEED_RESEND_EVERY
+    ):
+        with attempt:
+            assert (webseeds if isinstance(webseeds, list) else [webseeds]) in sorted(
+                [w.url for w in new_torrent.webseeds]
+            )
 
 
 @pytest.mark.skipif_before_api_version("2.11.3")
@@ -469,31 +517,23 @@ def test_edit_webseeds(new_torrent, edit_webseed_func):
             add_orig_url()
 
     add_orig_url()
-    check(
-        urls,
-        orig_url,
-        reverse=True,
-        action=add_orig_url,
-        check_time=WEBSEED_CHECK_TIME,
-        action_every=WEBSEED_ACTION_EVERY,
-    )
+    for attempt in eventually(
+        timeout=WEBSEED_TIMEOUT, resend=add_orig_url, resend_every=WEBSEED_RESEND_EVERY
+    ):
+        with attempt:
+            assert orig_url in urls()
     edit_webseed()
-    check(
-        urls,
-        new_url,
-        reverse=True,
-        action=redo_edit,
-        check_time=WEBSEED_CHECK_TIME,
-        action_every=WEBSEED_ACTION_EVERY,
-    )
+    for attempt in eventually(
+        timeout=WEBSEED_TIMEOUT, resend=redo_edit, resend_every=WEBSEED_RESEND_EVERY
+    ):
+        with attempt:
+            assert new_url in urls()
     # the original must have been replaced rather than added alongside
-    check(
-        lambda: len(new_torrent.webseeds),
-        1,
-        action=redo_edit,
-        check_time=WEBSEED_CHECK_TIME,
-        action_every=WEBSEED_ACTION_EVERY,
-    )
+    for attempt in eventually(
+        timeout=WEBSEED_TIMEOUT, resend=redo_edit, resend_every=WEBSEED_RESEND_EVERY
+    ):
+        with attempt:
+            assert len(new_torrent.webseeds) == 1
 
 
 @pytest.mark.skipif_before_api_version("2.11.3")
@@ -521,23 +561,20 @@ def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
 
     add_webseeds()
     # removing before qBittorrent registers them would silently do nothing
-    check(
-        lambda: [w.url for w in new_torrent.webseeds],
-        all_webseeds,
-        reverse=True,
-        action=add_webseeds,
-        check_time=WEBSEED_CHECK_TIME,
-        action_every=WEBSEED_ACTION_EVERY,
-    )
+    for attempt in eventually(
+        timeout=WEBSEED_TIMEOUT, resend=add_webseeds, resend_every=WEBSEED_RESEND_EVERY
+    ):
+        with attempt:
+            assert all_webseeds in [w.url for w in new_torrent.webseeds]
     remove_webseeds()
     for webseed in webseeds if isinstance(webseeds, list) else [webseeds]:
-        check(
-            lambda: webseed not in {w.url for w in new_torrent.webseeds},
-            True,
-            action=remove_webseeds,
-            check_time=WEBSEED_CHECK_TIME,
-            action_every=WEBSEED_ACTION_EVERY,
-        )
+        for attempt in eventually(
+            timeout=WEBSEED_TIMEOUT,
+            resend=remove_webseeds,
+            resend_every=WEBSEED_RESEND_EVERY,
+        ):
+            with attempt:
+                assert webseed not in {w.url for w in new_torrent.webseeds}
 
 
 def test_files(orig_torrent):
@@ -572,7 +609,9 @@ def test_rename_file(app_version, new_torrent, rename_file_func, name):
     @retry()
     def run_test_old():
         new_torrent.func(rename_file_func)(file_id=0, new_file_name=name)
-        check(lambda: new_torrent.files[0].name, name)
+        for attempt in eventually():
+            with attempt:
+                assert new_torrent.files[0].name == name
 
     run_test_old()
 
@@ -583,7 +622,9 @@ def test_rename_file(app_version, new_torrent, rename_file_func, name):
             curr_name = new_torrent.files[0].name
             new_name = "NEW_" + name
             new_torrent.func(rename_file_func)(old_path=curr_name, new_path=new_name)
-            check(lambda: new_torrent.files[0].name, new_name)
+            for attempt in eventually():
+                with attempt:
+                    assert new_torrent.files[0].name == new_name
 
         run_test_new()
 
@@ -606,21 +647,23 @@ def test_rename_folder(app_version, new_torrent, rename_folder_func, name):
             )
 
             # wait for the folder to be renamed
-            check(
-                lambda: [f.name.split("/")[0] for f in new_torrent.files],
-                new_folder,
-                reverse=True,
-            )
+            for attempt in eventually():
+                with attempt:
+                    assert new_folder in [
+                        f.name.split("/")[0] for f in new_torrent.files
+                    ]
 
             # test rename that new folder
             new_torrent.func(rename_folder_func)(
                 old_path=new_folder,
                 new_path=name,
             )
-            check(
-                lambda: new_torrent.files[0].name.replace("+", " "),
-                name + "/" + orig_file_path,
-            )
+            for attempt in eventually():
+                with attempt:
+                    assert (
+                        new_torrent.files[0].name.replace("+", " ")
+                        == name + "/" + orig_file_path
+                    )
 
     test()
 
@@ -643,13 +686,17 @@ def test_piece_hashes(orig_torrent, piece_hashes_func):
 @pytest.mark.parametrize("file_prio_func", ["file_priority", "filePriority"])
 def test_file_priority(orig_torrent, file_prio_func):
     orig_torrent.func(file_prio_func)(file_ids=0, priority=7)
-    check(lambda: orig_torrent.files[0].priority, 7)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.files[0].priority == 7
 
 
 @pytest.mark.parametrize("name", ["new_name", "new name"])
 def test_rename(new_torrent, name):
     new_torrent.rename(new_name=name)
-    check(lambda: new_torrent.info.name.replace("+", " "), name)
+    for attempt in eventually():
+        with attempt:
+            assert new_torrent.info.name.replace("+", " ") == name
 
 
 @pytest.mark.skipif_before_api_version("2.3.0")
@@ -661,10 +708,14 @@ def test_rename(new_torrent, name):
 def test_add_remove_tags(client, orig_torrent, add_tags_func, remove_tags_func, tags):
     try:
         orig_torrent.func(add_tags_func)(tags=tags)
-        check(lambda: orig_torrent.info.tags, tags, reverse=True)
+        for attempt in eventually():
+            with attempt:
+                assert tags in orig_torrent.info.tags
 
         orig_torrent.func(remove_tags_func)(tags=tags)
-        check(lambda: orig_torrent.info.tags, tags, reverse=True, negate=True)
+        for attempt in eventually():
+            with attempt:
+                assert tags not in orig_torrent.info.tags
     finally:
         client.torrents_delete_tags(tags=tags)
 
@@ -676,6 +727,8 @@ def test_set_tags(client, orig_torrent, set_tags_func, tags):
     try:
         orig_torrent.add_tags(tags="extra-tag")
         orig_torrent.func(set_tags_func)(tags=tags)
-        check(lambda: orig_torrent.info.tags, tags, reverse=True)
+        for attempt in eventually():
+            with attempt:
+                assert tags in orig_torrent.info.tags
     finally:
         client.torrents_delete_tags(tags=tags)

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -21,19 +21,11 @@ from tests.test_torrents import disable_queueing, enable_queueing
 from tests.utils import (
     WEBSEED_RESEND_EVERY,
     WEBSEED_TIMEOUT,
+    as_list,
     eventually,
     mkpath,
     retry,
 )
-
-
-def as_list(value):
-    """
-    Normalise a parameter given as either a single string or a list of them.
-
-    Several tests are parametrized both ways to prove the endpoint accepts each.
-    """
-    return [value] if isinstance(value, str) else list(value)
 
 
 def test_info(orig_torrent, monkeypatch):

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -27,6 +27,15 @@ from tests.utils import (
 )
 
 
+def as_list(value):
+    """
+    Normalise a parameter given as either a single string or a list of them.
+
+    Several tests are parametrized both ways to prove the endpoint accepts each.
+    """
+    return [value] if isinstance(value, str) else list(value)
+
+
 def test_info(orig_torrent, monkeypatch):
     assert orig_torrent.info.hash == orig_torrent.hash
     # mimic <=v2.0.1 where torrents_info() doesn't support hash arg
@@ -416,7 +425,7 @@ def test_trackers(orig_torrent, trackers):
     orig_torrent.trackers = trackers
     for attempt in eventually():
         with attempt:
-            assert trackers in (t.url for t in orig_torrent.trackers)
+            assert set(as_list(trackers)) <= {t.url for t in orig_torrent.trackers}
 
 
 @pytest.mark.parametrize("add_trackers_func", ["add_trackers", "addTrackers"])
@@ -426,7 +435,7 @@ def test_add_tracker(new_torrent, add_trackers_func, trackers):
     sleep(0.1)  # try to stop crashing qbittorrent
     for attempt in eventually():
         with attempt:
-            assert trackers in (t.url for t in new_torrent.trackers)
+            assert set(as_list(trackers)) <= {t.url for t in new_torrent.trackers}
 
 
 @pytest.mark.skipif_before_api_version("2.2.0")
@@ -449,15 +458,19 @@ def test_edit_tracker(orig_torrent, edit_tracker_func):
 def test_remove_trackers(orig_torrent, remove_trackers_func, trackers):
     for attempt in eventually():
         with attempt:
-            assert trackers not in (t.url for t in orig_torrent.trackers)
+            assert set(as_list(trackers)).isdisjoint(
+                {t.url for t in orig_torrent.trackers}
+            )
     orig_torrent.add_trackers(urls=trackers)
     for attempt in eventually():
         with attempt:
-            assert trackers in (t.url for t in orig_torrent.trackers)
+            assert set(as_list(trackers)) <= {t.url for t in orig_torrent.trackers}
     orig_torrent.func(remove_trackers_func)(urls=trackers)
     for attempt in eventually():
         with attempt:
-            assert trackers not in (t.url for t in orig_torrent.trackers)
+            assert set(as_list(trackers)).isdisjoint(
+                {t.url for t in orig_torrent.trackers}
+            )
 
 
 def test_webseeds(orig_torrent):
@@ -484,9 +497,7 @@ def test_add_webseed(new_torrent, add_webseeds_func, webseeds):
         timeout=WEBSEED_TIMEOUT, resend=add_webseeds, resend_every=WEBSEED_RESEND_EVERY
     ):
         with attempt:
-            assert (webseeds if isinstance(webseeds, list) else [webseeds]) in sorted(
-                [w.url for w in new_torrent.webseeds]
-            )
+            assert set(as_list(webseeds)) <= {w.url for w in new_torrent.webseeds}
 
 
 @pytest.mark.skipif_before_api_version("2.11.3")
@@ -565,7 +576,7 @@ def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
         timeout=WEBSEED_TIMEOUT, resend=add_webseeds, resend_every=WEBSEED_RESEND_EVERY
     ):
         with attempt:
-            assert all_webseeds in [w.url for w in new_torrent.webseeds]
+            assert set(all_webseeds) <= {w.url for w in new_torrent.webseeds}
     remove_webseeds()
     for webseed in webseeds if isinstance(webseeds, list) else [webseeds]:
         for attempt in eventually(
@@ -710,12 +721,12 @@ def test_add_remove_tags(client, orig_torrent, add_tags_func, remove_tags_func, 
         orig_torrent.func(add_tags_func)(tags=tags)
         for attempt in eventually():
             with attempt:
-                assert tags in orig_torrent.info.tags
+                assert all(tag in orig_torrent.info.tags for tag in as_list(tags))
 
         orig_torrent.func(remove_tags_func)(tags=tags)
         for attempt in eventually():
             with attempt:
-                assert tags not in orig_torrent.info.tags
+                assert all(tag not in orig_torrent.info.tags for tag in as_list(tags))
     finally:
         client.torrents_delete_tags(tags=tags)
 
@@ -729,6 +740,6 @@ def test_set_tags(client, orig_torrent, set_tags_func, tags):
         orig_torrent.func(set_tags_func)(tags=tags)
         for attempt in eventually():
             with attempt:
-                assert tags in orig_torrent.info.tags
+                assert all(tag in orig_torrent.info.tags for tag in as_list(tags))
     finally:
         client.torrents_delete_tags(tags=tags)

--- a/tests/test_torrentcreator.py
+++ b/tests/test_torrentcreator.py
@@ -11,7 +11,7 @@ from qbittorrentapi.torrentcreator import (
     TorrentCreatorTaskStatus,
     TorrentCreatorTaskStatusList,
 )
-from tests.utils import check
+from tests.utils import eventually
 
 
 @pytest.fixture
@@ -82,7 +82,9 @@ def test_status_enum():
     "torrent_file_func", ["torrentcreator_torrent_file", "torrentcreator.torrent_file"]
 )
 def test_torrent_file(client, torrent_file_func, task):
-    check(lambda: TaskStatus(task.status().status), [TaskStatus.FINISHED])
+    for attempt in eventually():
+        with attempt:
+            assert TaskStatus(task.status().status) == TaskStatus.FINISHED
     assert isinstance(client.func(torrent_file_func)(task_id=task.task_id), bytes)
     assert isinstance(task.torrent_file(), bytes)
     assert isinstance(task.torrentFile(), bytes)

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -48,8 +48,8 @@ from tests.conftest import (
     new_torrent_standalone,
 )
 from tests.utils import (
-    WEBSEED_ACTION_EVERY,
-    WEBSEED_CHECK_TIME,
+    WEBSEED_RESEND_EVERY,
+    WEBSEED_TIMEOUT,
     check,
     mkpath,
     retry,
@@ -445,8 +445,8 @@ def test_add_webseeds(client, new_torrent, add_webseeds_func, webseeds):
         reverse=True,
         # see tests/test_torrent.py::test_add_webseed for why this is re-sent
         action=add_webseeds,
-        check_time=WEBSEED_CHECK_TIME,
-        action_every=WEBSEED_ACTION_EVERY,
+        check_time=WEBSEED_TIMEOUT,
+        action_every=WEBSEED_RESEND_EVERY,
     )
 
 
@@ -481,8 +481,8 @@ def test_edit_webseeds(client, new_torrent, edit_webseed_func):
         orig_url,
         reverse=True,
         action=add_orig_url,
-        check_time=WEBSEED_CHECK_TIME,
-        action_every=WEBSEED_ACTION_EVERY,
+        check_time=WEBSEED_TIMEOUT,
+        action_every=WEBSEED_RESEND_EVERY,
     )
     edit_webseed()
     check(
@@ -490,15 +490,15 @@ def test_edit_webseeds(client, new_torrent, edit_webseed_func):
         new_url,
         reverse=True,
         action=redo_edit,
-        check_time=WEBSEED_CHECK_TIME,
-        action_every=WEBSEED_ACTION_EVERY,
+        check_time=WEBSEED_TIMEOUT,
+        action_every=WEBSEED_RESEND_EVERY,
     )
     check(
         lambda: len(new_torrent.webseeds),
         1,
         action=redo_edit,
-        check_time=WEBSEED_CHECK_TIME,
-        action_every=WEBSEED_ACTION_EVERY,
+        check_time=WEBSEED_TIMEOUT,
+        action_every=WEBSEED_RESEND_EVERY,
     )
 
 
@@ -526,8 +526,8 @@ def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
         all_webseeds,
         reverse=True,
         action=add_webseeds,
-        check_time=WEBSEED_CHECK_TIME,
-        action_every=WEBSEED_ACTION_EVERY,
+        check_time=WEBSEED_TIMEOUT,
+        action_every=WEBSEED_RESEND_EVERY,
     )
     remove_webseeds()
     for webseed in webseeds if isinstance(webseeds, list) else [webseeds]:
@@ -535,8 +535,8 @@ def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
             lambda: webseed not in {w.url for w in new_torrent.webseeds},
             True,
             action=remove_webseeds,
-            check_time=WEBSEED_CHECK_TIME,
-            action_every=WEBSEED_ACTION_EVERY,
+            check_time=WEBSEED_TIMEOUT,
+            action_every=WEBSEED_RESEND_EVERY,
         )
 
 

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -50,7 +50,8 @@ from tests.conftest import (
 from tests.utils import (
     WEBSEED_RESEND_EVERY,
     WEBSEED_TIMEOUT,
-    check,
+    as_list,
+    eventually,
     mkpath,
     retry,
 )
@@ -195,12 +196,9 @@ def test_add_delete(
         """Delete through ``delete_func`` so both namespaces are exercised."""
         client.func(delete_func)(delete_files=True, torrent_hashes=TORRENT1_HASH)
         client.func(delete_func)(delete_files=True, torrent_hashes=TORRENT2_HASH)
-        check(
-            lambda: [t.hash for t in client.torrents_info()],
-            TORRENT2_HASH,
-            reverse=True,
-            negate=True,
-        )
+        for attempt in eventually():
+            with attempt:
+                assert TORRENT2_HASH not in [t.hash for t in client.torrents_info()]
 
     @retry()
     def add_and_delete():
@@ -223,11 +221,9 @@ def test_add_delete(
                     assert resp == "Ok."
 
             for torrent_hash in expected_hashes:
-                check(
-                    lambda: [t.hash for t in client.torrents_info()],
-                    torrent_hash,
-                    reverse=True,
-                )
+                for attempt in eventually():
+                    with attempt:
+                        assert torrent_hash in [t.hash for t in client.torrents_info()]
         finally:
             delete_test_torrents()
 
@@ -316,31 +312,46 @@ def test_add_options(client, api_version, keep_root_folder, content_layout, tmp_
         )
 
         with new_torrent as torrent:
-            check(lambda: torrent.info.category, "test_category")
-            check(
-                lambda: torrent.info.state,
-                # qBittorrent v5 renamed the paused states to stopped
-                ("pausedDL", "stoppedDL"),
-                any=True,
-            )
-            check(
-                lambda: mkpath(torrent.info.save_path),
-                mkpath(tmp_path, "test_download"),
-            )
-            check(lambda: torrent.info.up_limit, 1024)
-            check(lambda: torrent.info.dl_limit, 2048)
-            check(lambda: torrent.info.seq_dl, True)
+            for attempt in eventually():
+                with attempt:
+                    assert torrent.info.category == "test_category"
+            for attempt in eventually():
+                with attempt:
+                    assert torrent.info.state in ("pausedDL", "stoppedDL")
+            for attempt in eventually():
+                with attempt:
+                    assert mkpath(torrent.info.save_path) == mkpath(
+                        tmp_path, "test_download"
+                    )
+            for attempt in eventually():
+                with attempt:
+                    assert torrent.info.up_limit == 1024
+            for attempt in eventually():
+                with attempt:
+                    assert torrent.info.dl_limit == 2048
+            for attempt in eventually():
+                with attempt:
+                    assert torrent.info.seq_dl is True
             if v(api_version) >= v("2.0.1"):
-                check(lambda: torrent.info.f_l_piece_prio, True)
+                for attempt in eventually():
+                    with attempt:
+                        assert torrent.info.f_l_piece_prio is True
             if content_layout is None:
-                check(
-                    lambda: torrent.files[0]["name"].startswith("root_folder"),
-                    keep_root_folder in {True, None},
-                )
-            check(lambda: torrent.info.name, "this is a new name for the torrent")
-            check(lambda: torrent.info.auto_tmm, False)
+                for attempt in eventually():
+                    with attempt:
+                        assert torrent.files[0]["name"].startswith("root_folder") == (
+                            keep_root_folder in {True, None}
+                        )
+            for attempt in eventually():
+                with attempt:
+                    assert torrent.info.name == "this is a new name for the torrent"
+            for attempt in eventually():
+                with attempt:
+                    assert torrent.info.auto_tmm is False
             if v(api_version) >= v("2.6.2"):
-                check(lambda: torrent.info.tags, "option-tag")
+                for attempt in eventually():
+                    with attempt:
+                        assert torrent.info.tags == "option-tag"
 
             if v(api_version) >= v("2.7"):
                 # after web api v2.7...root dir is driven by content_layout
@@ -354,14 +365,20 @@ def test_add_options(client, api_version, keep_root_folder, content_layout, tmp_
                     should_root_dir_exists = content_layout in {"Original", "Subfolder"}
                 else:
                     should_root_dir_exists = keep_root_folder in {None, True}
-            check(
-                lambda: any(f["name"].startswith("root_folder") for f in torrent.files),
-                should_root_dir_exists,
-            )
+            for attempt in eventually():
+                with attempt:
+                    assert (
+                        any(f["name"].startswith("root_folder") for f in torrent.files)
+                        == should_root_dir_exists
+                    )
 
             if v(api_version) >= v("2.8.1"):
-                check(lambda: torrent.info.ratio_limit, 2)
-                check(lambda: torrent.info.seeding_time_limit, 120)
+                for attempt in eventually():
+                    with attempt:
+                        assert torrent.info.ratio_limit == 2
+                for attempt in eventually():
+                    with attempt:
+                        assert torrent.info.seeding_time_limit == 120
 
     do_test()
 
@@ -384,11 +401,13 @@ def test_torrents_add_download_path(client, use_download_path, tmp_path):
 
     with new_torrent as torrent:
         if use_download_path is False:
-            check(
-                lambda: mkpath(torrent.info.download_path), download_path, negate=True
-            )
+            for attempt in eventually():
+                with attempt:
+                    assert mkpath(torrent.info.download_path) != download_path
         else:
-            check(lambda: mkpath(torrent.info.download_path), download_path)
+            for attempt in eventually():
+                with attempt:
+                    assert mkpath(torrent.info.download_path) == download_path
 
 
 @pytest.mark.skipif_before_api_version("2.9.3")
@@ -439,15 +458,11 @@ def test_add_webseeds(client, new_torrent, add_webseeds_func, webseeds):
         client.func(add_webseeds_func)(torrent_hash=new_torrent.hash, urls=webseeds)
 
     add_webseeds()
-    check(
-        lambda: sorted([w.url for w in new_torrent.webseeds]),
-        (webseeds if isinstance(webseeds, list) else [webseeds]),
-        reverse=True,
-        # see tests/test_torrent.py::test_add_webseed for why this is re-sent
-        action=add_webseeds,
-        check_time=WEBSEED_TIMEOUT,
-        action_every=WEBSEED_RESEND_EVERY,
-    )
+    for attempt in eventually(
+        timeout=WEBSEED_TIMEOUT, resend=add_webseeds, resend_every=WEBSEED_RESEND_EVERY
+    ):
+        with attempt:
+            assert set(as_list(webseeds)) <= {w.url for w in new_torrent.webseeds}
 
 
 @pytest.mark.skipif_before_api_version("2.11.3")
@@ -476,30 +491,22 @@ def test_edit_webseeds(client, new_torrent, edit_webseed_func):
             add_orig_url()
 
     add_orig_url()
-    check(
-        urls,
-        orig_url,
-        reverse=True,
-        action=add_orig_url,
-        check_time=WEBSEED_TIMEOUT,
-        action_every=WEBSEED_RESEND_EVERY,
-    )
+    for attempt in eventually(
+        timeout=WEBSEED_TIMEOUT, resend=add_orig_url, resend_every=WEBSEED_RESEND_EVERY
+    ):
+        with attempt:
+            assert orig_url in urls()
     edit_webseed()
-    check(
-        urls,
-        new_url,
-        reverse=True,
-        action=redo_edit,
-        check_time=WEBSEED_TIMEOUT,
-        action_every=WEBSEED_RESEND_EVERY,
-    )
-    check(
-        lambda: len(new_torrent.webseeds),
-        1,
-        action=redo_edit,
-        check_time=WEBSEED_TIMEOUT,
-        action_every=WEBSEED_RESEND_EVERY,
-    )
+    for attempt in eventually(
+        timeout=WEBSEED_TIMEOUT, resend=redo_edit, resend_every=WEBSEED_RESEND_EVERY
+    ):
+        with attempt:
+            assert new_url in urls()
+    for attempt in eventually(
+        timeout=WEBSEED_TIMEOUT, resend=redo_edit, resend_every=WEBSEED_RESEND_EVERY
+    ):
+        with attempt:
+            assert len(new_torrent.webseeds) == 1
 
 
 @pytest.mark.skipif_before_api_version("2.11.3")
@@ -521,23 +528,20 @@ def test_remove_webseeds(client, new_torrent, remove_webseeds_func, webseeds):
 
     add_webseeds()
     # removing before qBittorrent registers them would silently do nothing
-    check(
-        lambda: [w.url for w in new_torrent.webseeds],
-        all_webseeds,
-        reverse=True,
-        action=add_webseeds,
-        check_time=WEBSEED_TIMEOUT,
-        action_every=WEBSEED_RESEND_EVERY,
-    )
+    for attempt in eventually(
+        timeout=WEBSEED_TIMEOUT, resend=add_webseeds, resend_every=WEBSEED_RESEND_EVERY
+    ):
+        with attempt:
+            assert set(all_webseeds) <= {w.url for w in new_torrent.webseeds}
     remove_webseeds()
     for webseed in webseeds if isinstance(webseeds, list) else [webseeds]:
-        check(
-            lambda: webseed not in {w.url for w in new_torrent.webseeds},
-            True,
-            action=remove_webseeds,
-            check_time=WEBSEED_TIMEOUT,
-            action_every=WEBSEED_RESEND_EVERY,
-        )
+        for attempt in eventually(
+            timeout=WEBSEED_TIMEOUT,
+            resend=remove_webseeds,
+            resend_every=WEBSEED_RESEND_EVERY,
+        ):
+            with attempt:
+                assert webseed not in {w.url for w in new_torrent.webseeds}
 
 
 @pytest.mark.parametrize("files_func", ["torrents_files", "torrents.files"])
@@ -679,7 +683,9 @@ def test_piece_hashes_slice(client, orig_torrent, piece_hashes_func):
 )
 def test_add_trackers(client, trackers, new_torrent, add_trackers_func):
     client.func(add_trackers_func)(torrent_hash=new_torrent.hash, urls=trackers)
-    check(lambda: (t.url for t in new_torrent.trackers), trackers, reverse=True)
+    for attempt in eventually():
+        with attempt:
+            assert set(as_list(trackers)) <= {t.url for t in new_torrent.trackers}
 
 
 @pytest.mark.skipif_before_api_version("2.2.0")
@@ -693,7 +699,9 @@ def test_edit_tracker(client, orig_torrent, edit_trackers_func):
         original_url="127.1.0.1",
         new_url="127.1.0.2",
     )
-    check(lambda: (t.url for t in orig_torrent.trackers), "127.1.0.2", reverse=True)
+    for attempt in eventually():
+        with attempt:
+            assert "127.1.0.2" in (t.url for t in orig_torrent.trackers)
     client.torrents_remove_trackers(torrent_hash=orig_torrent.hash, urls="127.1.0.2")
 
 
@@ -711,12 +719,11 @@ def test_edit_tracker(client, orig_torrent, edit_trackers_func):
 def test_remove_trackers(client, trackers, orig_torrent, remove_trackers_func):
     orig_torrent.add_trackers(trackers)
     client.func(remove_trackers_func)(torrent_hash=orig_torrent.hash, urls=trackers)
-    check(
-        lambda: (t.url for t in orig_torrent.trackers),
-        trackers,
-        reverse=True,
-        negate=True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert set(as_list(trackers)).isdisjoint(
+                {t.url for t in orig_torrent.trackers}
+            )
 
 
 @pytest.mark.parametrize(
@@ -724,16 +731,22 @@ def test_remove_trackers(client, trackers, orig_torrent, remove_trackers_func):
 )
 def test_file_priority(client, orig_torrent, file_prio_func):
     client.func(file_prio_func)(torrent_hash=orig_torrent.hash, file_ids=0, priority=6)
-    check(lambda: orig_torrent.files[0].priority, 6)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.files[0].priority == 6
     client.func(file_prio_func)(torrent_hash=orig_torrent.hash, file_ids=0, priority=7)
-    check(lambda: orig_torrent.files[0].priority, 7)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.files[0].priority == 7
 
 
 @pytest.mark.parametrize("new_name", ["new name 2", "new_name_2"])
 @pytest.mark.parametrize("rename_func", ["torrents_rename", "torrents.rename"])
 def test_rename(client, new_torrent, new_name, rename_func):
     client.func(rename_func)(torrent_hash=new_torrent.hash, new_torrent_name=new_name)
-    check(lambda: new_torrent.info.name.replace("+", " "), new_name)
+    for attempt in eventually():
+        with attempt:
+            assert new_torrent.info.name.replace("+", " ") == new_name
 
 
 @pytest.mark.skipif_before_api_version("2.4.0")
@@ -753,7 +766,9 @@ def test_rename_file(
         client.func(rename_file_func)(
             torrent_hash=new_torrent.hash, file_id=0, new_file_name=new_name
         )
-        check(lambda: new_torrent.files[0].name.replace("+", " "), new_name)
+        for attempt in eventually():
+            with attempt:
+                assert new_torrent.files[0].name.replace("+", " ") == new_name
         # test invalid file ID is rejected
         with pytest.raises(Conflict409Error):
             client.func(rename_file_func)(
@@ -766,7 +781,9 @@ def test_rename_file(
             old_path=new_torrent.files[0].name,
             new_path=new_new_name,
         )
-        check(lambda: new_torrent.files[0].name.replace("+", " "), new_new_name)
+        for attempt in eventually():
+            with attempt:
+                assert new_torrent.files[0].name.replace("+", " ") == new_new_name
         # test invalid old_path is rejected
         with pytest.raises(Conflict409Error):
             client.func(rename_file_func)(
@@ -795,11 +812,11 @@ def test_rename_folder(client, app_version, new_torrent, new_name, rename_folder
             )
 
             # wait for the folder to be renamed
-            check(
-                lambda: [f.name.split("/")[0] for f in new_torrent.files],
-                new_folder,
-                reverse=True,
-            )
+            for attempt in eventually():
+                with attempt:
+                    assert new_folder in [
+                        f.name.split("/")[0] for f in new_torrent.files
+                    ]
 
             # test rename that new folder
             client.func(rename_folder_func)(
@@ -807,10 +824,12 @@ def test_rename_folder(client, app_version, new_torrent, new_name, rename_folder
                 old_path=new_folder,
                 new_path=new_name,
             )
-            check(
-                lambda: new_torrent.files[0].name.replace("+", " "),
-                new_name + "/" + orig_file_path,
-            )
+            for attempt in eventually():
+                with attempt:
+                    assert (
+                        new_torrent.files[0].name.replace("+", " ")
+                        == new_name + "/" + orig_file_path
+                    )
         elif v(app_version) >= v("v4.3.2"):
             with pytest.raises(NotImplementedError):
                 client.func(rename_folder_func)()
@@ -884,41 +903,43 @@ def test_torrents_info_tag(client, new_torrent, info_func):
 )
 def test_stop_start(client, new_torrent, stop_func, start_func):
     client.func(stop_func)(torrent_hashes=new_torrent.hash)
-    check(
-        lambda: (
-            client.torrents_info(torrent_hashes=new_torrent.hash)[
-                0
-            ].state_enum.is_paused
-        ),
-        True,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                client.torrents_info(torrent_hashes=new_torrent.hash)[
+                    0
+                ].state_enum.is_paused
+                is True
+            )
 
     client.func(start_func)(torrent_hashes=new_torrent.hash)
-    check(
-        lambda: (
-            client.torrents_info(torrent_hashes=new_torrent.hash)[
-                0
-            ].state_enum.is_paused
-        ),
-        False,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                client.torrents_info(torrent_hashes=new_torrent.hash)[
+                    0
+                ].state_enum.is_paused
+                is False
+            )
 
 
 def test_action_for_all_torrents(client):
     client.torrents.resume.all()
     for torrent in client.torrents.info():
-        check(
-            lambda: client.torrents_info(torrent_hashes=torrent.hash)[0].state,
-            {"pausedDL", "stoppedDL"},
-            negate=True,
-        )
+        for attempt in eventually():
+            with attempt:
+                assert client.torrents_info(torrent_hashes=torrent.hash)[
+                    0
+                ].state not in {"pausedDL", "stoppedDL"}
     client.torrents.pause.all()
     for torrent in client.torrents.info():
-        check(
-            lambda: client.torrents_info(torrent_hashes=torrent.hash)[0].state,
-            {"stalledDL", "pausedDL", "stoppedDL"},
-            any=True,
-        )
+        for attempt in eventually():
+            with attempt:
+                assert client.torrents_info(torrent_hashes=torrent.hash)[0].state in {
+                    "stalledDL",
+                    "pausedDL",
+                    "stoppedDL",
+                }
 
 
 @pytest.mark.parametrize("recheck_func", ["torrents_recheck", "torrents.recheck"])
@@ -989,22 +1010,30 @@ def test_priority(
     @retry()
     def test1(current_priority):
         client.func(inc_prio_func)(torrent_hashes=new_torrent.hash)
-        check(lambda: new_torrent.info.priority < current_priority, True)
+        for attempt in eventually():
+            with attempt:
+                assert new_torrent.info.priority < current_priority
 
     @retry()
     def test2(current_priority):
         client.func(dec_prio_func)(torrent_hashes=new_torrent.hash)
-        check(lambda: new_torrent.info.priority > current_priority, True)
+        for attempt in eventually():
+            with attempt:
+                assert new_torrent.info.priority > current_priority
 
     @retry()
     def test3(current_priority):
         client.func(top_prio_func)(torrent_hashes=new_torrent.hash)
-        check(lambda: new_torrent.info.priority < current_priority, True)
+        for attempt in eventually():
+            with attempt:
+                assert new_torrent.info.priority < current_priority
 
     @retry()
     def test4(current_priority):
         client.func(bottom_prio_func)(torrent_hashes=new_torrent.hash)
-        check(lambda: new_torrent.info.priority > current_priority, True)
+        for attempt in eventually():
+            with attempt:
+                assert new_torrent.info.priority > current_priority
 
     test1(current_priority=new_torrent.info.priority)
     test2(current_priority=new_torrent.info.priority)
@@ -1031,23 +1060,27 @@ def test_download_limit(client, orig_torrent, set_down_limit_func, down_limit_fu
         client.func(down_limit_func)(torrent_hashes=orig_torrent.hash),
         TorrentLimitsDictionary,
     )
-    check(
-        lambda: client.func(down_limit_func)(torrent_hashes=orig_torrent.hash)[
-            orig_torrent.hash
-        ],
-        100,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                client.func(down_limit_func)(torrent_hashes=orig_torrent.hash)[
+                    orig_torrent.hash
+                ]
+                == 100
+            )
 
     # reset download limit
     client.func(set_down_limit_func)(
         torrent_hashes=orig_torrent.hash, limit=orig_download_limit
     )
-    check(
-        lambda: client.func(down_limit_func)(torrent_hashes=orig_torrent.hash)[
-            orig_torrent.hash
-        ],
-        orig_download_limit,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                client.func(down_limit_func)(torrent_hashes=orig_torrent.hash)[
+                    orig_torrent.hash
+                ]
+                == orig_download_limit
+            )
 
 
 @pytest.mark.parametrize(
@@ -1069,23 +1102,27 @@ def test_upload_limit(client, orig_torrent, set_up_limit_func, up_limit_func):
         client.func(up_limit_func)(torrent_hashes=orig_torrent.hash),
         TorrentLimitsDictionary,
     )
-    check(
-        lambda: client.func(up_limit_func)(torrent_hashes=orig_torrent.hash)[
-            orig_torrent.hash
-        ],
-        100,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                client.func(up_limit_func)(torrent_hashes=orig_torrent.hash)[
+                    orig_torrent.hash
+                ]
+                == 100
+            )
 
     # reset upload limit
     client.func(set_up_limit_func)(
         torrent_hashes=orig_torrent.hash, limit=orig_upload_limit
     )
-    check(
-        lambda: client.func(up_limit_func)(torrent_hashes=orig_torrent.hash)[
-            orig_torrent.hash
-        ],
-        orig_upload_limit,
-    )
+    for attempt in eventually():
+        with attempt:
+            assert (
+                client.func(up_limit_func)(torrent_hashes=orig_torrent.hash)[
+                    orig_torrent.hash
+                ]
+                == orig_upload_limit
+            )
 
 
 @pytest.mark.skipif_before_api_version("2.0.1")
@@ -1107,14 +1144,24 @@ def test_set_share_limits(client, orig_torrent, set_share_limits_func):
         share_limits_mode="MatchAny",
         torrent_hashes=orig_torrent.hash,
     )
-    check(lambda: orig_torrent.info.max_ratio, 2)
-    check(lambda: orig_torrent.info.max_seeding_time, 5)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.max_ratio == 2
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.max_seeding_time == 5
     if "share_limit_action" in orig_torrent.info:
-        check(lambda: orig_torrent.info.share_limit_action, "Stop")
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.share_limit_action == "Stop"
     if "share_limits_mode" in orig_torrent.info:
-        check(lambda: orig_torrent.info.share_limits_mode, "MatchAny")
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.share_limits_mode == "MatchAny"
     if "max_inactive_seeding_time" in orig_torrent.info:
-        check(lambda: orig_torrent.info.max_inactive_seeding_time, 8)
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.max_inactive_seeding_time == 8
 
     client.func(set_share_limits_func)(
         ratio_limit=3,
@@ -1124,14 +1171,24 @@ def test_set_share_limits(client, orig_torrent, set_share_limits_func):
         share_limits_mode="MatchAll",
         torrent_hashes=orig_torrent.hash,
     )
-    check(lambda: orig_torrent.info.max_ratio, 3)
-    check(lambda: orig_torrent.info.max_seeding_time, 6)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.max_ratio == 3
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.max_seeding_time == 6
     if "share_limit_action" in orig_torrent.info:
-        check(lambda: orig_torrent.info.share_limit_action, "Remove")
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.share_limit_action == "Remove"
     if "share_limits_mode" in orig_torrent.info:
-        check(lambda: orig_torrent.info.share_limits_mode, "MatchAll")
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.share_limits_mode == "MatchAll"
     if "max_inactive_seeding_time" in orig_torrent.info:
-        check(lambda: orig_torrent.info.max_inactive_seeding_time, 9)
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.max_inactive_seeding_time == 9
 
 
 @pytest.mark.skipif_before_api_version("2.0.2")
@@ -1154,7 +1211,9 @@ def test_set_location(client, app_version, new_torrent, set_loc_func, tmp_path):
     loc = mkpath(tmp_path, "1")
     client.func(set_loc_func)(location=loc, torrent_hashes=new_torrent.hash)
     # qBittorrent may return trailing separators depending on version....
-    check(lambda: mkpath(new_torrent.info.save_path), loc, any=True)
+    for attempt in eventually():
+        with attempt:
+            assert mkpath(new_torrent.info.save_path) == loc
 
 
 @pytest.mark.skipif_before_api_version("2.8.4")
@@ -1180,7 +1239,9 @@ def test_set_save_path(client, new_torrent, set_save_path_func, tmp_path):
     loc = mkpath(tmp_path, "savepath1")
     client.func(set_save_path_func)(save_path=loc, torrent_hashes=new_torrent.hash)
     # qBittorrent may return trailing separators depending on version....
-    check(lambda: mkpath(new_torrent.info.save_path), loc, any=True)
+    for attempt in eventually():
+        with attempt:
+            assert mkpath(new_torrent.info.save_path) == loc
 
 
 @pytest.mark.skipif_before_api_version("2.8.4")
@@ -1206,7 +1267,9 @@ def test_set_download_path(client, new_torrent, set_down_path_func, tmp_path):
     loc = mkpath(tmp_path, "savepath1")
     client.func(set_down_path_func)(download_path=loc, torrent_hashes=new_torrent.hash)
     # qBittorrent may return trailing separators depending on version....
-    check(lambda: mkpath(new_torrent.info.download_path), loc, any=True)
+    for attempt in eventually():
+        with attempt:
+            assert mkpath(new_torrent.info.download_path) == loc
 
 
 @pytest.mark.parametrize(
@@ -1228,7 +1291,9 @@ def test_set_category(client, orig_torrent, set_cat_func, name):
     client.torrents_create_category(name=name)
     try:
         client.func(set_cat_func)(category=name, torrent_hashes=orig_torrent.hash)
-        check(lambda: orig_torrent.info.category.replace("+", " "), name)
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.category.replace("+", " ") == name
     finally:
         client.torrents_remove_categories(categories=name)
 
@@ -1247,7 +1312,9 @@ def test_torrents_set_auto_management(client, orig_torrent, set_auto_mgmt_func):
     client.func(set_auto_mgmt_func)(
         enable=(not current_setting), torrent_hashes=orig_torrent.hash
     )
-    check(lambda: orig_torrent.info.auto_tmm, (not current_setting))
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.auto_tmm == (not current_setting)
     client.func(set_auto_mgmt_func)(
         enable=False, torrent_hashes=orig_torrent.hash
     )  # leave on False
@@ -1267,9 +1334,13 @@ def test_torrents_set_comment(client, orig_torrent, set_comment_func):
     client.func(set_comment_func)(
         comment="new comment", torrent_hashes=orig_torrent.hash
     )
-    check(lambda: orig_torrent.info.comment, "new comment")
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.comment == "new comment"
     client.func(set_comment_func)(comment="", torrent_hashes=orig_torrent.hash)
-    check(lambda: orig_torrent.info.comment, "")
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.comment == ""
 
 
 @pytest.mark.parametrize(
@@ -1284,7 +1355,9 @@ def test_torrents_set_comment(client, orig_torrent, set_comment_func):
 def test_toggle_sequential_download(client, orig_torrent, toggle_seq_down_func):
     current_setting = orig_torrent.info.seq_dl
     client.func(toggle_seq_down_func)(torrent_hashes=orig_torrent.hash)
-    check(lambda: orig_torrent.info.seq_dl, not current_setting)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.seq_dl == (not current_setting)
 
 
 @pytest.mark.skipif_before_api_version("2.0.1")
@@ -1300,7 +1373,9 @@ def test_toggle_sequential_download(client, orig_torrent, toggle_seq_down_func):
 def test_toggle_first_last_piece_priority(client, new_torrent, toggle_piece_prio_func):
     current_setting = new_torrent.info.f_l_piece_prio
     client.func(toggle_piece_prio_func)(torrent_hashes=new_torrent.hash)
-    check(lambda: new_torrent.info.f_l_piece_prio, not current_setting)
+    for attempt in eventually():
+        with attempt:
+            assert new_torrent.info.f_l_piece_prio == (not current_setting)
 
 
 @pytest.mark.parametrize(
@@ -1317,7 +1392,9 @@ def test_set_force_start(client, orig_torrent, set_force_start_func):
     client.func(set_force_start_func)(
         enable=(not current_setting), torrent_hashes=orig_torrent.hash
     )
-    check(lambda: orig_torrent.info.force_start, not current_setting)
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.force_start == (not current_setting)
 
 
 @pytest.mark.parametrize(
@@ -1415,31 +1492,29 @@ def test_create_categories(
             enable_download_path=enable_download_path,
         )
         client.torrents_set_category(torrent_hashes=orig_torrent.hash, category=name)
-        check(lambda: orig_torrent.info.category.replace("+", " "), name)
+        for attempt in eventually():
+            with attempt:
+                assert orig_torrent.info.category.replace("+", " ") == name
         if v(api_version) >= v("2.2"):
-            check(
-                lambda: [n.replace("+", " ") for n in client.torrents_categories()],
-                name,
-                reverse=True,
-            )
+            for attempt in eventually():
+                with attempt:
+                    assert name in [
+                        n.replace("+", " ") for n in client.torrents_categories()
+                    ]
             save_path_key = _categories_save_path_key(api_version)
-            check(
-                lambda: [
-                    mkpath(cat[save_path_key])
-                    for cat in client.torrents_categories().values()
-                ],
-                mkpath(save_path) or "",
-                reverse=True,
-            )
+            for attempt in eventually():
+                with attempt:
+                    assert (mkpath(save_path) or "") in [
+                        mkpath(cat[save_path_key])
+                        for cat in client.torrents_categories().values()
+                    ]
         if v(api_version) >= v("2.8.4") and enable_download_path is not False:
-            check(
-                lambda: [
-                    mkpath(cat.get("download_path", ""))
-                    for cat in client.torrents_categories().values()
-                ],
-                mkpath(download_path) or "",
-                reverse=True,
-            )
+            for attempt in eventually():
+                with attempt:
+                    assert (mkpath(download_path) or "") in [
+                        mkpath(cat.get("download_path", ""))
+                        for cat in client.torrents_categories().values()
+                    ]
     finally:
         client.torrents_remove_categories(categories=name)
 
@@ -1466,29 +1541,25 @@ def test_edit_category(
             download_path=download_path,
             enable_download_path=enable_download_path,
         )
-        check(
-            lambda: [n.replace("+", " ") for n in client.torrents_categories()],
-            name,
-            reverse=True,
-        )
+        for attempt in eventually():
+            with attempt:
+                assert name in [
+                    n.replace("+", " ") for n in client.torrents_categories()
+                ]
         save_path_key = _categories_save_path_key(api_version)
-        check(
-            lambda: (
-                mkpath(cat[save_path_key])
-                for cat in client.torrents_categories().values()
-            ),
-            mkpath(save_path) or "",
-            reverse=True,
-        )
-        if v(api_version) >= v("2.8.4") and enable_download_path is not False:
-            check(
-                lambda: [
-                    mkpath(cat.get("download_path", ""))
+        for attempt in eventually():
+            with attempt:
+                assert (mkpath(save_path) or "") in (
+                    mkpath(cat[save_path_key])
                     for cat in client.torrents_categories().values()
-                ],
-                mkpath(download_path) or "",
-                reverse=True,
-            )
+                )
+        if v(api_version) >= v("2.8.4") and enable_download_path is not False:
+            for attempt in eventually():
+                with attempt:
+                    assert (mkpath(download_path) or "") in [
+                        mkpath(cat.get("download_path", ""))
+                        for cat in client.torrents_categories().values()
+                    ]
     finally:
         client.torrents_remove_categories(categories=name)
 
@@ -1506,13 +1577,14 @@ def test_remove_category(
     orig_torrent.set_category(category=categories[0])
     client.func(remove_cat_func)(categories=categories)
     if v(api_version) >= v("2.2"):
-        check(
-            lambda: [n.replace("+", " ") for n in client.torrents_categories()],
-            categories,
-            reverse=True,
-            negate=True,
-        )
-    check(lambda: orig_torrent.info.category, categories[0], negate=True)
+        for attempt in eventually():
+            with attempt:
+                assert set(categories).isdisjoint(
+                    {n.replace("+", " ") for n in client.torrents_categories()}
+                )
+    for attempt in eventually():
+        with attempt:
+            assert orig_torrent.info.category != categories[0]
 
 
 @pytest.mark.skipif_before_api_version("2.3.0")
@@ -1552,7 +1624,9 @@ def test_add_tag_though_property(client):
 def test_add_tags(client, orig_torrent, add_tags_func, tags):
     try:
         client.func(add_tags_func)(tags=tags, torrent_hashes=orig_torrent.hash)
-        check(lambda: orig_torrent.info.tags, tags, reverse=True)
+        for attempt in eventually():
+            with attempt:
+                assert all(tag in orig_torrent.info.tags for tag in tags)
     finally:
         client.torrents_delete_tags(tags=tags)
 
@@ -1566,7 +1640,9 @@ def test_set_tags(client, orig_torrent, set_tags_func, tags):
     try:
         client.torrents_add_tags(tags="extra-tag", torrent_hashes=orig_torrent.hash)
         client.func(set_tags_func)(tags=tags, torrent_hashes=orig_torrent.hash)
-        check(lambda: orig_torrent.info.tags, tags, reverse=True)
+        for attempt in eventually():
+            with attempt:
+                assert all(tag in orig_torrent.info.tags for tag in tags)
     finally:
         client.torrents_delete_tags(tags=tags)
 
@@ -1580,7 +1656,9 @@ def test_remove_tags(client, orig_torrent, remove_tags_func, tags):
     try:
         orig_torrent.add_tags(tags=tags)
         client.func(remove_tags_func)(tags=tags, torrent_hashes=orig_torrent.hash)
-        check(lambda: orig_torrent.info.tags, tags, reverse=True, negate=True)
+        for attempt in eventually():
+            with attempt:
+                assert all(tag not in orig_torrent.info.tags for tag in tags)
     finally:
         client.torrents_delete_tags(tags=tags)
 
@@ -1593,7 +1671,9 @@ def test_remove_tags(client, orig_torrent, remove_tags_func, tags):
 def test_create_tags(client, create_tags_func, tags):
     try:
         client.func(create_tags_func)(tags=tags)
-        check(lambda: client.torrents_tags(), tags, reverse=True)
+        for attempt in eventually():
+            with attempt:
+                assert set(tags) <= set(client.torrents_tags())
     finally:
         client.torrents_delete_tags(tags=tags)
 
@@ -1606,4 +1686,6 @@ def test_create_tags(client, create_tags_func, tags):
 def test_delete_tags(client, delete_tags_func, tags):
     client.torrents_create_tags(tags=tags)
     client.func(delete_tags_func)(tags=tags)
-    check(lambda: client.torrents_tags(), tags, reverse=True, negate=True)
+    for attempt in eventually():
+        with attempt:
+            assert set(tags).isdisjoint(client.torrents_tags())

--- a/tests/test_zzz_last_tests.py
+++ b/tests/test_zzz_last_tests.py
@@ -2,11 +2,13 @@ from os import environ
 
 import pytest
 
-from tests.utils import check
+from tests.utils import eventually
 
 
 @pytest.mark.skipif(environ.get("CI") != "true", reason="not in CI")
 def test_shutdown(client):
     client.app.shutdown()
     with pytest.raises(AssertionError, match="qBittorrent is unreachable"):
-        check(lambda: client.app_version(), "")
+        for attempt in eventually():
+            with attempt:
+                assert client.app_version() == ""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,6 +53,15 @@ def setup_environ():
     return qbt_version, is_qbt_dev
 
 
+def as_list(value):
+    """
+    Normalise a parameter given as either a single string or a list of them.
+
+    Several tests are parametrized both ways to prove the endpoint accepts each.
+    """
+    return [value] if isinstance(value, str) else list(value)
+
+
 def get_func(obj, method_name):
     """
     Retrieve a method from an object.
@@ -110,101 +119,6 @@ def add_torrent(client, torrent_url, torrent_hash):
     if torrent_hash not in [t.hash for t in client.torrents_info()]:
         sleep(0.1)
         raise Exception("didn't find added torrent")
-
-
-def check(
-    check_func,
-    value,
-    reverse=False,
-    negate=False,
-    any=False,
-    check_time=None,
-    action=None,
-    action_every=1,
-):
-    """
-    Compare the return value of an arbitrary function to expected value with retries.
-    Since some requests take some time to take effect in qBittorrent, the value is
-    re-checked every ``CHECK_SLEEP`` seconds for ``CHECK_TIME`` seconds.
-
-    :param check_func: callable to generate values to check
-    :param value: str, int, or iterator of values to look for
-    :param reverse: False: look for check_func return in value; True: look for value in
-        check_func return
-    :param negate: False: value must be found; True: value must not be found
-    :param check_time: maximum number of seconds to spend checking
-    :param any: False: all values must be (not) found; True: any value must be (not)
-        found
-    :param action: callable to re-send the request being checked before each retry;
-        qBittorrent occasionally never applies a request (e.g. it decides its own,
-        potentially stale, cached state already matches), and re-sending is the only
-        way to recover. Only use for requests that are safe to send more than once.
-    :param action_every: number of retries between each ``action`` call; raise it for
-        requests qBittorrent handles on a worker thread, where re-sending on every
-        retry just queues more work onto a pool that is already behind
-    """
-
-    # assertions are not rewritten by pytest in this module, so each
-    # assertion needs to report the values that caused it to fail
-    def _do_check(_check_func_val, _v, _negate, _reverse):
-        if _negate:
-            if _reverse:
-                assert _v not in _check_func_val, f"found {_v!r} in {_check_func_val!r}"
-            else:
-                assert _check_func_val not in (_v,), f"{_check_func_val!r} is {_v!r}"
-        else:
-            if _reverse:
-                assert _v in _check_func_val, f"{_v!r} not in {_check_func_val!r}"
-            else:
-                assert _check_func_val in (_v,), f"{_check_func_val!r} is not {_v!r}"
-
-    if isinstance(value, (str, int)):
-        value = (value,)
-
-    check_limit = int((check_time or CHECK_TIME) / CHECK_SLEEP)
-
-    try:
-        for i in range(check_limit):
-            try:
-                exp = None
-                for val in value:
-                    # clear any previous exceptions if any=True
-                    exp = None if any else exp
-
-                    try:
-                        # get val here so pytest includes value in failures
-                        check_val = check_func()
-                        _do_check(check_val, val, negate, reverse)
-                    except RETRY_ERRORS as e:
-                        exp = e
-
-                    # fail the test on first failure if any=False
-                    if not any and exp:
-                        break
-                    # this value passed so test succeeded if any=True
-                    if any and not exp:
-                        break
-
-                # raise caught inner exception for handling
-                if exp:
-                    raise exp
-
-                # test succeeded!!!!
-                return
-
-            except RETRY_ERRORS:
-                # let the last failure fail the test so its details are reported
-                if i >= check_limit - 1:
-                    raise
-                sleep(CHECK_SLEEP)
-                if action is not None and (i + 1) % action_every == 0:
-                    action()
-    except HTTPError:
-        # every HTTP error subclasses APIConnectionError, so let anything
-        # qBittorrent actually responded with be reported as itself
-        raise
-    except APIConnectionError as e:
-        raise AssertionError(f"qBittorrent is unreachable: {e!r}") from e
 
 
 class _Attempt:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,8 +24,8 @@ CHECK_SLEEP = 0.25
 # They need a much longer window than other checks, and re-sending on every retry
 # only queues more work onto the pool that is already behind, so back off between
 # attempts instead of hammering it.
-WEBSEED_CHECK_TIME = 60
-WEBSEED_ACTION_EVERY = 8
+WEBSEED_TIMEOUT = 60
+WEBSEED_RESEND_EVERY = 8
 # Errors that mean qBittorrent hasn't caught up yet, so the check should be retried.
 # LookupError and AttributeError cover values qBittorrent hasn't populated yet, e.g.
 # indexing into a list that is still empty. The last attempt raises regardless, so


### PR DESCRIPTION
Follows #671, which added `eventually()` and converted `test_search.py`. This
converts the remaining **168 call sites** and deletes `check()`.

| File | Sites |
|---|---|
| `test_torrents.py` | 80 |
| `test_torrent.py` | 59 |
| `test_rss.py` | 19 |
| conftest / torrentcreator / zzz | 4 |

## The audit was the work

The mechanical conversion was easy. What mattered was discovering that `check()`
behaved **four different ways depending on the runtime type of its expected
value** — most of why it was worth removing, and all of why removing it was
risky.

Four conversions were wrong before being caught:

- **`assert tags in orig_torrent.info.tags`** where `tags` is sometimes a list.
  `check()` iterates a list of expected values; a bare `in` raises `TypeError`.
  17 tests failed — loudly, which is the good case.
- **`assert state != {"pausedDL", "stoppedDL"}`.** `check()` iterates the set and
  asserts the result is none of them. Comparing a *string* to a *set* is always
  true, so this would have **passed forever while asserting nothing.** This is the
  one that would have quietly cost you coverage.
- **`assert mkpath(...) in loc`.** `any=True` beside a lone string is a no-op,
  because `check()` wraps scalars before iterating — so it means equality, and
  converting it to `in` made it a substring test.
- **`assert TaskStatus(...) == [TaskStatus.FINISHED]`**, comparing against the
  list rather than its element.

The converter distinguishes literal collections from scalars. The nine sites
where a *variable* holds a collection are statically undecidable, so they were
converted by hand against each `parametrize` declaration: `tags` and `categories`
are always lists, `trackers` and `webseeds` are given both ways. `as_list()` moved
to `tests/utils.py`, shared.

## What the tests read like now

```python
for attempt in eventually(timeout=WEBSEED_TIMEOUT, resend=add_orig_url,
                          resend_every=WEBSEED_RESEND_EVERY):
    with attempt:
        assert orig_url in urls()
```

instead of

```python
check(urls, orig_url, reverse=True, action=add_orig_url,
      check_time=WEBSEED_CHECK_TIME, action_every=WEBSEED_ACTION_EVERY)
```

Failures now report at the test's own line with pytest's diff, rather than as a
hand-built message pointing into `utils.py`.

`WEBSEED_CHECK_TIME`/`WEBSEED_ACTION_EVERY` are renamed to `WEBSEED_TIMEOUT`/
`WEBSEED_RESEND_EVERY` to match the new vocabulary.

## Verification

Each file was run as it was converted — 288 / 93 / 25 passed. Then the whole
suite against master:

```
1531 passed, 56 skipped in 8:14
```

CI's matrix back to v4.1.0 is the real check, since several converted assertions
only execute on older versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)