### PR TITLE
feat: add Web API v2.16.2 endpoints (qBittorrent v5.3.0beta1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
     strategy:
       matrix:
         QBT_VER:
+          - v5.3.0beta1
           - v5.1.4
           - v5.0.5
           - v4.6.7

--- a/docs/source/apidoc/transfer.rst
+++ b/docs/source/apidoc/transfer.rst
@@ -4,13 +4,13 @@ Transfer
 .. autoclass:: qbittorrentapi.transfer.TransferAPIMixIn
     :members:
     :undoc-members:
-    :exclude-members: transfer, transfer_speedLimitsMode, transfer_toggleSpeedLimitsMode, transfer_downloadLimit, transfer_uploadLimit, transfer_setDownloadLimit, transfer_setUploadLimit, transfer_getSpeedLimits, transfer_setSpeedLimits, transfer_banPeers
+    :exclude-members: transfer, transfer_speedLimitsMode, transfer_toggleSpeedLimitsMode, transfer_downloadLimit, transfer_uploadLimit, transfer_setDownloadLimit, transfer_setUploadLimit, transfer_getSpeedLimits, transfer_setSpeedLimits, transfer_banPeers, transfer_pauseSession, transfer_resumeSession
     :show-inheritance:
 
 .. autoclass:: qbittorrentapi.transfer.Transfer
     :members:
     :undoc-members:
-    :exclude-members: toggleSpeedLimitsMode, setDownloadLimit, setUploadLimit, banPeers, speedLimitsMode, downloadLimit, uploadLimit, setSpeedLimitsMode, getSpeedLimits, setSpeedLimits
+    :exclude-members: toggleSpeedLimitsMode, setDownloadLimit, setUploadLimit, banPeers, speedLimitsMode, downloadLimit, uploadLimit, setSpeedLimitsMode, getSpeedLimits, setSpeedLimits, pauseSession, resumeSession
 
 .. autoclass:: qbittorrentapi.transfer.TransferInfoDictionary
     :members:

--- a/docs/source/spelling_wordlist
+++ b/docs/source/spelling_wordlist
@@ -8,6 +8,7 @@ bt
 casted
 Curran
 Diffie
+dotfiles
 errored
 Errored
 filepath

--- a/src/qbittorrentapi/_version_support.py
+++ b/src/qbittorrentapi/_version_support.py
@@ -80,6 +80,7 @@ APP_VERSION_2_API_VERSION_MAP: dict[str, str] = {
     "v5.2.1": "2.15.1",
     "v5.2.2": "2.15.1",
     "v5.2.3": "2.15.1",
+    "v5.3.0beta1": "2.16.2",
 }
 
 MOST_RECENT_SUPPORTED_APP_VERSION: Final[Literal["v5.2.3"]] = "v5.2.3"

--- a/src/qbittorrentapi/_version_support.py
+++ b/src/qbittorrentapi/_version_support.py
@@ -79,8 +79,8 @@ APP_VERSION_2_API_VERSION_MAP: dict[str, str] = {
     "v5.2.0": "2.15.1",
     "v5.2.1": "2.15.1",
     "v5.2.2": "2.15.1",
-    "v5.2.3": "2.15.1",
     "v5.3.0beta1": "2.16.2",
+    "v5.2.3": "2.15.1",
 }
 
 MOST_RECENT_SUPPORTED_APP_VERSION: Final[Literal["v5.2.3"]] = "v5.2.3"

--- a/src/qbittorrentapi/torrentcreator.py
+++ b/src/qbittorrentapi/torrentcreator.py
@@ -80,6 +80,7 @@ class TorrentCreatorAPIMixIn(AppAPIMixIn):
         start_seeding: bool | None = None,
         is_private: bool | None = None,
         optimize_alignment: bool | None = None,
+        ignore_dotfiles: bool | None = None,
         padded_file_size_limit: int | None = None,
         piece_size: int | None = None,
         comment: str | None = None,
@@ -100,6 +101,8 @@ class TorrentCreatorAPIMixIn(AppAPIMixIn):
         :param is_private: is the torrent private or not?
         :param optimize_alignment: should optimized alignment be enforced for new
             torrent?
+        :param ignore_dotfiles: should dotfiles be excluded from the torrent?
+            defaults to ``True`` in qBittorrent (added in Web API v2.16.0)
         :param padded_file_size_limit: size limit for padding files
         :param piece_size: size of the pieces
         :param comment: comment
@@ -115,6 +118,9 @@ class TorrentCreatorAPIMixIn(AppAPIMixIn):
             "private": None if is_private is None else bool(is_private),
             "optimizeAlignment": (
                 None if optimize_alignment is None else bool(optimize_alignment)
+            ),
+            "ignoreDotfiles": (
+                None if ignore_dotfiles is None else bool(ignore_dotfiles)
             ),
             "startSeeding": None if start_seeding is None else bool(start_seeding),
             "paddedFileSizeLimit": padded_file_size_limit,
@@ -261,6 +267,7 @@ class TorrentCreator(ClientCache[TorrentCreatorAPIMixIn]):
         start_seeding: bool | None = None,
         is_private: bool | None = None,
         optimize_alignment: bool | None = None,
+        ignore_dotfiles: bool | None = None,
         padded_file_size_limit: int | None = None,
         piece_size: int | None = None,
         comment: str | None = None,
@@ -276,6 +283,7 @@ class TorrentCreator(ClientCache[TorrentCreatorAPIMixIn]):
             start_seeding=start_seeding,
             is_private=is_private,
             optimize_alignment=optimize_alignment,
+            ignore_dotfiles=ignore_dotfiles,
             padded_file_size_limit=padded_file_size_limit,
             piece_size=piece_size,
             comment=comment,

--- a/src/qbittorrentapi/transfer.py
+++ b/src/qbittorrentapi/transfer.py
@@ -244,6 +244,36 @@ class TransferAPIMixIn(AppAPIMixIn):
 
     transfer_banPeers = transfer_ban_peers
 
+    def transfer_pause_session(self, **kwargs: APIKwargsT) -> None:
+        """
+        Pause the BitTorrent session.
+
+        This method was introduced with qBittorrent v5.3.0 (Web API v2.16.2).
+        """
+        self._post(
+            _name=APINames.Transfer,
+            _method="pauseSession",
+            version_introduced="2.16.2",
+            **kwargs,
+        )
+
+    transfer_pauseSession = transfer_pause_session
+
+    def transfer_resume_session(self, **kwargs: APIKwargsT) -> None:
+        """
+        Resume the BitTorrent session.
+
+        This method was introduced with qBittorrent v5.3.0 (Web API v2.16.2).
+        """
+        self._post(
+            _name=APINames.Transfer,
+            _method="resumeSession",
+            version_introduced="2.16.2",
+            **kwargs,
+        )
+
+    transfer_resumeSession = transfer_resume_session
+
 
 class Transfer(ClientCache[TransferAPIMixIn]):
     """
@@ -398,3 +428,15 @@ class Transfer(ClientCache[TransferAPIMixIn]):
         self._client.transfer_ban_peers(peers=peers, **kwargs)
 
     banPeers = ban_peers
+
+    def pause_session(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_pause_session`."""
+        self._client.transfer_pause_session(**kwargs)
+
+    pauseSession = pause_session
+
+    def resume_session(self, **kwargs: APIKwargsT) -> None:
+        """Implements :meth:`~TransferAPIMixIn.transfer_resume_session`."""
+        self._client.transfer_resume_session(**kwargs)
+
+    resumeSession = resume_session

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -34,7 +34,7 @@ each other's state and produce failures that look like real bugs.
 
 **Offline** — `tests/test_api_surface.py`, derived from `tests/catalog.py`. These
 inspect the library itself and never talk to qBittorrent. They carry the
-`offline` marker, are generated from all 128 endpoints in the catalog, and
+`offline` marker, are generated from all 130 endpoints in the catalog, and
 finish in well under a second.
 
 **Live** — everything else. These make real requests and assert on what
@@ -75,31 +75,42 @@ monkeypatch.setattr(client, "app_web_api_version", MagicMock(return_value="0.0.1
 ## qBittorrent applies changes asynchronously
 
 A request that returns 200 has not necessarily taken effect yet, so a bare
-assert immediately after a mutation is a flake waiting to happen. Use `check()`
-from `tests/utils.py`, which re-reads the value until it matches or the timeout
-expires.
+assert immediately after a mutation is a flake waiting to happen. Wrap it in
+`eventually()` from `tests/utils.py`, which retries the block until it passes or
+the timeout expires (10 seconds by default):
+
+```python
+for attempt in eventually():
+    with attempt:
+        assert torrent.info.category == "test_category"
+```
+
+The assertions stay in the test module, so pytest rewrites them and a failure
+reports the values that did not match. Only `AssertionError`, `AttributeError`
+and `LookupError` are retried, and the final attempt re-raises whatever it gets,
+so retrying can delay a genuine failure but never hide one.
 
 Worse, qBittorrent sometimes drops a request entirely — webseed changes run in
 worker threads that swallow every exception, and some setters return early when
-qBittorrent's own cached state already looks correct. For those, pass
-`action=`, which re-sends the request between attempts:
+qBittorrent's own cached state already looks correct. For those, pass `resend=`,
+a callable that re-sends the request between attempts:
 
 ```python
 def add_webseeds():
-    torrent.add_webseeds(urls=urls)
+    client.func(add_webseeds_func)(torrent_hash=new_torrent.hash, urls=webseeds)
 
 
 add_webseeds()
-check(
-    lambda: [w.url for w in torrent.webseeds], urls, reverse=True, action=add_webseeds
-)
+for attempt in eventually(
+    timeout=WEBSEED_TIMEOUT, resend=add_webseeds, resend_every=WEBSEED_RESEND_EVERY
+):
+    with attempt:
+        assert [w.url for w in new_torrent.webseeds] == webseeds
 ```
 
-Only use `action=` for requests that are safe to send more than once.
-
-Note that `check()` lives outside a test module, so pytest does **not** rewrite
-its assertions. Any new assertion helper there must put the offending values in
-its own failure message, or failures will be undebuggable.
+Only use `resend=` for requests that are safe to send more than once. Raise
+`resend_every` for work handled on a thread pool, where re-sending on every
+attempt only queues more onto a pool that is already behind.
 
 ## Tests share one qBittorrent, so clean up
 
@@ -156,8 +167,9 @@ mechanism itself rather than any particular endpoint.
 ## Gotchas that have cost real time
 
 - **camelCase spellings are the same function object.** `torrents_addWebSeeds`
-  *is* `torrents_add_webseeds`, assigned, not reimplemented. 92 of the 128
-  endpoints have at least one alias, 94 alias bindings in all. Do not add live
+  *is* `torrents_add_webseeds`, assigned, not reimplemented. 94 of the 130
+  endpoints have at least one alias, 226 alias bindings in all across the
+  client, the namespace interfaces and the torrent methods. Do not add live
   tests per spelling; the offline layer asserts the identity for every endpoint
   already.
 - **`torrents_rename_folder` gates on the application version**, not the Web API

--- a/tests/api_surface.json
+++ b/tests/api_surface.json
@@ -2106,6 +2106,42 @@
     "version_removed": ""
   },
   {
+    "api_method": "pauseSession",
+    "client_aliases": [
+      "transfer_pauseSession"
+    ],
+    "interface": "transfer.pause_session",
+    "interface_aliases": [
+      "transfer.pauseSession"
+    ],
+    "interface_kind": "method",
+    "namespace": "transfer",
+    "primary": "transfer_pause_session",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
+    "version_introduced": "2.16.2",
+    "version_removed": ""
+  },
+  {
+    "api_method": "resumeSession",
+    "client_aliases": [
+      "transfer_resumeSession"
+    ],
+    "interface": "transfer.resume_session",
+    "interface_aliases": [
+      "transfer.resumeSession"
+    ],
+    "interface_kind": "method",
+    "namespace": "transfer",
+    "primary": "transfer_resume_session",
+    "torrent_method": "",
+    "torrent_method_aliases": [],
+    "torrent_method_kind": "",
+    "version_introduced": "2.16.2",
+    "version_removed": ""
+  },
+  {
     "api_method": "setDownloadLimit",
     "client_aliases": [
       "transfer_setDownloadLimit"

--- a/tests/test_torrentcreator.py
+++ b/tests/test_torrentcreator.py
@@ -55,6 +55,22 @@ def test_add_task(client, add_task_func):
     assert task.task_id
 
 
+@pytest.mark.skipif_before_api_version("2.16.0")
+@pytest.mark.parametrize("ignore_dotfiles", [True, False])
+def test_add_task_ignore_dotfiles(client, ignore_dotfiles):
+    task = client.torrentcreator_add_task(
+        source_path="/empty-dir",
+        start_seeding=False,
+        ignore_dotfiles=ignore_dotfiles,
+    )
+    try:
+        for attempt in eventually():
+            with attempt:
+                assert task.status().ignoreDotfiles is ignore_dotfiles
+    finally:
+        task.delete()
+
+
 @pytest.mark.skipif_before_api_version("2.10.4")
 @pytest.mark.parametrize(
     "status_func", ["torrentcreator_status", "torrentcreator.status"]

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -7,6 +7,7 @@ from qbittorrentapi.transfer import (
     TransferInfoDictionary,
     TransferSpeedLimitsDictionary,
 )
+from tests.utils import eventually
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="removeprefix not in 3.8")
@@ -161,3 +162,26 @@ def test_set_speed_limits(client, set_speed_limits_func):
             alt_upload_limit=original["alt_up_limit"],
             alt_download_limit=original["alt_dl_limit"],
         )
+
+
+@pytest.mark.skipif_before_api_version("2.16.2")
+@pytest.mark.parametrize(
+    "pause_func, resume_func",
+    [
+        ("transfer_pause_session", "transfer_resume_session"),
+        ("transfer.pause_session", "transfer.resume_session"),
+    ],
+)
+def test_pause_resume_session(client, pause_func, resume_func):
+    # session_state is True while the BitTorrent session is paused
+    try:
+        client.func(pause_func)()
+        for attempt in eventually():
+            with attempt:
+                assert client.sync_maindata().server_state.session_state
+    finally:
+        client.func(resume_func)()
+
+    for attempt in eventually():
+        with attempt:
+            assert not client.sync_maindata().server_state.session_state


### PR DESCRIPTION
qBittorrent [v5.3.0beta1](https://github.com/qbittorrent/qBittorrent/releases/tag/release-5.3.0beta1) was released on 5 Sep 2026 and ships **Web API v2.16.2**.

Most of the delta from v5.2.3 (Web API v2.15.1) was already implemented in #659, which targeted v2.16.0 against `master`. This picks up what landed after that, plus one parameter #659 missed.

### New endpoints — Web API v2.16.2

| Endpoint | Client method |
| --- | --- |
| `transfer/pauseSession` | `transfer_pause_session()` / `transfer.pause_session()` |
| `transfer/resumeSession` | `transfer_resume_session()` / `transfer.resume_session()` |

Both pause/resume the whole BitTorrent session (qbittorrent/qBittorrent@fe4506e). While paused, `sync/maindata` reports `server_state.session_state` as `true`.

### New parameter — Web API v2.16.0

`torrentcreator/addTask` gained `ignoreDotfiles` (qbittorrent/qBittorrent@7545541), exposed as `ignore_dotfiles`. qBittorrent defaults it to `true` when omitted.

### Version support

`v5.3.0beta1` → `2.16.2` added to `APP_VERSION_2_API_VERSION_MAP`, and the beta added to the Release Tests matrix. Following the precedent from v5.1.0beta1 (b0081e2), `MOST_RECENT_SUPPORTED_APP_VERSION` stays at the latest stable, v5.2.3.

### Changed upstream, but no client change needed

Responses are untyped dictionaries and preferences pass straight through, so these flow through already. Noting them because they affect users:

- **`torrentcreator/status` breaking change:** `timeAdded` / `timeStarted` / `timeFinished` are now epoch seconds, previously formatted strings (qbittorrent/qBittorrent@400d5c6).
- **Preferences renamed:** `export_dir` → `torrent_files_backup_dir` (+ `torrent_files_backup_enabled`), `export_dir_fin` → `torrent_files_finished_backup_dir` (+ `..._enabled`), new `remove_torrent_file_backup`; `mail_notification_ssl_enabled` (bool) → `mail_notification_encryption_type` (enum string).
- **New preferences:** `store_search_jobs`, `store_search_job_results`, `share_limits_mode`, `web_ui_sessions_count_limit`, `seeding_outgoing_connections`, `enable_multi_connections_from_same_peer_id`, `max_outstanding_block_requests`, `webtorrent_stun_server`.
- **New response fields:** torrent info `share_limits_mode`; `sync/maindata` `server_state.session_state`, `queued_tracker_announces`, `request_latency`, and per-peer `contribution`; `search/status` `pattern`, `category`, `plugins`; `torrents/parseMetadata` files gain `priority`.

`rss/setFeedRefreshInterval` and `search/downloadTorrent` now require POST (qbittorrent/qBittorrent@27a1fab) — this client already used POST for both, so nothing to change. No endpoints were removed, and no other request parameters changed.

### Testing

`tests/api_surface.json` regenerated; pre-commit (ruff, ruff-format, mypy --strict) passes. The live tests were **not** run locally — no Docker daemon available in this environment — so the two new live tests are unverified against a real qBittorrent and are relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)