### PR TITLE
test(tests): fail any test that leaves state behind in qBittorrent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ markers = [
     "skipif_before_api_version(api_version): skips test for current api version",
     "skipif_after_api_version(api_version): skips test for current api version",
     "offline: test inspects the library only and never talks to qBittorrent",
+    "no_sandbox: test deliberately leaves qBittorrent in an altered state",
 ]
 norecursedirs = "dist build .tox scripts"
 testpaths = ["tests"]

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -114,6 +114,22 @@ hand-rolling setup:
 
 Clean up in a `finally` block so a mid-test failure still tidies up.
 
+This is enforced. An autouse fixture compares qBittorrent's torrents,
+categories, tags, RSS items and preferences either side of every test, and fails
+one that leaves anything behind or changes a preference without putting it back:
+
+```
+AssertionError: test left state behind in qBittorrent: {'tags': ['extra-tag']}
+```
+
+Restore preferences you change by reading the original first, rather than
+assuming a default. If altering qBittorrent is the whole point of a test — as it
+is for rotating the Web UI API key — mark it `no_sandbox` instead.
+
+Be aware that one leak can hide another: if an earlier test already left a tag
+behind, a later test leaking the same tag shows no difference across itself.
+Fixing leaks tends to reveal more of them, so re-run after each fix.
+
 ## Version gating
 
 Endpoints exist only in some Web API versions. Skip accordingly:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,6 +232,10 @@ def new_torrent_standalone(client, torrent_hash=TORRENT1_HASH, tmp_path=None, **
     @retry()
     def delete_test_torrent(client_, torrent_hash_):
         client_.torrents_delete(torrent_hashes=torrent_hash_, delete_files=True)
+        # adding the torrent creates this category, and deleting the torrent
+        # leaves it behind
+        with suppress(Exception):
+            client_.torrents_remove_categories(categories="test_category")
         for attempt in eventually():
             with attempt:
                 assert torrent_hash_ not in [t.hash for t in client_.torrents_info()]
@@ -272,6 +276,67 @@ def api_version(client):
     if IS_QBT_DEV:
         return client.app.web_api_version
     return api_version_map[QBT_VERSION]
+
+
+def _state_snapshot(client):
+    """
+    What qBittorrent is currently holding that a test could have left behind.
+
+    Each piece is optional: the endpoints arrived in different Web API versions,
+    and the client raises NotImplementedError for the ones this qBittorrent is
+    too old to have.
+    """
+    snapshot = {}
+    for name, read in (
+        ("torrents", lambda: {t.hash for t in client.torrents_info()}),
+        ("categories", lambda: set(client.torrents_categories())),
+        ("tags", lambda: set(client.torrents_tags())),
+        ("rss", lambda: set(client.rss_items())),
+        ("preferences", lambda: dict(client.app.preferences)),
+    ):
+        try:
+            snapshot[name] = read()
+        except Exception:
+            snapshot[name] = None
+    return snapshot
+
+
+@pytest.fixture(autouse=True)
+def no_state_left_behind(request, client):
+    """
+    Fail a test that leaves torrents, categories, tags or RSS items behind, or
+    that changes a preference without putting it back.
+
+    Tests share one qBittorrent, so anything left over is inherited by whatever
+    runs next. That is how an unlucky ordering turns into failures that look
+    like real bugs somewhere else entirely. Mark a test ``no_sandbox`` if
+    altering qBittorrent is the point of it.
+    """
+    if "offline" in request.keywords or "no_sandbox" in request.keywords:
+        yield
+        return
+
+    before = _state_snapshot(client)
+    yield
+    after = _state_snapshot(client)
+
+    leaked = {}
+    for name, was in before.items():
+        now = after.get(name)
+        if was is None or now is None:
+            continue
+        if name == "preferences":
+            changed = [
+                key for key, value in was.items() if now.get(key, value) != value
+            ]
+            if changed:
+                leaked[name] = sorted(changed)
+        elif added := now - was:
+            leaked[name] = sorted(added)
+    assert not leaked, (
+        f"test left state behind in qBittorrent: {leaked}. Clean up in a "
+        f"finally block, or mark the test no_sandbox if that is the point of it."
+    )
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,6 +263,19 @@ def new_torrent(client, tmp_path):
 
 
 @pytest.fixture
+def restore_queueing(client):
+    """
+    Put the global queueing preference back.
+
+    The priority tests have to turn queueing on to exercise the endpoints, and
+    whether it was on to begin with depends on the qBittorrent version.
+    """
+    original = client.app.preferences.queueing_enabled
+    yield
+    client.app.set_preferences(dict(queueing_enabled=original))
+
+
+@pytest.fixture
 def app_version(client):
     """qBittorrent Version being used for testing."""
     if IS_QBT_DEV:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -174,6 +174,7 @@ def test_get_free_space_at_path(client, free_space_func):
 
 
 @pytest.mark.skipif_before_api_version("2.14.0")
+@pytest.mark.no_sandbox  # rotating the key is the point of the test
 @pytest.mark.parametrize(
     "rotate_api_key_func", ["app_rotate_api_key", "app.rotate_api_key"]
 )
@@ -186,6 +187,7 @@ def test_rotate_api_key(client, rotate_api_key_func):
 
 
 @pytest.mark.skipif_before_api_version("2.14.1")
+@pytest.mark.no_sandbox  # rotating the key is the point of the test
 @pytest.mark.parametrize(
     "delete_api_key_func", ["app_delete_api_key", "app.delete_api_key"]
 )

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -150,7 +150,12 @@ def _enable_disable_https(use_https):
             "web_ui_https_key_path": mkpath("/tmp", "_resources", "server.key"),
         }
     else:
-        https_client.app.preferences = {"use_https": False}
+        # the cert paths outlive use_https, so clear them as well
+        https_client.app.preferences = {
+            "use_https": False,
+            "web_ui_https_cert_path": "",
+            "web_ui_https_key_path": "",
+        }
 
 
 def _wait_for_http_web_ui(client):

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -147,7 +147,13 @@ def test_delete(client_mock, new_torrent, delete):
     ],
 )
 def test_priority(
-    client, new_torrent, inc_prio_func, dec_prio_func, top_prio_func, bottom_prio_func
+    client,
+    new_torrent,
+    inc_prio_func,
+    dec_prio_func,
+    top_prio_func,
+    bottom_prio_func,
+    restore_queueing,
 ):
     disable_queueing(client)
 

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -734,4 +734,4 @@ def test_set_tags(client, orig_torrent, set_tags_func, tags):
             with attempt:
                 assert all(tag in orig_torrent.info.tags for tag in as_list(tags))
     finally:
-        client.torrents_delete_tags(tags=tags)
+        client.torrents_delete_tags(tags=[*as_list(tags), "extra-tag"])

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -1000,7 +1000,13 @@ def test_reannounce_urls(client, monkeypatch):
     ],
 )
 def test_priority(
-    client, new_torrent, inc_prio_func, dec_prio_func, top_prio_func, bottom_prio_func
+    client,
+    new_torrent,
+    inc_prio_func,
+    dec_prio_func,
+    top_prio_func,
+    bottom_prio_func,
+    restore_queueing,
 ):
     disable_queueing(client)
 

--- a/tests/test_torrents.py
+++ b/tests/test_torrents.py
@@ -1,7 +1,7 @@
 import errno
 import platform
 import sys
-from contextlib import ExitStack
+from contextlib import ExitStack, suppress
 from time import sleep
 from unittest.mock import MagicMock
 
@@ -380,7 +380,12 @@ def test_add_options(client, api_version, keep_root_folder, content_layout, tmp_
                     with attempt:
                         assert torrent.info.seeding_time_limit == 120
 
-    do_test()
+    try:
+        do_test()
+    finally:
+        # created by do_test() and not removed with the torrent
+        with suppress(Exception):
+            client.torrents_delete_tags(tags="option-tag")
 
 
 @pytest.mark.skipif_before_api_version("2.8.4")
@@ -885,9 +890,12 @@ def test_torrents_info_slice(client):
 @pytest.mark.parametrize("info_func", ["torrents_info", "torrents.info"])
 def test_torrents_info_tag(client, new_torrent, info_func):
     tag_name = "tag_filter_name"
-    client.torrents_add_tags(tags=tag_name, torrent_hashes=new_torrent.hash)
-    torrents = client.func(info_func)(torrent_hashes=new_torrent.hash, tag=tag_name)
-    assert new_torrent.hash in {t.hash for t in torrents}
+    try:
+        client.torrents_add_tags(tags=tag_name, torrent_hashes=new_torrent.hash)
+        torrents = client.func(info_func)(torrent_hashes=new_torrent.hash, tag=tag_name)
+        assert new_torrent.hash in {t.hash for t in torrents}
+    finally:
+        client.torrents_delete_tags(tags=tag_name)
 
 
 # test fails on 4.1.0 release
@@ -1644,7 +1652,7 @@ def test_set_tags(client, orig_torrent, set_tags_func, tags):
             with attempt:
                 assert all(tag in orig_torrent.info.tags for tag in tags)
     finally:
-        client.torrents_delete_tags(tags=tags)
+        client.torrents_delete_tags(tags=[*tags, "extra-tag"])
 
 
 @pytest.mark.skipif_before_api_version("2.3.0")

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -71,6 +71,7 @@ def test_speed_limits_mode(client):
 
 
 def test_download_limit(client):
+    original = client.transfer_download_limit()
     client.transfer_set_download_limit(limit=2048)
     assert client.transfer_download_limit() == 2048
     client.transfer_setDownloadLimit(limit=3072)
@@ -81,8 +82,11 @@ def test_download_limit(client):
     client.transfer.downloadLimit = 5120
     assert client.transfer.downloadLimit == 5120
 
+    client.transfer_set_download_limit(limit=original)
+
 
 def test_upload_limit(client):
+    original = client.transfer_upload_limit()
     client.transfer_set_upload_limit(limit=2048)
     assert client.transfer_upload_limit() == 2048
     client.transfer_setUploadLimit(limit=3072)
@@ -93,9 +97,12 @@ def test_upload_limit(client):
     client.transfer.uploadLimit = 5120
     assert client.transfer.uploadLimit == 5120
 
+    client.transfer_set_upload_limit(limit=original)
+
 
 @pytest.mark.skipif_before_api_version("2.3")
 def test_ban_peers(client):
+    original_bans = client.app.preferences.banned_IPs
     client.transfer_ban_peers(peers="1.1.1.1:8080")
     assert "1.1.1.1" in client.app.preferences.banned_IPs
     client.transfer.ban_peers(peers="1.1.1.2:8080")
@@ -107,6 +114,9 @@ def test_ban_peers(client):
     client.transfer.ban_peers(peers=["1.1.1.5:8080", "1.1.1.6:8080"])
     assert "1.1.1.5" in client.app.preferences.banned_IPs
     assert "1.1.1.6" in client.app.preferences.banned_IPs
+
+    # banned_IPs is global and nothing else clears it
+    client.app.set_preferences(dict(banned_IPs=original_bans))
 
 
 @pytest.mark.skipif_before_api_version("2.16.0")

--- a/tests/test_zzz_last_tests.py
+++ b/tests/test_zzz_last_tests.py
@@ -5,6 +5,7 @@ import pytest
 from tests.utils import eventually
 
 
+@pytest.mark.no_sandbox
 @pytest.mark.skipif(environ.get("CI") != "true", reason="not in CI")
 def test_shutdown(client):
     client.app.shutdown()


### PR DESCRIPTION
Follows #672.

Tests share one qBittorrent, so anything a test leaves behind is inherited by
whatever runs next — and an unlucky ordering turns into failures that look like
real bugs somewhere else entirely. An autouse fixture now compares torrents,
categories, tags, RSS items and preferences either side of every test, and fails
one that leaves anything behind.

## This is not the sandbox I proposed, because I measured first

The plan was a full sandbox: snapshot everything, purge between tests. I'd argued
for it off the back of a 162-failure incident — which I later traced to **my own
interrupted runs polluting a long-lived container**, not to the suite.

So I ran the detector in report-only mode first. It found **11 leaks across 1,531
tests**, each a specific missing cleanup rather than the systemic disorder that
would justify per-test purging.

Fixing eleven bugs beats papering over them with machinery that runs 1,531 times,
and the detector then makes the property permanent for **~10s on an 8:24 run**.

## The twelve leaks

| Leak | Note |
|---|---|
| `test_category` | created by the shared `new_torrent` fixture, so **every** test using it leaked |
| `extra-tag`, `option-tag`, `tag_filter_name` | created and never deleted |
| `dl_limit`, `up_limit` | global; now captured and restored |
| `banned_IPs` | global, and **accumulated bans for the entire session** |
| `web_ui_https_cert_path`/`_key_path` | the HTTP-restore helper left them set |
| `web_ui_api_key` ×3 | `no_sandbox` — rotating the key *is* the test |

## One leak can hide another

`test_torrent.py` and `test_torrents.py` both have a `test_set_tags` that adds
`extra-tag`. The first leaked it, so by the time the second ran the tag was
already there — its before/after diff was empty and the report-only runs never
mentioned it. It only appeared **after** the first was fixed.

That's inherent to detection by differencing: an empty report never proves nothing
leaks. Four rounds were needed to reach zero, and `tests/CLAUDE.md` now says so.

## Verification

```
1531 passed, 56 skipped in 8:21 — no leaks, detector enforcing
```

## Note on scope

This does **not** retire `test_zzz_last_tests.py`, which I'd earlier suggested it
would. `test_shutdown` has to run last because it shuts qBittorrent down, and the
filename is what orders it — unrelated to state isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)